### PR TITLE
:sparkles: feat: 添加大会员失效时退出

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,11 @@ cat ~/.yutto_alias | yutto tensura-nikki --batch --alias-file -
 -  参数 `--metadata-only`
 -  默认值 `False`
 
+#### 严格校验大会员状态有效
+
+-  参数 `--vip-check`
+-  默认值 `False`
+
 #### 不显示颜色
 
 -  参数 `--no-color`

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ cat ~/.yutto_alias | yutto tensura-nikki --batch --alias-file -
 
 #### 严格校验大会员状态有效
 
--  参数 `--vip-check`
+-  参数 `--vip-strict`
 -  默认值 `False`
 
 #### 不显示颜色

--- a/yutto/__main__.py
+++ b/yutto/__main__.py
@@ -254,6 +254,9 @@ async def run(args_list: list[argparse.Namespace]):
             for i, episode_data_coro in enumerate(download_list):
                 if episode_data_coro is None:
                     continue
+                if args.vip_strict and not await validate_vip():
+                    Logger.error("启用了严格校验大会员模式，请检查SESSDATA或大会员状态！")
+                    return
                 # 这时候才真正开始解析链接
                 episode_data = await episode_data_coro
                 if episode_data is None:
@@ -263,9 +266,7 @@ async def run(args_list: list[argparse.Namespace]):
                         f"{episode_data['filename']}",
                         Badge(f"[{i+1}/{len(download_list)}]", fore="black", back="cyan"),
                     )
-                if args.vip_strict and not await validate_vip():
-                    Logger.error("启用了严格校验大会员模式，请检查SESSDATA或大会员状态！")
-                    return
+
                 await start_downloader(
                     session,
                     episode_data,

--- a/yutto/__main__.py
+++ b/yutto/__main__.py
@@ -265,7 +265,7 @@ async def run(args_list: list[argparse.Namespace]):
                     )
                 if args.vip_check and not await validate_vip():
                     Logger.error("启用了严格校验大会员模式，请检查SESSDATA或大会员状态！")
-                    break
+                    return
                 await start_downloader(
                     session,
                     episode_data,

--- a/yutto/__main__.py
+++ b/yutto/__main__.py
@@ -169,7 +169,7 @@ def cli() -> argparse.ArgumentParser:
     group_common.add_argument("--no-color", action="store_true", help="不使用颜色")
     group_common.add_argument("--no-progress", action="store_true", help="不显示进度条")
     group_common.add_argument("--debug", action="store_true", help="启用 debug 模式")
-    group_common.add_argument("--vip-check", action="store_true", help="启用严格检查大会员生效")
+    group_common.add_argument("--vip-strict", action="store_true", help="启用严格检查大会员生效")
 
     # 仅批量下载使用
     group_batch = parser.add_argument_group("batch", "批量下载参数")
@@ -263,7 +263,7 @@ async def run(args_list: list[argparse.Namespace]):
                         f"{episode_data['filename']}",
                         Badge(f"[{i+1}/{len(download_list)}]", fore="black", back="cyan"),
                     )
-                if args.vip_check and not await validate_vip():
+                if args.vip_strict and not await validate_vip():
                     Logger.error("启用了严格校验大会员模式，请检查SESSDATA或大会员状态！")
                     return
                 await start_downloader(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

批量下载时，大会员因为多端登录、大量下载行为而冻结，需要等待30min或主动刷新，此时，下载到的视频是无大会员情况下的清晰度。

也就是 https://github.com/yutto-dev/yutto/issues/133 的`A2`问题。

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

## 解决方案

提供一个`--vip-check` 参数，给定时，会在下载前校验大会员状态，如果异常则直接退出。

ps: 在run()函数中直接return，不知道是否会引起其他异常？
<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

```bash
poetry run yutto 'https://www.bilibili.com/bangumi/play/ep473904' -c 'x' -d 'download'  --with-metadata --vip-check
> WARN  以非大会员身份登录，注意无法下载会员专享剧集喔～
> 番剧  明日酱的水手服
> ERROR  启用了严格校验大会员模式，请检查SESSDATA或大会员状态！
echo $?
> 0
```

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
