### PR TITLE
🐛 fix: automatically close coroutine

### DIFF
--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -6,6 +6,7 @@ import aiohttp
 import pytest
 
 from yutto.processor.downloader import slice_blocks
+from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.fetcher import Fetcher
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.funcutils import as_sync
@@ -31,7 +32,7 @@ async def test_150_kB_downloader():
             Fetcher.set_semaphore(4)
             size = await Fetcher.get_size(session, url)
             coroutines = [
-                Fetcher.download_file_with_offset(session, url, [], buffer, offset, block_size)
+                CoroutineWrapper(Fetcher.download_file_with_offset(session, url, [], buffer, offset, block_size))
                 for offset, block_size in slice_blocks(buffer.written_size, size, 1 * 1024 * 1024)
             ]
 
@@ -57,7 +58,7 @@ async def test_150_kB_no_slice_downloader():
         ) as session:
             Fetcher.set_semaphore(4)
             size = await Fetcher.get_size(session, url)
-            coroutines = [Fetcher.download_file_with_offset(session, url, [], buffer, 0, size)]
+            coroutines = [CoroutineWrapper(Fetcher.download_file_with_offset(session, url, [], buffer, 0, size))]
 
             print("开始下载……")
             await asyncio.gather(*coroutines)

--- a/yutto/extractor/_abc.py
+++ b/yutto/extractor/_abc.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import argparse
 from abc import ABCMeta, abstractmethod
-from collections.abc import Coroutine
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import aiohttp
 
 from yutto._typing import EpisodeData
+from yutto.utils.asynclib import CoroutineWrapper
 
 T = TypeVar("T")
 
@@ -25,31 +25,31 @@ class Extractor(metaclass=ABCMeta):
     @abstractmethod
     async def __call__(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> list[Coroutine[Any, Any, EpisodeData | None] | None]:
+    ) -> list[CoroutineWrapper[EpisodeData | None] | None]:
         raise NotImplementedError
 
 
 class SingleExtractor(Extractor):
     async def __call__(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> list[Coroutine[Any, Any, EpisodeData | None] | None]:
+    ) -> list[CoroutineWrapper[EpisodeData | None] | None]:
         return [await self.extract(session, args)]
 
     @abstractmethod
     async def extract(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> Coroutine[Any, Any, EpisodeData | None] | None:
+    ) -> CoroutineWrapper[EpisodeData | None] | None:
         raise NotImplementedError
 
 
 class BatchExtractor(Extractor):
     async def __call__(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> list[Coroutine[Any, Any, EpisodeData | None] | None]:
+    ) -> list[CoroutineWrapper[EpisodeData | None] | None]:
         return await self.extract(session, args)
 
     @abstractmethod
     async def extract(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> list[Coroutine[Any, Any, EpisodeData | None] | None]:
+    ) -> list[CoroutineWrapper[EpisodeData | None] | None]:
         raise NotImplementedError

--- a/yutto/extractor/bangumi.py
+++ b/yutto/extractor/bangumi.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-from collections.abc import Coroutine
-from typing import Any
 
 import aiohttp
 
@@ -19,6 +17,7 @@ from yutto.exceptions import (
 )
 from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import extract_bangumi_data
+from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
 
 
@@ -48,7 +47,7 @@ class BangumiExtractor(SingleExtractor):
 
     async def extract(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> Coroutine[Any, Any, EpisodeData | None] | None:
+    ) -> CoroutineWrapper[EpisodeData | None] | None:
         season_id = await get_season_id_by_episode_id(session, self.episode_id)
         bangumi_list = await get_bangumi_list(session, season_id)
         Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))
@@ -61,15 +60,17 @@ class BangumiExtractor(SingleExtractor):
                 Logger.error("在列表中未找到该剧集")
                 sys.exit(ErrorCode.EPISODE_NOT_FOUND_ERROR.value)
 
-            return extract_bangumi_data(
-                session,
-                self.episode_id,
-                bangumi_list_item,
-                args,
-                {
-                    "title": bangumi_list["title"],
-                },
-                "{name}",
+            return CoroutineWrapper(
+                extract_bangumi_data(
+                    session,
+                    self.episode_id,
+                    bangumi_list_item,
+                    args,
+                    {
+                        "title": bangumi_list["title"],
+                    },
+                    "{name}",
+                )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
             Logger.error(e.message)

--- a/yutto/extractor/ugc_video_batch.py
+++ b/yutto/extractor/ugc_video_batch.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import argparse
 import re
-from collections.abc import Coroutine
-from typing import Any
 
 import aiohttp
 
@@ -13,6 +11,7 @@ from yutto.exceptions import NotFoundError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import extract_ugc_video_data
 from yutto.processor.selector import parse_episodes_selection
+from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
 
 
@@ -56,7 +55,7 @@ class UgcVideoBatchExtractor(BatchExtractor):
 
     async def extract(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> list[Coroutine[Any, Any, EpisodeData | None] | None]:
+    ) -> list[CoroutineWrapper[EpisodeData | None] | None]:
         try:
             ugc_video_list = await get_ugc_video_list(session, self.avid)
             Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
@@ -70,16 +69,18 @@ class UgcVideoBatchExtractor(BatchExtractor):
         ugc_video_list["pages"] = list(filter(lambda item: item["id"] in episodes, ugc_video_list["pages"]))
 
         return [
-            extract_ugc_video_data(
-                session,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                args,
-                {
-                    "title": ugc_video_list["title"],
-                    "pubdate": ugc_video_list["pubdate"],
-                },
-                "{title}/{name}",
+            CoroutineWrapper(
+                extract_ugc_video_data(
+                    session,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    args,
+                    {
+                        "title": ugc_video_list["title"],
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    "{title}/{name}",
+                )
             )
             for ugc_video_item in ugc_video_list["pages"]
         ]

--- a/yutto/extractor/user_all_favourites.py
+++ b/yutto/extractor/user_all_favourites.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import argparse
 import re
-from collections.abc import Coroutine
-from typing import Any
 
 import aiohttp
 
@@ -13,6 +11,7 @@ from yutto.api.ugc_video import UgcVideoListItem, get_ugc_video_list
 from yutto.exceptions import NotFoundError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import extract_ugc_video_data
+from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.fetcher import Fetcher
 
@@ -33,7 +32,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
 
     async def extract(
         self, session: aiohttp.ClientSession, args: argparse.Namespace
-    ) -> list[Coroutine[Any, Any, EpisodeData | None] | None]:
+    ) -> list[CoroutineWrapper[EpisodeData | None] | None]:
         username = await get_user_name(session, self.mid)
         Logger.custom(username, Badge("用户收藏夹", fore="black", back="cyan"))
 
@@ -60,18 +59,20 @@ class UserAllFavouritesExtractor(BatchExtractor):
                     continue
 
         return [
-            extract_ugc_video_data(
-                session,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                args,
-                {
-                    "title": title,
-                    "username": username,
-                    "series_title": series_title,
-                    "pubdate": pubdate,
-                },
-                "{username}的收藏夹/{series_title}/{title}/{name}",
+            CoroutineWrapper(
+                extract_ugc_video_data(
+                    session,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    args,
+                    {
+                        "title": title,
+                        "username": username,
+                        "series_title": series_title,
+                        "pubdate": pubdate,
+                    },
+                    "{username}的收藏夹/{series_title}/{title}/{name}",
+                )
             )
             for ugc_video_item, title, pubdate, series_title in ugc_video_info_list
         ]

--- a/yutto/utils/asynclib.py
+++ b/yutto/utils/asynclib.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import platform
-from typing import Any, Coroutine, Generator, Generic, TypeVar
+from typing import Any, Generic, TypeVar
+from collections.abc import Coroutine, Generator
 
 from yutto.utils.console.logger import Logger
 

--- a/yutto/utils/asynclib.py
+++ b/yutto/utils/asynclib.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import platform
-from typing import Any, Generic, TypeVar
 from collections.abc import Coroutine, Generator
+from typing import Any, Generic, TypeVar
 
 from yutto.utils.console.logger import Logger
 

--- a/yutto/utils/asynclib.py
+++ b/yutto/utils/asynclib.py
@@ -2,11 +2,27 @@ from __future__ import annotations
 
 import asyncio
 import platform
+from typing import Any, Coroutine, Generator, Generic, TypeVar
 
 from yutto.utils.console.logger import Logger
+
+RetT = TypeVar("RetT")
 
 
 def initial_async_policy():
     if platform.system() == "Windows":
         Logger.debug("Windows 平台，单独设置 EventLoopPolicy")
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore
+
+
+class CoroutineWrapper(Generic[RetT]):
+    coro: Coroutine[Any, Any, RetT]
+
+    def __init__(self, coro: Coroutine[Any, Any, RetT]):
+        self.coro = coro
+
+    def __await__(self) -> Generator[Any, None, RetT]:
+        return (yield from self.coro.__await__())
+
+    def __del__(self):
+        self.coro.close()


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

closes #135

这是一个已知问题，比如用户用 <kbd>Ctrl</kbd> + <kbd>C</kbd> 暂停下载时，也会有这个问题

问题的原因是 yutto 在各种地方创建了 coroutine，但没有 await，最小复现样例如下：

```python
async def foo():
    return 1

foo()
```

对于 #135，是正在遍历一个 coroutine 列表，提前终止会导致后面的元素没有 await

如果想解决该问题，只需要在创建后将未 await 的 close 掉即可

```python
async def foo():
    return 1

a = foo()
a.close()
```

此时即可消除该 Warning

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

第一种方案是在提前终止退出时，对后面的所有元素逐个 close，但是 yutto 目前多处使用了 coroutine，这就需要在多处添加相关维护代码，会非常繁琐

另一种方案是不再返回 coroutine，而是包装成一个新类型，该类型会自动在析构时帮助我们来 close，本 PR 选择了该方案。

本 PR 添加了一个新结构 `CoroutineWrapper`，在 `__del__` 时会自动 close 被包装的 coroutine

```python
RetT = TypeVar("RetT")

class CoroutineWrapper(Generic[RetT]):
    coro: Coroutine[Any, Any, RetT]

    def __init__(self, coro: Coroutine[Any, Any, RetT]):
        self.coro = coro

    def __await__(self) -> Generator[Any, None, RetT]:
        return (yield from self.coro.__await__())

    def __del__(self):
        self.coro.close()
```

使用样例如下：

```diff
  async def foo():
      return 1

- a = await foo()
+ a = await CoroutineWrapper(foo())
- b = foo() # 有 Warning
+ b = CoroutineWrapper(foo()) # 无 Warning
```

用法完全一样，只是在 coroutine 外面包了一层 `CoroutineWrapper`

对于类型提示修改也只是 `Coroutine[Any, Any, T]` -> `CoroutineWrapper[T]`

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
