### PR TITLE
🐛 fix: timestamp conversion failure

### DIFF
--- a/yutto/utils/filter.py
+++ b/yutto/utils/filter.py
@@ -7,8 +7,9 @@ from yutto.utils.console.logger import Logger
 
 
 class Filter:
-    batch_filter_start_time: datetime.datetime = datetime.datetime.min
-    batch_filter_end_time: datetime.datetime = datetime.datetime.max
+    # XXX: A workaround to https://bugs.python.org/issue31212.
+    batch_filter_start_time: datetime.datetime = datetime.datetime(1, 1, 2)
+    batch_filter_end_time: datetime.datetime = datetime.datetime(9999, 12, 31)
 
     @staticmethod
     def set_timer(key: str, user_input: str):

--- a/yutto/utils/filter.py
+++ b/yutto/utils/filter.py
@@ -7,7 +7,7 @@ from yutto.utils.console.logger import Logger
 
 
 class Filter:
-    # XXX: A workaround to https://bugs.python.org/issue31212.
+    # NOTE(FrankHB): A workaround to https://bugs.python.org/issue31212.
     batch_filter_start_time: datetime.datetime = datetime.datetime(1, 1, 2)
     batch_filter_end_time: datetime.datetime = datetime.datetime(9999, 12, 31)
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

The default values of both `batch_filter_start_time` and `batch_filter_end_time` are invalid for `.timestamp()`, so it fails in batch mode when the values are not set explicitly. See https://bugs.python.org/issue31212 for details.

This was introduced by #146 .

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
