### PR TITLE
🐛 fix: lazy match of date string params

### DIFF
--- a/yutto/processor/path_resolver.py
+++ b/yutto/processor/path_resolver.py
@@ -52,7 +52,7 @@ def repair_filename(filename: str) -> str:
 
 
 def create_time_formatter(name: str, value: int):
-    regex = re.compile(rf"{{{name}(@(?P<timefmt>.+))?}}")
+    regex = re.compile(rf"{{{name}(@(?P<timefmt>.+?))?}}")
     DEFAULT_TIMEFMT = "%Y-%m-%d"
 
     def convert_pubdate(matchobj: re.Match[str]):


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

我遇到了一个bug：

```
$ yutto --vcodec hevc:copy --output-format=mp4 --with-metadata -c `cat ~/.sessdata` -tp '{owner_uid}-{username}/{pubdate@%Y}/{pubdate@%m}/{pubdate@%Y%m%d%H%M}-{name}' -b https://space.bilibili.com/8220628
 大会员  成功以大会员身份登录～
 UP 主投稿视频  蝶云栁月
Traceback (most recent call last):
  File "/opt/homebrew/bin/yutto", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/homebrew/Cellar/yutto/2.0.0b28/libexec/lib/python3.11/site-packages/yutto/__main__.py", line 57, in main
    run(args_list)
  File "/opt/homebrew/Cellar/yutto/2.0.0b28/libexec/lib/python3.11/site-packages/yutto/utils/funcutils/as_sync.py", line 34, in sync_func
    return asyncio.run(async_func(*args, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yutto/2.0.0b28/libexec/lib/python3.11/site-packages/yutto/__main__.py", line 269, in run
    episode_data = await episode_data_coro
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yutto/2.0.0b28/libexec/lib/python3.11/site-packages/yutto/utils/asynclib.py", line 26, in __await__
    return (yield from self.coro.__await__())
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yutto/2.0.0b28/libexec/lib/python3.11/site-packages/yutto/extractor/common.py", line 160, in extract_ugc_video_data
    subpath = resolve_path_template(args.subpath_template, auto_subpath_template, subpath_variables_base)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/yutto/2.0.0b28/libexec/lib/python3.11/site-packages/yutto/processor/path_resolver.py", line 97, in resolve_path_template
    return path_template.format(auto=auto_path_template.format(**subpath_variables), **subpath_variables)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Single '}' encountered in format string
```

我在这里打印了 `path_template`：

```diff
diff --git a/yutto/processor/path_resolver.py b/yutto/processor/path_resolver.py
index 14cc41f..6b396f5 100644
--- a/yutto/processor/path_resolver.py
+++ b/yutto/processor/path_resolver.py
@@ -94,4 +94,5 @@ def resolve_path_template(
         assert isinstance(value, int), f"变量 {var} 的值必须为 int 型，但是传入了 {value}"
         time_formatter = create_time_formatter(var, value)
         path_template = time_formatter(path_template)
+    print(path_template)
     return path_template.format(auto=auto_path_template.format(**subpath_variables), **subpath_variables)
```

发现这里输出为：`{owner_uid}-{username}/2023}／{pubdate@09}／{pubdate@202309062206}-{name`

而我的预期是：`{owner_uid}-{username}/2023/09/202309062206-{name}`

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

问题的原因是 `create_time_formatter()` 中的正则表达式不正确，改用懒惰模式匹配即可。

**因为这个 commit 的变动太小了，所以我没有按照 [CONTRIBUTING.md](https://github.com/yutto-dev/yutto/blob/main/CONTRIBUTING.md) 仔细测试，仅测试了我自己的 case。辛苦 reviewer 仔细看看。**

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [*] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
