### PR TITLE
🐛 fix: prevent ffmpeg read bytes from stdin

### DIFF
--- a/yutto/utils/ffmpeg.py
+++ b/yutto/utils/ffmpeg.py
@@ -28,8 +28,8 @@ class FFmpeg(metaclass=Singleton):
         cmd = [self.path]
         cmd.extend(args)
         Logger.debug(" ".join(cmd))
-        # ffmpeg 会谜之从 stdin 读取一个字节，这会让调用 yutto 的 shell 脚本踩到坑.
-        # 这个行为在目前最新的 ffmpeg 6.0 仍然存在.
+        # NOTE(aheadlead): FFmpeg 会谜之从 stdin 读取一个字节，这会让调用 yutto 的 shell 脚本踩到坑
+        # 这个行为在目前最新的 FFmpeg 6.0 仍然存在
         return subprocess.run(cmd, stdin=subprocess.DEVNULL, capture_output=True)
 
     @cached_property

--- a/yutto/utils/ffmpeg.py
+++ b/yutto/utils/ffmpeg.py
@@ -28,7 +28,9 @@ class FFmpeg(metaclass=Singleton):
         cmd = [self.path]
         cmd.extend(args)
         Logger.debug(" ".join(cmd))
-        return subprocess.run(cmd, capture_output=True)
+        # ffmpeg 会谜之从 stdin 读取一个字节，这会让调用 yutto 的 shell 脚本踩到坑.
+        # 这个行为在目前最新的 ffmpeg 6.0 仍然存在.
+        return subprocess.run(cmd, stdin=subprocess.DEVNULL, capture_output=True)
 
     @cached_property
     def version(self) -> str:


### PR DESCRIPTION
The ffmpeg anomalously reads exactly one byte from stdin during video and audio stream merging, disrupting the shell script process which relies on stdin and invokes yutto.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

在 `yutto/utils/ffmpeg.py` 中合并音视频的逻辑中会调用 ffmpeg，然而 ffmpeg 在合并时会神秘的从 stdin 里读取一个字节，这会导致调用 yutto 的 shell 脚本出问题（我还认真思考了很久我的 shell 是不是生疏了） 。

<img width="1920" alt="image" src="https://github.com/yutto-dev/yutto/assets/8691447/928ac2c3-66d5-4ca0-b3aa-8e1ba1eeaf61">

btw 如果你也遇到类似的问题话，可以在shell里调用yutto处加一个 `</dev/null`，这样直接把 yutto 的 stdin 给重定向了，也能规避问题。

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

`subprocess.run()` 调用 ffmpeg，把 stdin 重定向到 `/dev/null`。

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
