### PR TITLE
✨ feat: always use `picture` instead of `first_frame`

### DIFF
--- a/yutto/api/ugc_video.py
+++ b/yutto/api/ugc_video.py
@@ -31,7 +31,7 @@ from yutto.utils.time import get_time_stamp_by_now
 
 class _UgcVideoPageInfo(TypedDict):
     part: str
-    first_frame: str | None
+    first_frame: str | None  # 该属性已经废弃，可能会在未来彻底移除
 
 
 class _UgcVideoInfo(TypedDict):
@@ -270,15 +270,11 @@ def _parse_ugc_video_metadata(
     page_info: _UgcVideoPageInfo,
     is_first_page: bool = False,
 ) -> MetaData:
-    thumb = page_info["first_frame"] if page_info["first_frame"] is not None else video_info["picture"]
-    # Only the non-first page use the first frame as the thumbnail
-    if is_first_page:
-        thumb = video_info["picture"]
     return MetaData(
         title=page_info["part"],
         show_title=page_info["part"],
         plot=video_info["description"],
-        thumb=thumb,
+        thumb=video_info["picture"],
         premiered=video_info["pubdate"],
         dateadded=get_time_stamp_by_now(),
         actor=video_info["actor"],


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

resolves #246

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

原来考虑到区分度，为分 P 每一 P 设置不同的封面，因此多 P 视频仅第一 P 使用封面，其余使用 `first_frame`，因为一个多 P 视频只有一个封面，但每 P 都有自己的 `first_frame`

但 `first_frame` 对于视频自身来说可能并没有精心挑选的封面更美观，因此统一使用封面

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
