### PR TITLE
💚 ci: pin ubuntu to 22.04

### DIFF
--- a/.github/workflows/biliass-build-and-release.yml
+++ b/.github/workflows/biliass-build-and-release.yml
@@ -138,7 +138,8 @@ jobs:
           path: packages/biliass/dist
 
   sdist:
-    runs-on: ubuntu-latest
+    # TODO: Change to ubuntu-latest when PyO3/maturin-action#291 fixed
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    # TODO: Change to ubuntu-latest when CodSpeedHQ/runner#42 fixed
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

暂时将 ubuntu-latest 降级到 22.04，目前有两处因为 ubuntu-latest 升级到 24.04 挂掉

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

1. codspeed 明确尚未支持 24.04，见 CodSpeedHQ/runner#42

```
______            __ _____                         __
  / ____/____   ____/ // ___/ ____   ___   ___   ____/ /
 / /    / __ \ / __  / \__ \ / __ \ / _ \ / _ \ / __  /
/ /___ / /_/ // /_/ / ___/ // /_/ //  __//  __// /_/ /
\____/ \____/ \__,_/ /____// .___/ \___/ \___/ \__,_/
  https://codspeed.io/     /_/          runner v3.0.0

Error: Error: Only Ubuntu 20.04 and 22.04 are supported at the moment
Error: Process completed with exit code 1.
```

2. maturin sdist build 会挂掉，见 PyO3/maturin-action#291

```
Installing 'maturin' from tag 'v1.7.4'
  /usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/60704b39-958a-466b-96dd-076018ffce2a -f /home/runner/work/_temp/cf93b7da-458b-430d-95d9-1dd5ecd8bc82
  Installed 'maturin' to /home/runner/work/_temp/60704b39-958a-466b-96dd-076018ffce2a/maturin
  /home/runner/work/_temp/60704b39-958a-466b-96dd-076018ffce2a/maturin --version
  maturin 1.7.4
  /usr/bin/python3 -m pip install cffi
  error: externally-managed-environment
  
  × This environment is externally managed
  ╰─> To install Python packages system-wide, try apt install
      python3-xyz, where xyz is the package you are trying to
      install.
      
      If you wish to install a non-Debian-packaged Python package,
      create a virtual environment using python3 -m venv path/to/venv.
      Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
      sure you have python3-full installed.
      
      If you wish to install a non-Debian packaged Python application,
      it may be easiest to use pipx install xyz, which will manage a
      virtual environment for you. Make sure you have pipx installed.
      
      See /usr/share/doc/python3.12/README.venv for more information.
  
  note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
  hint: See PEP 668 for the detailed specification.
  /usr/bin/python3 -m pip install patchelf
  error: externally-managed-environment
  
  × This environment is externally managed
  ╰─> To install Python packages system-wide, try apt install
      python3-xyz, where xyz is the package you are trying to
      install.
      
      If you wish to install a non-Debian-packaged Python package,
      create a virtual environment using python3 -m venv path/to/venv.
      Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
      sure you have python3-full installed.
      
      If you wish to install a non-Debian packaged Python application,
      it may be easiest to use pipx install xyz, which will manage a
      virtual environment for you. Make sure you have pipx installed.
      
      See /usr/share/doc/python3.12/README.venv for more information.
  
  note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
  hint: See PEP 668 for the detailed specification.
  Error: The process '/usr/bin/python3' failed with exit code 1
      at ExecState._setResult (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:1702:25)
      at ExecState.CheckComplete (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:1685:18)
      at ChildProcess.<anonymous> (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:[15](https://github.com/yutto-dev/yutto/actions/runs/11305888881/job/31445873638?pr=363#step:3:17)79:27)
      at ChildProcess.emit (node:events:519:28)
      at maybeClose (node:internal/child_process:1105:[16](https://github.com/yutto-dev/yutto/actions/runs/11305888881/job/31445873638?pr=363#step:3:18))
      at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

后续待全部支持后会重新改回 ubuntu-latest

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
