### PR TITLE
👷 ci: replace quansight-labs/setup-python with actions/setup-python

### DIFF
--- a/.github/workflows/biliass-build-and-release.yml
+++ b/.github/workflows/biliass-build-and-release.yml
@@ -138,7 +138,7 @@ jobs:
             target: x86
     steps:
       - uses: actions/checkout@v4
-      - uses: Quansight-Labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.13t
           architecture: ${{ matrix.platform.target }}


### PR DESCRIPTION
The changes in the fork were upstreamed and released in 5.5.0. See https://github.com/actions/setup-python/releases/tag/v5.5.0.