### PR TITLE
:sparkles: feature: Add `--parse-resources` to parse resources but not download.

### DIFF
--- a/docs/guide/cli/resource.md
+++ b/docs/guide/cli/resource.md
@@ -8,8 +8,8 @@ aside: true
 
 ## 仅下载视频流
 
-- 参数 `--video-only`
-- 默认值 `False`
+-  参数 `--video-only`
+-  默认值 `False`
 
 ::: tip
 
@@ -21,47 +21,47 @@ aside: true
 
 ## 仅下载音频流
 
-- 参数 `--audio-only`
-- 默认值 `False`
+-  参数 `--audio-only`
+-  默认值 `False`
 
 仅下载其中的音频流，保存为 `.m4a` 文件。
 
 ## 不生成弹幕文件
 
-- 参数 `--no-danmaku`
-- 默认值 `False`
+-  参数 `--no-danmaku`
+-  默认值 `False`
 
 ## 仅生成弹幕文件
 
-- 参数 `--danmaku-only`
-- 默认值 `False`
+-  参数 `--danmaku-only`
+-  默认值 `False`
 
 ## 不生成字幕文件
 
-- 参数 `--no-subtitle`
-- 默认值 `False`
+-  参数 `--no-subtitle`
+-  默认值 `False`
 
 ## 仅生成字幕文件
 
-- 参数 `--subtitle-only`
-- 默认值 `False`
+-  参数 `--subtitle-only`
+-  默认值 `False`
 
 ## 生成媒体元数据文件
 
-- 参数 `--with-metadata`
-- 默认值 `False`
+-  参数 `--with-metadata`
+-  默认值 `False`
 
 目前媒体元数据生成尚在试验阶段，可能提取出的信息并不完整。
 
 ## 仅生成媒体元数据文件
 
-- 参数 `--metadata-only`
-- 默认值 `False`
+-  参数 `--metadata-only`
+-  默认值 `False`
 
 ## 不生成视频封面
 
-- 参数 `--no-cover`
-- 默认值 `False`
+-  参数 `--no-cover`
+-  默认值 `False`
 
 ::: tip
 
@@ -71,18 +71,18 @@ aside: true
 
 ## 生成视频流封面时单独保存封面
 
-- 参数 `--save-cover`
-- 默认值 `False`
+-  参数 `--save-cover`
+-  默认值 `False`
 
 ## 仅生成视频封面
 
-- 参数 `--cover-only`
-- 默认值 `False`
+-  参数 `--cover-only`
+-  默认值 `False`
 
 ## 不生成章节信息
 
-- 参数 `--no-chapter-info`
-- 默认值 `False`
+-  参数 `--no-chapter-info`
+-  默认值 `False`
 
 不生成章节信息，包含 MetaData 和嵌入视频流的章节信息。
 
@@ -103,45 +103,45 @@ require_danmaku = false
 
 ### 是否需要视频流
 
-- 配置项 `resource.video_only`
-- 默认值 `True`
+-  配置项 `resource.video_only`
+-  默认值 `True`
 
 ### 是否需要音频流
 
-- 配置项 `resource.require_audio`
-- 默认值 `True`
+-  配置项 `resource.require_audio`
+-  默认值 `True`
 
 ### 是否需要弹幕
 
-- 配置项 `resource.require_danmaku`
-- 默认值 `True`
+-  配置项 `resource.require_danmaku`
+-  默认值 `True`
 
 ### 是否需要字幕
 
-- 配置项 `resource.require_subtitle`
-- 默认值 `True`
+-  配置项 `resource.require_subtitle`
+-  默认值 `True`
 
 ### 是否需要媒体元数据
 
-- 配置项 `resource.require_metadata`
-- 默认值 `False`
+-  配置项 `resource.require_metadata`
+-  默认值 `False`
 
 ### 是否需要视频封面
 
-- 配置项 `resource.require_cover`
-- 默认值 `True`
+-  配置项 `resource.require_cover`
+-  默认值 `True`
 
 ### 是否需要章节信息
 
-- 配置项 `resource.require_chapter_info`
-- 默认值 `True`
+-  配置项 `resource.require_chapter_info`
+-  默认值 `True`
 
 ### 生成视频流封面时单独保存封面
 
-- 配置项 `resource.save_cover`
-- 默认值 `False`
+-  配置项 `resource.save_cover`
+-  默认值 `False`
 
 ### 是否跳过对选中资源的下载
 
-- 配置项 `resource.skip_download`
-- 默认值 `False`
+-  配置项 `resource.skip_download`
+-  默认值 `False`

--- a/docs/guide/cli/resource.md
+++ b/docs/guide/cli/resource.md
@@ -140,3 +140,8 @@ require_danmaku = false
 
 - 配置项 `resource.save_cover`
 - 默认值 `False`
+
+### 是否跳过对选中资源的下载
+
+- 配置项 `resource.skip_download`
+- 默认值 `False`

--- a/src/yutto/_typing.py
+++ b/src/yutto/_typing.py
@@ -239,7 +239,6 @@ class EpisodeData(TypedDict):
     path: Path
 
 
-
 class DownloaderOptions(TypedDict):
     output_dir: Path
     tmp_dir: Path

--- a/src/yutto/_typing.py
+++ b/src/yutto/_typing.py
@@ -236,6 +236,7 @@ class EpisodeData(TypedDict):
     cover_data: bytes | None
     chapter_info_data: list[ChapterInfoData]
     path: Path
+    url: str
 
 
 class DownloaderOptions(TypedDict):

--- a/src/yutto/_typing.py
+++ b/src/yutto/_typing.py
@@ -244,6 +244,7 @@ class DownloaderOptions(TypedDict):
     require_video: bool
     require_chapter_info: bool
     save_cover: bool
+    parse_resources: bool
     video_quality: VideoQuality
     video_download_codec: VideoCodec
     video_save_codec: str

--- a/src/yutto/_typing.py
+++ b/src/yutto/_typing.py
@@ -233,7 +233,7 @@ class EpisodeData(TypedDict):
     subtitles: list[MultiLangSubtitle]
     metadata: MetaData | None
     danmaku: DanmakuData
-    cover_data: bytes | None
+    cover_link: str | None
     chapter_info_data: list[ChapterInfoData]
     path: Path
     url: str

--- a/src/yutto/_typing.py
+++ b/src/yutto/_typing.py
@@ -228,6 +228,7 @@ class ExtractorOptions(TypedDict):
 class EpisodeData(TypedDict):
     """剧集数据，包含了一个视频资源的基本信息以及相关资源"""
 
+    url: str
     videos: list[VideoUrlMeta]
     audios: list[AudioUrlMeta]
     subtitles: list[MultiLangSubtitle]
@@ -236,7 +237,7 @@ class EpisodeData(TypedDict):
     cover_link: str | None
     chapter_info_data: list[ChapterInfoData]
     path: Path
-    url: str
+
 
 
 class DownloaderOptions(TypedDict):
@@ -245,7 +246,7 @@ class DownloaderOptions(TypedDict):
     require_video: bool
     require_chapter_info: bool
     save_cover: bool
-    parse_resources: bool
+    skip_download: bool
     video_quality: VideoQuality
     video_download_codec: VideoCodec
     video_save_codec: str

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -71,12 +71,16 @@ async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: 
             # 如 https://www.bilibili.com/bangumi/play/ep409825 中的「次元发电机采访」
             # 和 https://www.bilibili.com/bangumi/play/ep424859 中的「编辑推荐」
             section_episodes += section["episodes"]
+    
+    for i,item in enumerate(result["episodes"] + section_episodes):
+        print(i,":",item["share_url"])
     return {
         "title": result["title"],
         "pages": [
             {
                 "id": i + 1,
                 "name": _bangumi_episode_title(item["title"], item["long_title"]),
+                "url": item["share_url"],
                 "cid": CId(str(item["cid"])),
                 "episode_id": EpisodeId(str(item["id"])),
                 "avid": BvId(item["bvid"]),

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -31,6 +31,7 @@ class BangumiListItem(TypedDict):
     id: int
     name: str
     cid: CId
+    url: str
     episode_id: EpisodeId
     avid: AvId
     is_section: bool  # 是否属于专区
@@ -71,9 +72,10 @@ async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: 
             # 如 https://www.bilibili.com/bangumi/play/ep409825 中的「次元发电机采访」
             # 和 https://www.bilibili.com/bangumi/play/ep424859 中的「编辑推荐」
             section_episodes += section["episodes"]
-    
-    for i,item in enumerate(result["episodes"] + section_episodes):
-        print(i,":",item["share_url"])
+
+    # for i,item in enumerate(result["episodes"] + section_episodes):
+    #     print(i,"share_url:",item["share_url"])
+    #     print(item)
     return {
         "title": result["title"],
         "pages": [

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -31,7 +31,7 @@ class BangumiListItem(TypedDict):
     id: int
     name: str
     cid: CId
-    url: str
+    url: str # https://www.bilibili.com/bangumi/play/ep1448960
     episode_id: EpisodeId
     avid: AvId
     is_section: bool  # 是否属于专区

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -73,9 +73,6 @@ async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: 
             # 和 https://www.bilibili.com/bangumi/play/ep424859 中的「编辑推荐」
             section_episodes += section["episodes"]
 
-    # for i,item in enumerate(result["episodes"] + section_episodes):
-    #     print(i,"share_url:",item["share_url"])
-    #     print(item)
     return {
         "title": result["title"],
         "pages": [

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -28,10 +28,10 @@ if TYPE_CHECKING:
 
 
 class BangumiListItem(TypedDict):
+    url: str  # https://www.bilibili.com/bangumi/play/ep1448960
     id: int
     name: str
     cid: CId
-    url: str  # https://www.bilibili.com/bangumi/play/ep1448960
     episode_id: EpisodeId
     avid: AvId
     is_section: bool  # 是否属于专区

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -31,7 +31,7 @@ class BangumiListItem(TypedDict):
     id: int
     name: str
     cid: CId
-    url: str # https://www.bilibili.com/bangumi/play/ep1448960
+    url: str  # https://www.bilibili.com/bangumi/play/ep1448960
     episode_id: EpisodeId
     avid: AvId
     is_section: bool  # 是否属于专区

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -32,6 +32,7 @@ class CheeseListItem(TypedDict):
     episode_id: EpisodeId
     avid: AvId
     metadata: MetaData
+    url: str
 
 
 class CheeseList(TypedDict):
@@ -55,6 +56,8 @@ async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: S
         raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["data"]
     section_episodes = result["episodes"]
+    # print(result)
+    print(section_episodes)
     return {
         "title": result["title"],
         "pages": [
@@ -65,6 +68,7 @@ async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: S
                 "episode_id": EpisodeId(str(item["id"])),
                 "avid": AId(str(item["aid"])),
                 "metadata": _parse_cheese_metadata(item),
+                "url": f"https://www.bilibili.com/cheese/play/ep{item['id']}",
             }
             for i, item in enumerate(section_episodes)
         ],

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -32,7 +32,7 @@ class CheeseListItem(TypedDict):
     episode_id: EpisodeId
     avid: AvId
     metadata: MetaData
-    url: str
+    url: str # https://www.bilibili.com/cheese/play/ep487830
 
 
 class CheeseList(TypedDict):

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -56,8 +56,6 @@ async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: S
         raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["data"]
     section_episodes = result["episodes"]
-    # print(result)
-    print(section_episodes)
     return {
         "title": result["title"],
         "pages": [

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -32,7 +32,7 @@ class CheeseListItem(TypedDict):
     episode_id: EpisodeId
     avid: AvId
     metadata: MetaData
-    url: str # https://www.bilibili.com/cheese/play/ep487830
+    url: str  # https://www.bilibili.com/cheese/play/ep487830
 
 
 class CheeseList(TypedDict):

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -26,13 +26,13 @@ if TYPE_CHECKING:
 
 
 class CheeseListItem(TypedDict):
+    url: str  # https://www.bilibili.com/cheese/play/ep487830
     id: int
     name: str
     cid: CId
     episode_id: EpisodeId
     avid: AvId
     metadata: MetaData
-    url: str  # https://www.bilibili.com/cheese/play/ep487830
 
 
 class CheeseList(TypedDict):

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -58,7 +58,7 @@ class UgcVideoListItem(TypedDict):
     avid: AvId
     cid: CId
     metadata: MetaData
-    url: str  # Bvid to url.
+    url: str  # https://www.bilibili.com/video/BV1vZ4y1M7mQ?p=1
 
 
 class UgcVideoList(TypedDict):

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -53,12 +53,12 @@ class _UgcVideoInfo(TypedDict):
 
 
 class UgcVideoListItem(TypedDict):
+    url: str  # https://www.bilibili.com/video/BV1vZ4y1M7mQ?p=1
     id: int
     name: str
     avid: AvId
     cid: CId
     metadata: MetaData
-    url: str  # https://www.bilibili.com/video/BV1vZ4y1M7mQ?p=1
 
 
 class UgcVideoList(TypedDict):

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -58,6 +58,7 @@ class UgcVideoListItem(TypedDict):
     avid: AvId
     cid: CId
     metadata: MetaData
+    url: str # Bvid to url.
 
 
 class UgcVideoList(TypedDict):
@@ -161,6 +162,7 @@ async def get_ugc_video_list(ctx: FetcherContext, client: AsyncClient, avid: AvI
             "avid": avid,
             "cid": CId(str(item["cid"])),
             "metadata": _parse_ugc_video_metadata(video_info, page_info, is_first_page=i == 0),
+            "url": video_info["bvid"].to_url()+f"?p={i + 1}",
         }
         for i, (item, page_info) in enumerate(
             zip(cast("list[Any]", res_json["data"]), video_info["pages"], strict=True)

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -58,7 +58,7 @@ class UgcVideoListItem(TypedDict):
     avid: AvId
     cid: CId
     metadata: MetaData
-    url: str # Bvid to url.
+    url: str  # Bvid to url.
 
 
 class UgcVideoList(TypedDict):
@@ -162,7 +162,7 @@ async def get_ugc_video_list(ctx: FetcherContext, client: AsyncClient, avid: AvI
             "avid": avid,
             "cid": CId(str(item["cid"])),
             "metadata": _parse_ugc_video_metadata(video_info, page_info, is_first_page=i == 0),
-            "url": video_info["bvid"].to_url()+f"?p={i + 1}",
+            "url": video_info["bvid"].to_url() + f"?p={i + 1}",
         }
         for i, (item, page_info) in enumerate(
             zip(cast("list[Any]", res_json["data"]), video_info["pages"], strict=True)

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -274,6 +274,12 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         action="store_true",
         help="生成视频流封面后单独保存封面文件",
     )
+    group_resource.add_argument(
+        "--skip-download",
+        default=settings.resource.skip_download,
+        action="store_true",
+        help="仅解析视频信息和资源项，跳过资源项目下载。",
+    )
     group_resource.set_defaults(
         require_video=settings.resource.require_video,
         require_audio=settings.resource.require_audio,

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -274,6 +274,12 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         action="store_true",
         help="生成视频流封面后单独保存封面文件",
     )
+    group_resource.add_argument(
+        "--parse-resources",
+        default=settings.resource.parse_resources,
+        action="store_true",
+        help="解析视频资源列表但所有内容均不下载",
+    )
     group_resource.set_defaults(
         require_video=settings.resource.require_video,
         require_audio=settings.resource.require_audio,

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -199,6 +199,10 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         "--no-progress", default=settings.basic.no_progress, action="store_true", help="不显示进度条"
     )
     group_basic.add_argument("--debug", default=settings.basic.debug, action="store_true", help="启用 debug 模式")
+    group_basic.add_argument("--skip-download",
+                             default=settings.basic.skip_download,
+                             action="store_true",
+                             help="仅解析视频信息和资源项，跳过资源项目下载。")
 
     # 资源选择
     group_resource = parser.add_argument_group("resource", "资源选择参数")
@@ -273,12 +277,6 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         default=settings.resource.save_cover,
         action="store_true",
         help="生成视频流封面后单独保存封面文件",
-    )
-    group_resource.add_argument(
-        "--parse-resources",
-        default=settings.resource.parse_resources,
-        action="store_true",
-        help="解析视频资源列表但所有内容均不下载",
     )
     group_resource.set_defaults(
         require_video=settings.resource.require_video,

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -199,10 +199,6 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         "--no-progress", default=settings.basic.no_progress, action="store_true", help="不显示进度条"
     )
     group_basic.add_argument("--debug", default=settings.basic.debug, action="store_true", help="启用 debug 模式")
-    group_basic.add_argument("--skip-download",
-                             default=settings.basic.skip_download,
-                             action="store_true",
-                             help="仅解析视频信息和资源项，跳过资源项目下载。")
 
     # 资源选择
     group_resource = parser.add_argument_group("resource", "资源选择参数")

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -58,7 +58,6 @@ class YuttoBasicSettings(BaseModel):
     no_color: Annotated[bool, Field(False)]
     no_progress: Annotated[bool, Field(False)]
     debug: Annotated[bool, Field(False)]
-    skip_download: Annotated[bool, Field(False)]
 
 
 class YuttoResourceSettings(BaseModel):
@@ -70,6 +69,7 @@ class YuttoResourceSettings(BaseModel):
     require_cover: Annotated[bool, Field(True)]
     require_chapter_info: Annotated[bool, Field(True)]
     save_cover: Annotated[bool, Field(False)]
+    skip_download: Annotated[bool, Field(False)]
 
 
 class YuttoDanmakuSettings(BaseModel):

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -69,6 +69,7 @@ class YuttoResourceSettings(BaseModel):
     require_cover: Annotated[bool, Field(True)]
     require_chapter_info: Annotated[bool, Field(True)]
     save_cover: Annotated[bool, Field(False)]
+    parse_resources: Annotated[bool, Field(False)]
 
 
 class YuttoDanmakuSettings(BaseModel):

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -58,6 +58,7 @@ class YuttoBasicSettings(BaseModel):
     no_color: Annotated[bool, Field(False)]
     no_progress: Annotated[bool, Field(False)]
     debug: Annotated[bool, Field(False)]
+    skip_download: Annotated[bool, Field(False)]
 
 
 class YuttoResourceSettings(BaseModel):
@@ -69,7 +70,6 @@ class YuttoResourceSettings(BaseModel):
     require_cover: Annotated[bool, Field(True)]
     require_chapter_info: Annotated[bool, Field(True)]
     save_cover: Annotated[bool, Field(False)]
-    parse_resources: Annotated[bool, Field(False)]
 
 
 class YuttoDanmakuSettings(BaseModel):

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -247,7 +247,7 @@ class DownloadManager:
                     "block_size": int(args.block_size * 1024 * 1024),
                     "num_workers": args.num_workers,
                     "save_cover": args.save_cover,
-                    "parse_resources": args.parse_resources,
+                    "skip_download": args.skip_download,
                     "metadata_format": {
                         "premiered": args.metadata_format_premiered,
                         "dateadded": TIME_FULL_FMT,

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -247,6 +247,7 @@ class DownloadManager:
                     "block_size": int(args.block_size * 1024 * 1024),
                     "num_workers": args.num_workers,
                     "save_cover": args.save_cover,
+                    "parse_resources": args.parse_resources,
                     "metadata_format": {
                         "premiered": args.metadata_format_premiered,
                         "dateadded": TIME_FULL_FMT,

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -393,7 +393,7 @@ async def start_downloader(
         else:
             # TODO 可以考虑直接 show nfo
             Logger.custom(
-                "存在可下载 NFO 媒体描述文件",
+                f"{metadata}",
                 badge=Badge("描述文件", fore="black", back="cyan"),
             )
 
@@ -420,9 +420,8 @@ async def start_downloader(
         if not parse_resources:
             write_chapter_info(filename, chapter_info_data, chapter_info_path)
         else:
-            # TODO 了解一下章节信息
             Logger.custom(
-                "存在可下载章节信息",
+                f"{chapter_info_data}",
                 badge=Badge("章节", fore="black", back="cyan"),
             )
 

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -301,6 +301,7 @@ async def start_downloader(
     danmaku = episode_data["danmaku"]
     metadata = episode_data["metadata"]
     cover_data = episode_data["cover_data"]
+    url:str = episode_data["url"]
     chapter_info_data = episode_data["chapter_info_data"]
     output_dir, tmp_dir, filename = resolve_path(options["output_dir"], options["tmp_dir"], episode_data["path"])
     require_video = options["require_video"]
@@ -322,7 +323,7 @@ async def start_downloader(
     audio = select_audio(audios, options["audio_quality"], options["audio_download_codec"])
     will_download_video = video is not None and require_video
     will_download_audio = audio is not None and require_audio
-
+    Logger.custom(f"{url}", badge=Badge("url", fore="black", back="cyan"))
     # 显示音视频详细信息
     show_videos_info(
         videos,
@@ -397,7 +398,7 @@ async def start_downloader(
 
     # 保存封面
     if cover_data is not None:
-        if not parse_resources:            
+        if not parse_resources:
             cover_path.write_bytes(cover_data)
             if options["save_cover"]:
                 cover_save_path = output_dir.joinpath(f"{filename}-poster.jpg")
@@ -421,7 +422,7 @@ async def start_downloader(
                 "存在可下载章节信息",
                 badge=Badge("章节", fore="black", back="cyan"),
             )
-    
+
     if parse_resources:
         # 跳过下载.
         return DownloadState.SKIP

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -307,7 +307,7 @@ async def start_downloader(
     output_dir, tmp_dir, filename = resolve_path(options["output_dir"], options["tmp_dir"], episode_data["path"])
     require_video = options["require_video"]
     require_audio = options["require_audio"]
-    parse_resources = options["parse_resources"]
+    skip_download = options["skip_download"]
     metadata_format = options["metadata_format"]
     danmaku_options = options["danmaku_options"]
     Logger.info(f"开始处理视频 {filename}")
@@ -324,7 +324,7 @@ async def start_downloader(
     audio = select_audio(audios, options["audio_quality"], options["audio_download_codec"])
     will_download_video = video is not None and require_video
     will_download_audio = audio is not None and require_audio
-    Logger.custom(f"{url}", badge=Badge("url", fore="black", back="cyan"))
+    Logger.custom(url, badge=Badge("LINK", fore="black", back="cyan"))
     # 显示音视频详细信息
     show_videos_info(
         videos,
@@ -353,7 +353,7 @@ async def start_downloader(
 
     # 保存字幕
     if subtitles:
-        if not parse_resources:
+        if not skip_download:
             for subtitle in subtitles:
                 write_subtitle(subtitle["lines"], output_path, subtitle["lang"])
             Logger.custom(
@@ -368,7 +368,7 @@ async def start_downloader(
 
     # 保存弹幕
     if danmaku["data"]:
-        if not parse_resources:
+        if not skip_download:
             write_danmaku(
                 danmaku,
                 str(output_path),
@@ -387,7 +387,7 @@ async def start_downloader(
 
     # 保存媒体描述文件
     if metadata is not None:
-        if not parse_resources:
+        if not skip_download:
             write_metadata(metadata, output_path, metadata_format)
             Logger.custom("NFO 媒体描述文件已生成", badge=Badge("描述文件", fore="black", back="cyan"))
         else:
@@ -399,7 +399,7 @@ async def start_downloader(
 
     # 保存封面
     if cover_link is not None:
-        if not parse_resources:
+        if not skip_download:
             cover_data = await Fetcher.fetch_bin(ctx, client, cover_link)
             cover_path.write_bytes(cover_data) if cover_data else None
             if options["save_cover"]:
@@ -417,7 +417,7 @@ async def start_downloader(
 
     # 保存章节信息
     if chapter_info_data:
-        if not parse_resources:
+        if not skip_download:
             write_chapter_info(filename, chapter_info_data, chapter_info_path)
         else:
             Logger.custom(
@@ -425,7 +425,7 @@ async def start_downloader(
                 badge=Badge("章节", fore="black", back="cyan"),
             )
 
-    if parse_resources:
+    if skip_download:
         # 跳过下载.
         return DownloadState.SKIP
 

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -302,7 +302,7 @@ async def start_downloader(
     metadata = episode_data["metadata"]
     cover_link = episode_data["cover_link"]
     cover_data: bytes | None = None
-    url:str = episode_data["url"]
+    url: str = episode_data["url"]
     chapter_info_data = episode_data["chapter_info_data"]
     output_dir, tmp_dir, filename = resolve_path(options["output_dir"], options["tmp_dir"], episode_data["path"])
     require_video = options["require_video"]
@@ -414,7 +414,6 @@ async def start_downloader(
             )
     else:
         Logger.warning("封面链接不存在，跳过下载")
-
 
     # 保存章节信息
     if chapter_info_data:

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -66,6 +66,7 @@ class CheeseBatchExtractor(BatchExtractor):
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(cheese_list["pages"]))
         cheese_list["pages"] = list(filter(lambda item: item["id"] in episodes, cheese_list["pages"]))
+        print(cheese_list["pages"])
         return [
             CoroutineWrapper(
                 extract_cheese_data(

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -66,7 +66,6 @@ class CheeseBatchExtractor(BatchExtractor):
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(cheese_list["pages"]))
         cheese_list["pages"] = list(filter(lambda item: item["id"] in episodes, cheese_list["pages"]))
-        print(cheese_list["pages"])
         return [
             CoroutineWrapper(
                 extract_cheese_data(

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -215,6 +215,7 @@ async def extract_ugc_video_data(
         }
         subpath_variables_base.update(subpath_variables)
         path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
+        url = ugc_video_info["url"]
         return EpisodeData(
             videos=videos,
             audios=audios,
@@ -224,6 +225,7 @@ async def extract_ugc_video_data(
             cover_data=cover_data,
             chapter_info_data=chapter_info_data,
             path=Path(path),
+            url=url,
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
         Logger.error(e.message)

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -30,11 +30,12 @@ from yutto.path_resolver import (
 )
 from yutto.utils.console.logger import Logger
 from yutto.utils.danmaku import EmptyDanmakuData
-from yutto.utils.fetcher import FetcherContext
 from yutto.utils.metadata import attach_chapter_info
 
 if TYPE_CHECKING:
     import httpx
+
+    from yutto.utils.fetcher import FetcherContext
 
 
 async def extract_bangumi_data(

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -143,6 +143,7 @@ async def extract_cheese_data(
         }
         subpath_variables_base.update(subpath_variables)
         path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
+        url:str = cheese_info["url"]
         return EpisodeData(
             videos=videos,
             audios=audios,
@@ -152,6 +153,7 @@ async def extract_cheese_data(
             cover_data=cover_data,
             chapter_info_data=[],
             path=Path(path),
+            url=url,
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
         Logger.error(e.message)

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -83,6 +83,7 @@ async def extract_bangumi_data(
         }
         subpath_variables_base.update(subpath_variables)
         path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
+        url:str = bangumi_info["url"]
         return EpisodeData(
             videos=videos,
             audios=audios,
@@ -92,6 +93,7 @@ async def extract_bangumi_data(
             cover_data=cover_data,
             chapter_info_data=[],
             path=Path(path),
+            url=url
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
         Logger.error(e.message)

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -30,7 +30,7 @@ from yutto.path_resolver import (
 )
 from yutto.utils.console.logger import Logger
 from yutto.utils.danmaku import EmptyDanmakuData
-from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.fetcher import FetcherContext
 from yutto.utils.metadata import attach_chapter_info
 
 if TYPE_CHECKING:
@@ -79,7 +79,7 @@ async def extract_bangumi_data(
         }
         subpath_variables_base.update(subpath_variables)
         path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
-        url:str = bangumi_info["url"]
+        url: str = bangumi_info["url"]
         return EpisodeData(
             videos=videos,
             audios=audios,
@@ -89,7 +89,7 @@ async def extract_bangumi_data(
             cover_link=cover_link,
             chapter_info_data=[],
             path=Path(path),
-            url=url
+            url=url,
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
         Logger.error(e.message)
@@ -137,7 +137,7 @@ async def extract_cheese_data(
         }
         subpath_variables_base.update(subpath_variables)
         path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
-        url:str = cheese_info["url"]
+        url: str = cheese_info["url"]
         return EpisodeData(
             videos=videos,
             audios=audios,

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -64,11 +64,7 @@ async def extract_bangumi_data(
             else EmptyDanmakuData
         )
         metadata = bangumi_info["metadata"] if options["require_metadata"] else None
-        cover_data = (
-            await Fetcher.fetch_bin(ctx, client, bangumi_info["metadata"]["thumb"])
-            if options["require_cover"]
-            else None
-        )
+        cover_link = bangumi_info["metadata"]["thumb"] if options["require_cover"] else None
         subpath_variables_base: PathTemplateVariableDict = {
             "id": id,
             "aid": str(avid.as_aid()),
@@ -90,7 +86,7 @@ async def extract_bangumi_data(
             subtitles=subtitles,
             metadata=metadata,
             danmaku=danmaku,
-            cover_data=cover_data,
+            cover_link=cover_link,
             chapter_info_data=[],
             path=Path(path),
             url=url
@@ -126,9 +122,7 @@ async def extract_cheese_data(
             else EmptyDanmakuData
         )
         metadata = cheese_info["metadata"] if options["require_metadata"] else None
-        cover_data = (
-            await Fetcher.fetch_bin(ctx, client, cheese_info["metadata"]["thumb"]) if options["require_cover"] else None
-        )
+        cover_link = cheese_info["metadata"]["thumb"] if options["require_cover"] else None
         subpath_variables_base: PathTemplateVariableDict = {
             "id": id,
             "aid": str(avid.as_aid()),
@@ -150,7 +144,7 @@ async def extract_cheese_data(
             subtitles=subtitles,
             metadata=metadata,
             danmaku=danmaku,
-            cover_data=cover_data,
+            cover_link=cover_link,
             chapter_info_data=[],
             path=Path(path),
             url=url,
@@ -190,11 +184,7 @@ async def extract_ugc_video_data(
         metadata = ugc_video_info["metadata"] if options["require_metadata"] else None
         if metadata and chapter_info_data:
             attach_chapter_info(metadata, chapter_info_data)
-        cover_data = (
-            await Fetcher.fetch_bin(ctx, client, ugc_video_info["metadata"]["thumb"])
-            if options["require_cover"]
-            else None
-        )
+        cover_link = ugc_video_info["metadata"]["thumb"] if options["require_cover"] else None
         owner_uid: str = (
             ugc_video_info["metadata"]["actor"][0]["profile"].split("/")[-1]
             if ugc_video_info["metadata"]["actor"]
@@ -224,7 +214,7 @@ async def extract_ugc_video_data(
             subtitles=subtitles,
             metadata=metadata,
             danmaku=danmaku,
-            cover_data=cover_data,
+            cover_link=cover_link,
             chapter_info_data=chapter_info_data,
             path=Path(path),
             url=url,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->


- [x] feat: 添加 `--parse-resources` 参数. 解析包含的资源项目但不下载。parse 时 show play url, video_quality, audio_quality, metadata, cover_link)
- [x] refact:  将 `cover_data` 的下载移动至 `start_downloader` 中.


在 parse 时解析出来的 `play url` (可以二次解析进而单独下载), 可以把 `batch` 性质的任务转化为 `single` ,比如如果在 WebUI 中，可以进行手动选集(原本收藏夹和合集和 space 是不能选集的)。或者如果要支持 toml 任务列表，也可以先把所有任务解析为 `play url` 然后一个一个下载。而不用考虑 batch single 混合时问题。
提前显示 metadata , cover_link 这些则是我在 WebUI 中可以描述一下解析出来的 url 对应的是啥。

cover 本身并不小， 如果在解析的时候下载，会严重拖慢解析速度， 并且似乎还会引起风控，过高的请求频率。所以把 cover_link 单独传递到 start_downloader 进行下载。



## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

### 1. --parse-reousrces

本质是 `return DownloadState.SKIP` 来跳过音视频下载。并且通过 `parse_resources:bool` 来控制 `show metadata ,  cover_link , url` 等信息。

提取出来 url 都对应的是 playing_url :

- ugc_video :  https://www.bilibili.com/video/BV1vZ4y1M7mQ?p=1
- bangumi : https://www.bilibili.com/bangumi/play/ep1448960
- cheese: https://www.bilibili.com/cheese/play/ep487830

它们有个特点就是都可以 `yutto url` 进行单独下载。那么就可以通过二次解析来手动选集。

使用方式:

yutto.toml(因为基本都不用额外下载，所以我把所有资源选项都设置为 true , 设置一些 false 则不会解析那些。):

```toml
[basic]
num_workers = 8
video_quality = 80
audio_quality = 30280
sessdata = "=-="
vip_strict = false
login_strict = false
dir = "./downloads"

[resource]
require_video = true # video_quality
require_audio = true # audio_quality
require_danmaku = true 
require_subtitle = true
require_metadata = true # show metadata
require_cover = true # show cover_link
save_cover = false
```

command:

```shell
uv run yutto -b --parse-resources https://www.bilibili.com/bangumi/play/ss81007/
```
```shell
uv run yutto  --parse-resources https://www.bilibili.com/video/BV1hzADeFEvA/
```


### 2. cover_data -> cover_link

延迟 cover_data 的下载。

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
