### PR TITLE
🐛  fix:  explicit use `utf-8` encoding when read version file

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=false

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,1 +1,0 @@
-strict-peer-dependencies=false

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,2 +1,1 @@
-auto-install-peers=true
-strict-peer-dependencies=false
+auto-install-peers=false

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,1 +1,1 @@
-auto-install-peers=false
+strict-peer-dependencies=false

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -27,7 +27,7 @@ def cli() -> argparse.Namespace:
 
 def main():
     args = cli()
-    with Path(args.file).open("r",encoding="utf-8") as f:
+    with Path(args.file).open("r", encoding="utf-8") as f:
         code = f.read()
     tree = ast.parse(code)
     analyzer = VersionAnalyzer(args.literal_name)

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -27,7 +27,7 @@ def cli() -> argparse.Namespace:
 
 def main():
     args = cli()
-    with Path(args.file).open("r") as f:
+    with Path(args.file).open("r",encoding="utf-8") as f:
         code = f.read()
     tree = ast.parse(code)
     analyzer = VersionAnalyzer(args.literal_name)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

`gbk`  cannt work but default use in windows:

```shell
D:\tmp\yutto>just docs-setup
Traceback (most recent call last):
  File "D:\tmp\yutto\scripts\get-version.py", line 42, in <module>
    main()
    ~~~~^^
  File "D:\tmp\yutto\scripts\get-version.py", line 31, in main
    code = f.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 10: illegal multibyte sequence
error: Backtick failed with exit code 1
 ——▶ justfile:3:12
  │
3 │ VERSION := `uv run scripts/get-version.py src/yutto/__version__.py`
  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->



## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
