### PR TITLE
👽️ deps: bump `quick-xml` to `0.38.0` and unescape manually

### DIFF
--- a/packages/biliass/rust/Cargo.lock
+++ b/packages/biliass/rust/Cargo.lock
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
 ]

--- a/packages/biliass/rust/Cargo.toml
+++ b/packages/biliass/rust/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = { version = "0.25.0", features = ["abi3-py310"] }
 bytes = "1.10.0"
 prost = "0.14.0"
 thiserror = "2.0.11"
-quick-xml = "0.37.2"
+quick-xml = "0.38.0"
 cached = "0.55.0"
 serde = "1.0.218"
 serde_json = "1.0.139"

--- a/packages/biliass/rust/src/reader/xml.rs
+++ b/packages/biliass/rust/src/reader/xml.rs
@@ -64,8 +64,8 @@ fn parse_comment_content(reader: &mut Reader<&[u8]>) -> Result<String, ParseErro
                 )));
             }
         }
+        buf.clear();
     }
-    buf.clear();
 
     if contents.is_empty() {
         return Err(ParseError::Xml("No content found in comment".to_string()));

--- a/packages/biliass/rust/src/reader/xml.rs
+++ b/packages/biliass/rust/src/reader/xml.rs
@@ -36,7 +36,11 @@ fn parse_comment_content(reader: &mut Reader<&[u8]>) -> Result<String, ParseErro
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Text(e)) => {
-                contents.push(e.decode().unwrap().into_owned());
+                contents.push(
+                    e.decode()
+                        .map_err(|e| ParseError::Xml(format!("Error decoding text: {e}")))?
+                        .into_owned(),
+                );
             }
             Ok(Event::GeneralRef(e)) => {
                 let entity_str = std::str::from_utf8(e.as_ref())

--- a/packages/biliass/rust/src/reader/xml.rs
+++ b/packages/biliass/rust/src/reader/xml.rs
@@ -36,7 +36,7 @@ fn parse_comment_content(reader: &mut Reader<&[u8]>) -> Result<String, ParseErro
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Text(e)) => {
-                contents.push(Some(e.decode().unwrap().into_owned()));
+                contents.push(e.decode().unwrap().into_owned());
             }
             Ok(Event::GeneralRef(e)) => {
                 let entity_str = std::str::from_utf8(e.as_ref())
@@ -45,7 +45,7 @@ fn parse_comment_content(reader: &mut Reader<&[u8]>) -> Result<String, ParseErro
                     .ok_or_else(|| {
                         ParseError::Xml(format!("Error resolving entity: {entity_str}"))
                     })?;
-                contents.push(Some(resolved_entity.to_string()));
+                contents.push(resolved_entity.to_string());
             }
             Ok(Event::End(_) | Event::Eof) => {
                 break;
@@ -66,7 +66,7 @@ fn parse_comment_content(reader: &mut Reader<&[u8]>) -> Result<String, ParseErro
     if contents.is_empty() {
         return Err(ParseError::Xml("No content found in comment".to_string()));
     }
-    Ok(contents.into_iter().flatten().collect::<String>())
+    Ok(contents.into_iter().collect::<String>())
 }
 
 fn parse_comment_item(

--- a/packages/biliass/rust/src/reader/xml.rs
+++ b/packages/biliass/rust/src/reader/xml.rs
@@ -30,15 +30,43 @@ fn parse_raw_p(reader: &mut Reader<&[u8]>, element: &BytesStart) -> Result<Strin
 }
 
 fn parse_comment_content(reader: &mut Reader<&[u8]>) -> Result<String, ParseError> {
-    let mut content = None;
+    let mut contents = Vec::new();
     let mut buf = Vec::new();
 
-    if let Ok(Event::Text(e)) = reader.read_event_into(&mut buf) {
-        content = Some(e.unescape().unwrap().into_owned());
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Text(e)) => {
+                contents.push(Some(e.decode().unwrap().into_owned()));
+            }
+            Ok(Event::GeneralRef(e)) => {
+                let entity_str = std::str::from_utf8(e.as_ref())
+                    .map_err(|e| ParseError::Xml(format!("Error decoding entity: {e}")))?;
+                let resolved_entity = quick_xml::escape::resolve_predefined_entity(entity_str)
+                    .ok_or_else(|| {
+                        ParseError::Xml(format!("Error resolving entity: {entity_str}"))
+                    })?;
+                contents.push(Some(resolved_entity.to_string()));
+            }
+            Ok(Event::End(_) | Event::Eof) => {
+                break;
+            }
+            Ok(_) => {
+                // Ignore other events
+                continue;
+            }
+            Err(e) => {
+                return Err(ParseError::Xml(format!(
+                    "Error reading comment content: {e}"
+                )));
+            }
+        }
     }
     buf.clear();
 
-    content.ok_or(ParseError::Xml("No content found in comment".to_string()))
+    if contents.is_empty() {
+        return Err(ParseError::Xml("No content found in comment".to_string()));
+    }
+    Ok(contents.into_iter().flatten().collect::<String>())
 }
 
 fn parse_comment_item(
@@ -201,7 +229,7 @@ where
                             "No version specified".to_string(),
                         )));
                     }
-                    if let Ok(comment_option) = parse_comment(
+                    match parse_comment(
                         &mut reader,
                         e,
                         version.clone().unwrap(),
@@ -210,11 +238,18 @@ where
                         count,
                         block_options,
                     ) {
-                        if let Some(comment) = comment_option {
-                            comments.push(comment);
+                        Ok(comment_option) => {
+                            if let Some(comment) = comment_option {
+                                comments.push(comment);
+                            }
                         }
-                    } else {
-                        eprintln!("Error parsing comment at {:?}", reader.buffer_position());
+                        Err(e) => {
+                            eprintln!(
+                                "Error parsing comment at {:?}, {}",
+                                reader.buffer_position(),
+                                e
+                            );
+                        }
                     }
                     count += 1;
                 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

升级 quick-xml，根据其修改需要手动处理 unescape（https://github.com/tafia/quick-xml/releases/tag/v0.38.0 、tafia/quick-xml#766）

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
