### PR TITLE
🐛 fix: 视频字幕下载中跳过无效的字幕url，避免fetch报错打断下载

### DIFF
--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -160,7 +160,14 @@ async def get_bangumi_subtitles(
     subtitles_info = subtitles_json_info["data"]["subtitle"]
     results: list[MultiLangSubtitle] = []
     for sub_info in subtitles_info["subtitles"]:
-        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + sub_info["subtitle_url"])
+        subtitle_url = sub_info["subtitle_url"]
+
+        # 检查 subtitle_url 是否有效
+        if subtitle_url is None or not subtitle_url.strip():
+            Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
+            continue
+
+        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
         if subtitle_text is None:
             continue
         results.append(

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -129,7 +129,10 @@ async def get_cheese_subtitles(
     subtitles_info = subtitles_json_info["data"]["subtitle"]
     results: list[MultiLangSubtitle] = []
     for sub_info in subtitles_info["subtitles"]:
-        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + sub_info["subtitle_url"])
+        subtitle_url = sub_info["subtitle_url"]
+        if not subtitle_url or subtitle_url.strip() == "":
+            continue
+        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
         if subtitle_text is None:
             continue
         results.append(

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -130,8 +130,12 @@ async def get_cheese_subtitles(
     results: list[MultiLangSubtitle] = []
     for sub_info in subtitles_info["subtitles"]:
         subtitle_url = sub_info["subtitle_url"]
-        if not subtitle_url or subtitle_url.strip() == "":
+
+        # 检查 subtitle_url 是否有效
+        if subtitle_url is None or not subtitle_url.strip():
+            Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
+
         subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
         if subtitle_text is None:
             continue

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -254,7 +254,14 @@ async def get_ugc_video_subtitles(
         return []
     results: list[MultiLangSubtitle] = []
     for sub_info in res_json["data"]["subtitle"]["subtitles"]:
-        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + sub_info["subtitle_url"])
+        subtitle_url = sub_info["subtitle_url"]
+
+        # 检查 subtitle_url 是否有效
+        if subtitle_url is None or not subtitle_url.strip():
+            Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
+            continue
+
+        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
         if subtitle_text is None:
             continue
         results.append(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

修复 cheese 字幕获取时的错误

**测试用例**

当发生错误时，输出以下追踪的结果为

```
DEBUG subtitles_info = {'allow_submit': False, 'lan': '', 'lan_doc': '', 'subtitles': [{'id': 1134851933073485824, 'lan': 'ai-zh', 'lan_doc': '中文（自动生成）', 'is_lock': False, 'subtitle_url': '', 'type': 1, 'id_str': '1134851933073485824', 'ai_type': 0, 'ai_status': 2}]}
DEBUG sub_info = {'id': 1134851933073485824, 'lan': 'ai-zh', 'lan_doc': '中文（自动生成）', 'is_lock': False, 'subtitle_url': '', 'type': 1, 'id_str': '1134851933073485824', 'ai_type': 0, 'ai_status': 2}
DEBUG subtitle_url = ''
DEBUG full_url = 'https:'
```

其中ai_status为2怀疑是字幕生成出错

当获取 B站课程（cheese）字幕时，如果 API 返回的 `subtitle_url` 字段为空字符串，程序会构造无效的 URL `"https:"`，导致抛出 `ValueError: unknown url type: '/'` 异常并崩溃。

**错误堆栈**
```
ValueError: unknown url type: '/'
    at get_cheese_subtitles() line 132
    subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + sub_info["subtitle_url"])
```

## 解决方案

在构造字幕 URL 之前，添加对 `subtitle_url` 的有效性检查：

`ps:上一个pr被我环境弄乱了commit信息所以重新创了一个www`

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
