### PR TITLE
⚡ perf: cache biliass builds in CI

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,6 +24,10 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            packages/biliass/**/*
 
       - name: Install python
         uses: actions/setup-python@v6

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,6 +23,10 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            packages/biliass/**/*
 
       - name: Install python
         uses: actions/setup-python@v6

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: e2e without subprocess
         run: |
-          uv run yutto -v
-          uv run yutto -h
-          uv run yutto https://www.bilibili.com/video/BV1AZ4y147Yg -w -d __test_files__
+          uv run --no-sync yutto -v
+          uv run --no-sync yutto -h
+          uv run --no-sync yutto https://www.bilibili.com/video/BV1AZ4y147Yg -w -d __test_files__
           rm -rf __test_files__
 
       - name: e2e test

--- a/.github/workflows/lint-and-fmt.yml
+++ b/.github/workflows/lint-and-fmt.yml
@@ -23,6 +23,10 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            packages/biliass/**/*
 
       - name: Install python
         uses: actions/setup-python@v6

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,6 +25,10 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+            packages/biliass/**/*
 
       - name: Install python
         uses: actions/setup-python@v6

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,4 +55,4 @@ jobs:
         if: ${{ matrix.python-version == '3.14' && github.event_name != 'merge_group' }}
         with:
           mode: simulation
-          run: uv run -p ${{ matrix.python-version }} pytest --codspeed
+          run: uv run --no-sync -p ${{ matrix.python-version }} pytest --codspeed

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set positional-arguments
 
-VERSION := `uv run scripts/get-version.py src/yutto/__version__.py`
-BILIASS_VERSION := `uv run scripts/get-version.py packages/biliass/src/biliass/__version__.py`
+VERSION := `python3 scripts/get-version.py src/yutto/__version__.py`
+BILIASS_VERSION := `python3 scripts/get-version.py packages/biliass/src/biliass/__version__.py`
 DOCKER_NAME := "siguremo/yutto"
 
 run *ARGS:
@@ -75,16 +75,18 @@ ci-install pyversion:
   uv sync --all-extras --dev --no-editable -p {{pyversion}}
 
 ci-fmt-check:
-  uv run ruff format --check --diff .
+  uv run --no-sync ruff format --check --diff .
 
 ci-lint:
-  just lint
+  uv run --no-sync ty check --error-on-warning src/yutto packages/biliass/src/biliass tests
+  uv run --no-sync ruff check .
+  uv run --no-sync typos
 
 ci-test pyversion:
-  uv run -p {{pyversion}} pytest -m "(api or processor or biliass) and not (ci_skip or ignore)" --reruns 3 --reruns-delay 1
+  uv run --no-sync -p {{pyversion}} pytest -m "(api or processor or biliass) and not (ci_skip or ignore)" --reruns 3 --reruns-delay 1
 
 ci-e2e-test pyversion:
-  uv run -p {{pyversion}} pytest -m "e2e and not (ci_skip or ignore)"
+  uv run --no-sync -p {{pyversion}} pytest -m "e2e and not (ci_skip or ignore)"
 
 # docker specific
 docker-run *ARGS:

--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ generate-schema:
 
 # CI specific
 ci-install pyversion:
-  uv sync --all-extras --dev -p {{pyversion}}
+  uv sync --all-extras --dev --no-editable -p {{pyversion}}
 
 ci-fmt-check:
   uv run ruff format --check --diff .

--- a/packages/biliass/pyproject.toml
+++ b/packages/biliass/pyproject.toml
@@ -39,6 +39,17 @@ biliass = "biliass.__main__:main"
 features = ["pyo3/extension-module"]
 module-name = "biliass._core"
 
+[tool.uv]
+cache-keys = [
+  { file = "pyproject.toml" },
+  { file = "rust/Cargo.toml" },
+  { file = "rust/Cargo.lock" },
+  { file = "rust/build.rs" },
+  { file = "rust/src/**/*.rs" },
+  { file = "rust/proto/**/*.proto" },
+  { file = "src/biliass/**/*" },
+]
+
 [build-system]
 requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"


### PR DESCRIPTION
## 动机

CI 中 `just ci-install` 会通过 workspace 从源码安装 `biliass`，但原先的配置没有让 uv 的缓存对 `biliass` 源码变更敏感，导致每次安装阶段都更容易重新构建这个 Rust 扩展库。

## 解决方案

- 在 CI 安装命令中使用 `uv sync --all-extras --dev --no-editable`，让 `biliass` 走可缓存的非 editable 构建路径
- 为使用 `astral-sh/setup-uv` 的 workflow 补充 `cache-dependency-glob`，将 `packages/biliass/**/*` 纳入 cache key
- 保持配置简洁，只保留 `pyproject.toml`、`uv.lock` 和 `packages/biliass/**/*` 三类输入

## 类型

-  [x] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
