### PR TITLE
🐛 fix: retry on non-2xx response and catch MaxRetryError in space API

### DIFF
--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, TypedDict
 
+from returns.result import Failure, Success
+
 from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
@@ -49,23 +51,31 @@ class BangumiList(TypedDict):
 
 async def get_season_id_by_media_id(ctx: FetcherContext, client: AsyncClient, media_id: MediaId) -> SeasonId:
     media_api = f"https://api.bilibili.com/pgc/review/user?media_id={media_id}"
-    res_json = await Fetcher.fetch_json(ctx, client, media_api)
-    assert res_json is not None
-    return SeasonId(str(res_json["result"]["media"]["season_id"]))
+    match await Fetcher.fetch_json(ctx, client, media_api):
+        case Success(res_json):
+            return SeasonId(str(res_json["result"]["media"]["season_id"]))
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, episode_id: EpisodeId) -> SeasonId:
     episode_api = f"https://api.bilibili.com/pgc/view/web/season?ep_id={episode_id}"
-    res_json = await Fetcher.fetch_json(ctx, client, episode_api)
-    assert res_json is not None
-    return SeasonId(str(res_json["result"]["season_id"]))
+    match await Fetcher.fetch_json(ctx, client, episode_api):
+        case Success(res_json):
+            return SeasonId(str(res_json["result"]["season_id"]))
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> BangumiList:
     list_api = "http://api.bilibili.com/pgc/view/web/season?season_id={season_id}"
-    resp_json = await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id))
-    if resp_json is None:
-        raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）")
+    match await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)):
+        case Success(resp_json):
+            pass
+        case Failure(_):
+            raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）")
     if resp_json.get("result") is None:
         raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["result"]
@@ -98,9 +108,11 @@ async def get_bangumi_playurl(
 ) -> tuple[list[VideoUrlMeta], list[AudioUrlMeta]]:
     play_api = "https://api.bilibili.com/pgc/player/web/v2/playurl?avid={aid}&bvid={bvid}&cid={cid}&qn=127&fnver=0&fnval=4048&fourk=1&support_multi_audio=true&from_client=BROWSER"
 
-    resp_json = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
-    if resp_json is None:
-        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
+    match await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid)):
+        case Success(resp_json):
+            pass
+        case Failure(_):
+            raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
     if resp_json.get("result") is None or resp_json["result"].get("video_info") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
@@ -155,9 +167,11 @@ async def get_bangumi_subtitles(
 ) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/wbi/v2?aid={aid}&bvid={bvid}&cid={cid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    subtitles_json_info = await Fetcher.fetch_json(ctx, client, subtitle_url)
-    if subtitles_json_info is None:
-        return []
+    match await Fetcher.fetch_json(ctx, client, subtitle_url):
+        case Success(subtitles_json_info):
+            pass
+        case Failure(_):
+            return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
         Logger.warning(f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}")
         return []
@@ -171,9 +185,11 @@ async def get_bangumi_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
-        if subtitle_text is None:
-            continue
+        match await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url):
+            case Success(subtitle_text):
+                pass
+            case Failure(_):
+                continue
         results.append(
             {
                 "lang": sub_info["lan_doc"],

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from returns.result import Failure, Success
 
-from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
+from yutto.exceptions import MaxRetryError, NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
     AudioUrlMeta,
@@ -17,7 +17,7 @@ from yutto.types import (
     format_ids,
 )
 from yutto.utils.console.logger import Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.functional import data_has_chained_keys
 from yutto.utils.metadata import MetaData
 from yutto.utils.time import get_time_stamp_by_now
@@ -51,31 +51,22 @@ class BangumiList(TypedDict):
 
 async def get_season_id_by_media_id(ctx: FetcherContext, client: AsyncClient, media_id: MediaId) -> SeasonId:
     media_api = f"https://api.bilibili.com/pgc/review/user?media_id={media_id}"
-    match await Fetcher.fetch_json(ctx, client, media_api):
-        case Success(res_json):
-            return SeasonId(str(res_json["result"]["media"]["season_id"]))
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, media_api))
+    return SeasonId(str(res_json["result"]["media"]["season_id"]))
 
 
 async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, episode_id: EpisodeId) -> SeasonId:
     episode_api = f"https://api.bilibili.com/pgc/view/web/season?ep_id={episode_id}"
-    match await Fetcher.fetch_json(ctx, client, episode_api):
-        case Success(res_json):
-            return SeasonId(str(res_json["result"]["season_id"]))
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, episode_api))
+    return SeasonId(str(res_json["result"]["season_id"]))
 
 
 async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> BangumiList:
     list_api = "http://api.bilibili.com/pgc/view/web/season?season_id={season_id}"
-    match await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)):
-        case Success(resp_json):
-            pass
-        case Failure(_):
-            raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）")
+    try:
+        resp_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)))
+    except MaxRetryError as e:
+        raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）") from e
     if resp_json.get("result") is None:
         raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["result"]
@@ -108,11 +99,12 @@ async def get_bangumi_playurl(
 ) -> tuple[list[VideoUrlMeta], list[AudioUrlMeta]]:
     play_api = "https://api.bilibili.com/pgc/player/web/v2/playurl?avid={aid}&bvid={bvid}&cid={cid}&qn=127&fnver=0&fnval=4048&fourk=1&support_multi_audio=true&from_client=BROWSER"
 
-    match await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid)):
-        case Success(resp_json):
-            pass
-        case Failure(_):
-            raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
+    try:
+        resp_json = unwrap_fetch_result(
+            await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
+        )
+    except MaxRetryError as e:
+        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from e
     if resp_json.get("result") is None or resp_json["result"].get("video_info") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, TypedDict
 
-from returns.result import Failure, Success
+from returns.result import Failure
 
-from yutto.exceptions import MaxRetryError, NoAccessPermissionError, UnSupportedTypeError
+from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
     AudioUrlMeta,
@@ -63,10 +63,10 @@ async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, 
 
 async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> BangumiList:
     list_api = "http://api.bilibili.com/pgc/view/web/season?season_id={season_id}"
-    try:
-        resp_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)))
-    except MaxRetryError as e:
-        raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）") from e
+    list_result = await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id))
+    if isinstance(list_result, Failure):
+        raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）") from list_result.failure()
+    resp_json = list_result.unwrap()
     if resp_json.get("result") is None:
         raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["result"]
@@ -99,12 +99,10 @@ async def get_bangumi_playurl(
 ) -> tuple[list[VideoUrlMeta], list[AudioUrlMeta]]:
     play_api = "https://api.bilibili.com/pgc/player/web/v2/playurl?avid={aid}&bvid={bvid}&cid={cid}&qn=127&fnver=0&fnval=4048&fourk=1&support_multi_audio=true&from_client=BROWSER"
 
-    try:
-        resp_json = unwrap_fetch_result(
-            await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
-        )
-    except MaxRetryError as e:
-        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from e
+    play_result = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
+    if isinstance(play_result, Failure):
+        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from play_result.failure()
+    resp_json = play_result.unwrap()
     if resp_json.get("result") is None or resp_json["result"].get("video_info") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
@@ -159,11 +157,9 @@ async def get_bangumi_subtitles(
 ) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/wbi/v2?aid={aid}&bvid={bvid}&cid={cid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    match await Fetcher.fetch_json(ctx, client, subtitle_url):
-        case Success(subtitles_json_info):
-            pass
-        case Failure(_):
-            return []
+    subtitles_json_info = (await Fetcher.fetch_json(ctx, client, subtitle_url)).value_or(None)
+    if subtitles_json_info is None:
+        return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
         Logger.warning(f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}")
         return []
@@ -177,11 +173,9 @@ async def get_bangumi_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        match await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url):
-            case Success(subtitle_text):
-                pass
-            case Failure(_):
-                continue
+        subtitle_text = (await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)).value_or(None)
+        if subtitle_text is None:
+            continue
         results.append(
             {
                 "lang": sub_info["lan_doc"],

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypedDict
 
-from returns.result import Failure, Success
+from returns.result import Failure
 
-from yutto.exceptions import MaxRetryError, NoAccessPermissionError, UnSupportedTypeError
+from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
     AId,
@@ -53,10 +53,10 @@ async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, 
 
 async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> CheeseList:
     list_api = "https://api.bilibili.com/pugv/view/web/season?season_id={season_id}"
-    try:
-        resp_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)))
-    except MaxRetryError as e:
-        raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）") from e
+    list_result = await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id))
+    if isinstance(list_result, Failure):
+        raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）") from list_result.failure()
+    resp_json = list_result.unwrap()
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["data"]
@@ -84,12 +84,12 @@ async def get_cheese_playurl(
         "https://api.bilibili.com/pugv/player/web/playurl?avid={aid}&cid={"
         "cid}&qn=80&fnver=0&fnval=16&fourk=1&ep_id={episode_id}&from_client=BROWSER&drm_tech_type=2"
     )
-    try:
-        resp_json = unwrap_fetch_result(
-            await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id))
-        )
-    except MaxRetryError as e:
-        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from e
+    play_result = await Fetcher.fetch_json(
+        ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id)
+    )
+    if isinstance(play_result, Failure):
+        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from play_result.failure()
+    resp_json = play_result.unwrap()
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
@@ -129,11 +129,9 @@ async def get_cheese_subtitles(
 ) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/v2?cid={cid}&aid={aid}&bvid={bvid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    match await Fetcher.fetch_json(ctx, client, subtitle_url):
-        case Success(subtitles_json_info):
-            pass
-        case Failure(_):
-            return []
+    subtitles_json_info = (await Fetcher.fetch_json(ctx, client, subtitle_url)).value_or(None)
+    if subtitles_json_info is None:
+        return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
         Logger.warning(f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}")
         return []
@@ -147,11 +145,9 @@ async def get_cheese_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        match await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url):
-            case Success(subtitle_text):
-                pass
-            case Failure(_):
-                continue
+        subtitle_text = (await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)).value_or(None)
+        if subtitle_text is None:
+            continue
         results.append(
             {
                 "lang": sub_info["lan_doc"],

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, TypedDict
 
+from returns.result import Failure, Success
+
 from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
@@ -45,16 +47,21 @@ class CheeseList(TypedDict):
 
 async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, episode_id: EpisodeId) -> SeasonId:
     home_url = f"https://api.bilibili.com/pugv/view/web/season?ep_id={episode_id}"
-    res_json = await Fetcher.fetch_json(ctx, client, home_url)
-    assert res_json is not None
-    return SeasonId(str(res_json["data"]["season_id"]))
+    match await Fetcher.fetch_json(ctx, client, home_url):
+        case Success(res_json):
+            return SeasonId(str(res_json["data"]["season_id"]))
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> CheeseList:
     list_api = "https://api.bilibili.com/pugv/view/web/season?season_id={season_id}"
-    resp_json = await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id))
-    if resp_json is None:
-        raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）")
+    match await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)):
+        case Success(resp_json):
+            pass
+        case Failure(_):
+            raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）")
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["data"]
@@ -82,9 +89,11 @@ async def get_cheese_playurl(
         "https://api.bilibili.com/pugv/player/web/playurl?avid={aid}&cid={"
         "cid}&qn=80&fnver=0&fnval=16&fourk=1&ep_id={episode_id}&from_client=BROWSER&drm_tech_type=2"
     )
-    resp_json = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id))
-    if resp_json is None:
-        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
+    match await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id)):
+        case Success(resp_json):
+            pass
+        case Failure(_):
+            raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
@@ -124,9 +133,11 @@ async def get_cheese_subtitles(
 ) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/v2?cid={cid}&aid={aid}&bvid={bvid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    subtitles_json_info = await Fetcher.fetch_json(ctx, client, subtitle_url)
-    if subtitles_json_info is None:
-        return []
+    match await Fetcher.fetch_json(ctx, client, subtitle_url):
+        case Success(subtitles_json_info):
+            pass
+        case Failure(_):
+            return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
         Logger.warning(f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}")
         return []
@@ -140,9 +151,11 @@ async def get_cheese_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
-        if subtitle_text is None:
-            continue
+        match await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url):
+            case Success(subtitle_text):
+                pass
+            case Failure(_):
+                continue
         results.append(
             {
                 "lang": sub_info["lan_doc"],

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from returns.result import Failure, Success
 
-from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
+from yutto.exceptions import MaxRetryError, NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
     AId,
@@ -16,7 +16,7 @@ from yutto.types import (
     format_ids,
 )
 from yutto.utils.console.logger import Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.functional import data_has_chained_keys
 from yutto.utils.metadata import MetaData
 from yutto.utils.time import get_time_stamp_by_now
@@ -47,21 +47,16 @@ class CheeseList(TypedDict):
 
 async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, episode_id: EpisodeId) -> SeasonId:
     home_url = f"https://api.bilibili.com/pugv/view/web/season?ep_id={episode_id}"
-    match await Fetcher.fetch_json(ctx, client, home_url):
-        case Success(res_json):
-            return SeasonId(str(res_json["data"]["season_id"]))
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, home_url))
+    return SeasonId(str(res_json["data"]["season_id"]))
 
 
 async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> CheeseList:
     list_api = "https://api.bilibili.com/pugv/view/web/season?season_id={season_id}"
-    match await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)):
-        case Success(resp_json):
-            pass
-        case Failure(_):
-            raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）")
+    try:
+        resp_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id)))
+    except MaxRetryError as e:
+        raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）") from e
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}），原因：{resp_json.get('message')}")
     result = resp_json["data"]
@@ -89,11 +84,12 @@ async def get_cheese_playurl(
         "https://api.bilibili.com/pugv/player/web/playurl?avid={aid}&cid={"
         "cid}&qn=80&fnver=0&fnval=16&fourk=1&ep_id={episode_id}&from_client=BROWSER&drm_tech_type=2"
     )
-    match await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id)):
-        case Success(resp_json):
-            pass
-        case Failure(_):
-            raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
+    try:
+        resp_json = unwrap_fetch_result(
+            await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id))
+        )
+    except MaxRetryError as e:
+        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from e
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"

--- a/src/yutto/api/collection.py
+++ b/src/yutto/api/collection.py
@@ -4,6 +4,8 @@ import asyncio
 import math
 from typing import TYPE_CHECKING, TypedDict
 
+from returns.result import Failure, Success
+
 from yutto.types import BvId
 from yutto.utils.fetcher import Fetcher
 
@@ -54,8 +56,11 @@ async def _get_collection_avids(ctx: FetcherContext, client: AsyncClient, series
 
     while pn <= total:
         space_videos_url = api.format(series_id=series_id, ps=ps, pn=pn, mid=mid)
-        json_data = await Fetcher.fetch_json(ctx, client, space_videos_url)
-        assert json_data is not None
+        match await Fetcher.fetch_json(ctx, client, space_videos_url):
+            case Success(json_data):
+                pass
+            case Failure(error):
+                raise error
         total = math.ceil(json_data["data"]["page"]["total"] / ps)
         pn += 1
         all_avid += [BvId(archives["bvid"]) for archives in json_data["data"]["archives"]]
@@ -64,6 +69,9 @@ async def _get_collection_avids(ctx: FetcherContext, client: AsyncClient, series
 
 async def _get_collection_title(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId) -> str:
     api = "https://api.bilibili.com/x/v1/medialist/info?type=8&biz_id={series_id}"
-    json_data = await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id))
-    assert json_data is not None
-    return json_data["data"]["title"]
+    match await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)):
+        case Success(json_data):
+            return json_data["data"]["title"]
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")

--- a/src/yutto/api/collection.py
+++ b/src/yutto/api/collection.py
@@ -4,10 +4,8 @@ import asyncio
 import math
 from typing import TYPE_CHECKING, TypedDict
 
-from returns.result import Failure, Success
-
 from yutto.types import BvId
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -56,11 +54,7 @@ async def _get_collection_avids(ctx: FetcherContext, client: AsyncClient, series
 
     while pn <= total:
         space_videos_url = api.format(series_id=series_id, ps=ps, pn=pn, mid=mid)
-        match await Fetcher.fetch_json(ctx, client, space_videos_url):
-            case Success(json_data):
-                pass
-            case Failure(error):
-                raise error
+        json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, space_videos_url))
         total = math.ceil(json_data["data"]["page"]["total"] / ps)
         pn += 1
         all_avid += [BvId(archives["bvid"]) for archives in json_data["data"]["archives"]]
@@ -69,9 +63,5 @@ async def _get_collection_avids(ctx: FetcherContext, client: AsyncClient, series
 
 async def _get_collection_title(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId) -> str:
     api = "https://api.bilibili.com/x/v1/medialist/info?type=8&biz_id={series_id}"
-    match await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)):
-        case Success(json_data):
-            return json_data["data"]["title"]
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)))
+    return json_data["data"]["title"]

--- a/src/yutto/api/danmaku.py
+++ b/src/yutto/api/danmaku.py
@@ -18,14 +18,20 @@ if TYPE_CHECKING:
 
 async def get_xml_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, cid: CId) -> str:
     danmaku_api = "http://comment.bilibili.com/{cid}.xml"
-    return unwrap_fetch_result(await Fetcher.fetch_text(ctx, client, danmaku_api.format(cid=cid), encoding="utf-8"))
+    results = unwrap_fetch_result(await Fetcher.fetch_text(ctx, client, danmaku_api.format(cid=cid), encoding="utf-8"))
+    assert results is not None
+    return results
 
 
 async def get_protobuf_danmaku_segment(
     ctx: FetcherContext, client: httpx.AsyncClient, cid: CId, segment_id: int = 1
 ) -> bytes:
     danmaku_api = "http://api.bilibili.com/x/v2/dm/web/seg.so?type=1&oid={cid}&segment_index={segment_id}"
-    return unwrap_fetch_result(await Fetcher.fetch_bin(ctx, client, danmaku_api.format(cid=cid, segment_id=segment_id)))
+    results = unwrap_fetch_result(
+        await Fetcher.fetch_bin(ctx, client, danmaku_api.format(cid=cid, segment_id=segment_id))
+    )
+    assert results is not None
+    return results
 
 
 async def get_protobuf_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, avid: AvId, cid: CId) -> list[bytes]:
@@ -34,6 +40,7 @@ async def get_protobuf_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, a
     meta_results = unwrap_fetch_result(
         await Fetcher.fetch_bin(ctx, client, danmaku_meta_api.format(cid=cid, aid=aid.value))
     )
+    assert meta_results is not None
     size = get_danmaku_meta_size(meta_results)
 
     results = await asyncio.gather(

--- a/src/yutto/api/danmaku.py
+++ b/src/yutto/api/danmaku.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from biliass import get_danmaku_meta_size
 
 from yutto.api.user_info import get_user_info
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
     import httpx
@@ -18,25 +18,22 @@ if TYPE_CHECKING:
 
 async def get_xml_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, cid: CId) -> str:
     danmaku_api = "http://comment.bilibili.com/{cid}.xml"
-    results = await Fetcher.fetch_text(ctx, client, danmaku_api.format(cid=cid), encoding="utf-8")
-    assert results is not None
-    return results
+    return unwrap_fetch_result(await Fetcher.fetch_text(ctx, client, danmaku_api.format(cid=cid), encoding="utf-8"))
 
 
 async def get_protobuf_danmaku_segment(
     ctx: FetcherContext, client: httpx.AsyncClient, cid: CId, segment_id: int = 1
 ) -> bytes:
     danmaku_api = "http://api.bilibili.com/x/v2/dm/web/seg.so?type=1&oid={cid}&segment_index={segment_id}"
-    results = await Fetcher.fetch_bin(ctx, client, danmaku_api.format(cid=cid, segment_id=segment_id))
-    assert results is not None
-    return results
+    return unwrap_fetch_result(await Fetcher.fetch_bin(ctx, client, danmaku_api.format(cid=cid, segment_id=segment_id)))
 
 
 async def get_protobuf_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, avid: AvId, cid: CId) -> list[bytes]:
     danmaku_meta_api = "https://api.bilibili.com/x/v2/dm/web/view?type=1&oid={cid}&pid={aid}"
     aid = avid.as_aid()
-    meta_results = await Fetcher.fetch_bin(ctx, client, danmaku_meta_api.format(cid=cid, aid=aid.value))
-    assert meta_results is not None
+    meta_results = unwrap_fetch_result(
+        await Fetcher.fetch_bin(ctx, client, danmaku_meta_api.format(cid=cid, aid=aid.value))
+    )
     size = get_danmaku_meta_size(meta_results)
 
     results = await asyncio.gather(

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -46,7 +46,7 @@ async def get_user_space_all_videos_avids(
             "order": "pubdate",
         }
         params = encode_wbi(params, wbi_img)
-        match await Fetcher.fetch_json_result(ctx, client, space_videos_api, params=params):
+        match await Fetcher.fetch_json(ctx, client, space_videos_api, params=params):
             case Success(json_data):
                 match _parse_user_space_videos_page(json_data, ps):
                     case Success((total, video_infos)):
@@ -102,7 +102,7 @@ async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> s
     params = encode_wbi(params, wbi_img)
     space_info_api = "https://api.bilibili.com/x/space/wbi/acc/info"
     await Fetcher.touch_url(ctx, client, "https://www.bilibili.com")
-    match await Fetcher.fetch_json_result(ctx, client, space_info_api, params=params):
+    match await Fetcher.fetch_json(ctx, client, space_info_api, params=params):
         case Success({"code": 0, "data": {"name": username}}):
             return str(username)
         case Success({"code": -404}):
@@ -121,18 +121,24 @@ async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> s
 # 个人空间·收藏夹·信息
 async def get_favourite_info(ctx: FetcherContext, client: AsyncClient, fid: FId) -> FavouriteMetaData:
     api = "https://api.bilibili.com/x/v3/fav/folder/info?media_id={fid}"
-    json_data = await Fetcher.fetch_json(ctx, client, api.format(fid=fid))
-    assert json_data is not None
-    data = json_data["data"]
-    return FavouriteMetaData(title=data["title"], fid=FId(str(data["id"])))
+    match await Fetcher.fetch_json(ctx, client, api.format(fid=fid)):
+        case Success(json_data):
+            data = json_data["data"]
+            return FavouriteMetaData(title=data["title"], fid=FId(str(data["id"])))
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 # 个人空间·收藏夹·avid
 async def get_favourite_avids(ctx: FetcherContext, client: AsyncClient, fid: FId) -> list[AvId]:
     api = "https://api.bilibili.com/x/v3/fav/resource/ids?media_id={fid}"
-    json_data = await Fetcher.fetch_json(ctx, client, api.format(fid=fid))
-    assert json_data is not None
-    return [BvId(video_info["bvid"]) for video_info in json_data["data"]]
+    match await Fetcher.fetch_json(ctx, client, api.format(fid=fid)):
+        case Success(json_data):
+            return [BvId(video_info["bvid"]) for video_info in json_data["data"]]
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 # 个人空间·收藏夹·条目（含标题和分 p 数量）
@@ -156,8 +162,11 @@ async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId
     favourite_items: list[FavouriteVideoData] = []
 
     while True:
-        json_data = await Fetcher.fetch_json(ctx, client, api.format(fid=fid, pn=pn, ps=ps))
-        assert json_data is not None
+        match await Fetcher.fetch_json(ctx, client, api.format(fid=fid, pn=pn, ps=ps)):
+            case Success(json_data):
+                pass
+            case Failure(error):
+                raise error
         data = cast("dict[str, Any]", json_data["data"])
         medias = cast("list[dict[str, Any]]", data["medias"] or [])
         # 仅保留正常视频（type=2），过滤已失效条目（bvid 为空）
@@ -187,11 +196,16 @@ async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId
 # 个人空间·收藏夹·全部
 async def get_all_favourites(ctx: FetcherContext, client: AsyncClient, mid: MId) -> list[FavouriteMetaData]:
     api = "https://api.bilibili.com/x/v3/fav/folder/created/list-all?up_mid={mid}"
-    json_data = await Fetcher.fetch_json(ctx, client, api.format(mid=mid))
-    assert json_data is not None
-    if not json_data["data"]:
-        return []
-    return [FavouriteMetaData(title=data["title"], fid=FId(str(data["id"]))) for data in json_data["data"]["list"]]
+    match await Fetcher.fetch_json(ctx, client, api.format(mid=mid)):
+        case Success(json_data):
+            if not json_data["data"]:
+                return []
+            return [
+                FavouriteMetaData(title=data["title"], fid=FId(str(data["id"]))) for data in json_data["data"]["list"]
+            ]
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 # 个人空间·视频列表·avid
@@ -204,8 +218,11 @@ async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_i
 
     while pn <= total:
         url = api.format(series_id=series_id, mid=mid, ps=ps, pn=pn)
-        json_data = await Fetcher.fetch_json(ctx, client, url)
-        assert json_data is not None
+        match await Fetcher.fetch_json(ctx, client, url):
+            case Success(json_data):
+                pass
+            case Failure(error):
+                raise error
         total = math.ceil(json_data["data"]["page"]["total"] / ps)
         pn += 1
         all_avid += [BvId(video_info["bvid"]) for video_info in json_data["data"]["archives"]]
@@ -215,17 +232,23 @@ async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_i
 # 个人空间·视频列表·标题
 async def get_medialist_title(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId) -> str:
     api = "https://api.bilibili.com/x/v1/medialist/info?type=5&biz_id={series_id}"
-    json_data = await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id))
-    assert json_data is not None
-    return json_data["data"]["title"]
+    match await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)):
+        case Success(json_data):
+            return json_data["data"]["title"]
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 # 个人空间·稍后再看
 async def get_watch_later_avids(ctx: FetcherContext, client: AsyncClient) -> list[AvId]:
     api = "https://api.bilibili.com/x/v2/history/toview/web"
-    json_data = await Fetcher.fetch_json(ctx, client, api)
-    assert json_data is not None
-    if json_data["code"] in [-101, -400]:
-        raise NotLoginError("账号未登录，无法获取稍后再看列表哦~ Ծ‸Ծ")
-    # TODO: 处理其他code不为0的异常
-    return [BvId(video_info["bvid"]) for video_info in json_data["data"]["list"]]
+    match await Fetcher.fetch_json(ctx, client, api):
+        case Success(json_data):
+            if json_data["code"] in [-101, -400]:
+                raise NotLoginError("账号未登录，无法获取稍后再看列表哦~ Ծ‸Ծ")
+            # TODO: 处理其他code不为0的异常
+            return [BvId(video_info["bvid"]) for video_info in json_data["data"]["list"]]
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -4,7 +4,7 @@ import math
 from typing import TYPE_CHECKING, Any, cast
 
 from yutto.api.user_info import encode_wbi, get_wbi_img
-from yutto.exceptions import NotLoginError
+from yutto.exceptions import MaxRetryError, NotLoginError
 from yutto.types import BvId, FavouriteMetaData, FavouriteVideoData, FId
 from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher
@@ -35,7 +35,11 @@ async def get_user_space_all_videos_avids(ctx: FetcherContext, client: AsyncClie
             "order": "pubdate",
         }
         params = encode_wbi(params, wbi_img)
-        json_data = await Fetcher.fetch_json(ctx, client, space_videos_api, params=params)
+        try:
+            json_data = await Fetcher.fetch_json(ctx, client, space_videos_api, params=params)
+        except MaxRetryError as e:
+            Logger.error(f"获取用户空间视频列表第 {pn} 页失败：{e}")
+            break
         assert json_data is not None
         total = math.ceil(json_data["data"]["page"]["count"] / ps)
         pn += 1

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -9,7 +9,7 @@ from yutto.api.user_info import encode_wbi, get_wbi_img
 from yutto.exceptions import NotLoginError
 from yutto.types import BvId, FavouriteMetaData, FavouriteVideoData, FId
 from yutto.utils.console.logger import Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -101,7 +101,7 @@ async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> s
     params = {"mid": mid}
     params = encode_wbi(params, wbi_img)
     space_info_api = "https://api.bilibili.com/x/space/wbi/acc/info"
-    await Fetcher.touch_url(ctx, client, "https://www.bilibili.com")
+    unwrap_fetch_result(await Fetcher.touch_url(ctx, client, "https://www.bilibili.com"))
     match await Fetcher.fetch_json(ctx, client, space_info_api, params=params):
         case Success({"code": 0, "data": {"name": username}}):
             return str(username)
@@ -121,24 +121,16 @@ async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> s
 # 个人空间·收藏夹·信息
 async def get_favourite_info(ctx: FetcherContext, client: AsyncClient, fid: FId) -> FavouriteMetaData:
     api = "https://api.bilibili.com/x/v3/fav/folder/info?media_id={fid}"
-    match await Fetcher.fetch_json(ctx, client, api.format(fid=fid)):
-        case Success(json_data):
-            data = json_data["data"]
-            return FavouriteMetaData(title=data["title"], fid=FId(str(data["id"])))
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(fid=fid)))
+    data = json_data["data"]
+    return FavouriteMetaData(title=data["title"], fid=FId(str(data["id"])))
 
 
 # 个人空间·收藏夹·avid
 async def get_favourite_avids(ctx: FetcherContext, client: AsyncClient, fid: FId) -> list[AvId]:
     api = "https://api.bilibili.com/x/v3/fav/resource/ids?media_id={fid}"
-    match await Fetcher.fetch_json(ctx, client, api.format(fid=fid)):
-        case Success(json_data):
-            return [BvId(video_info["bvid"]) for video_info in json_data["data"]]
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(fid=fid)))
+    return [BvId(video_info["bvid"]) for video_info in json_data["data"]]
 
 
 # 个人空间·收藏夹·条目（含标题和分 p 数量）
@@ -162,11 +154,7 @@ async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId
     favourite_items: list[FavouriteVideoData] = []
 
     while True:
-        match await Fetcher.fetch_json(ctx, client, api.format(fid=fid, pn=pn, ps=ps)):
-            case Success(json_data):
-                pass
-            case Failure(error):
-                raise error
+        json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(fid=fid, pn=pn, ps=ps)))
         data = cast("dict[str, Any]", json_data["data"])
         medias = cast("list[dict[str, Any]]", data["medias"] or [])
         # 仅保留正常视频（type=2），过滤已失效条目（bvid 为空）
@@ -196,16 +184,10 @@ async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId
 # 个人空间·收藏夹·全部
 async def get_all_favourites(ctx: FetcherContext, client: AsyncClient, mid: MId) -> list[FavouriteMetaData]:
     api = "https://api.bilibili.com/x/v3/fav/folder/created/list-all?up_mid={mid}"
-    match await Fetcher.fetch_json(ctx, client, api.format(mid=mid)):
-        case Success(json_data):
-            if not json_data["data"]:
-                return []
-            return [
-                FavouriteMetaData(title=data["title"], fid=FId(str(data["id"]))) for data in json_data["data"]["list"]
-            ]
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(mid=mid)))
+    if not json_data["data"]:
+        return []
+    return [FavouriteMetaData(title=data["title"], fid=FId(str(data["id"]))) for data in json_data["data"]["list"]]
 
 
 # 个人空间·视频列表·avid
@@ -218,11 +200,7 @@ async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_i
 
     while pn <= total:
         url = api.format(series_id=series_id, mid=mid, ps=ps, pn=pn)
-        match await Fetcher.fetch_json(ctx, client, url):
-            case Success(json_data):
-                pass
-            case Failure(error):
-                raise error
+        json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, url))
         total = math.ceil(json_data["data"]["page"]["total"] / ps)
         pn += 1
         all_avid += [BvId(video_info["bvid"]) for video_info in json_data["data"]["archives"]]
@@ -232,23 +210,15 @@ async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_i
 # 个人空间·视频列表·标题
 async def get_medialist_title(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId) -> str:
     api = "https://api.bilibili.com/x/v1/medialist/info?type=5&biz_id={series_id}"
-    match await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)):
-        case Success(json_data):
-            return json_data["data"]["title"]
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)))
+    return json_data["data"]["title"]
 
 
 # 个人空间·稍后再看
 async def get_watch_later_avids(ctx: FetcherContext, client: AsyncClient) -> list[AvId]:
     api = "https://api.bilibili.com/x/v2/history/toview/web"
-    match await Fetcher.fetch_json(ctx, client, api):
-        case Success(json_data):
-            if json_data["code"] in [-101, -400]:
-                raise NotLoginError("账号未登录，无法获取稍后再看列表哦~ Ծ‸Ծ")
-            # TODO: 处理其他code不为0的异常
-            return [BvId(video_info["bvid"]) for video_info in json_data["data"]["list"]]
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api))
+    if json_data["code"] in [-101, -400]:
+        raise NotLoginError("账号未登录，无法获取稍后再看列表哦~ Ծ‸Ծ")
+    # TODO: 处理其他code不为0的异常
+    return [BvId(video_info["bvid"]) for video_info in json_data["data"]["list"]]

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any, cast
 
+from returns.result import Failure, Result, Success
+
 from yutto.api.user_info import encode_wbi, get_wbi_img
-from yutto.exceptions import MaxRetryError, NotLoginError
+from yutto.exceptions import NotLoginError
 from yutto.types import BvId, FavouriteMetaData, FavouriteVideoData, FId
 from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from httpx import AsyncClient
 
     from yutto.types import AvId, MId, SeriesId
@@ -17,7 +21,14 @@ if TYPE_CHECKING:
 
 
 # 个人空间·全部
-async def get_user_space_all_videos_avids(ctx: FetcherContext, client: AsyncClient, mid: MId) -> list[AvId]:
+async def get_user_space_all_videos_avids(
+    ctx: FetcherContext,
+    client: AsyncClient,
+    mid: MId,
+    *,
+    pubdate_filter: Callable[[int], bool] | None = None,
+    stop_before_timestamp: int | None = None,
+) -> list[AvId]:
     space_videos_api = "https://api.bilibili.com/x/space/wbi/arc/search"
     # ps 随机设置有时会出现错误，因此暂时固定在 30
     # ps: int = random.randint(3, 6) * 10
@@ -35,16 +46,53 @@ async def get_user_space_all_videos_avids(ctx: FetcherContext, client: AsyncClie
             "order": "pubdate",
         }
         params = encode_wbi(params, wbi_img)
-        try:
-            json_data = await Fetcher.fetch_json(ctx, client, space_videos_api, params=params)
-        except MaxRetryError as e:
-            Logger.error(f"获取用户空间视频列表第 {pn} 页失败：{e}")
-            break
-        assert json_data is not None
-        total = math.ceil(json_data["data"]["page"]["count"] / ps)
+        match await Fetcher.fetch_json_result(ctx, client, space_videos_api, params=params):
+            case Success(json_data):
+                match _parse_user_space_videos_page(json_data, ps):
+                    case Success((total, video_infos)):
+                        all_avid += _filter_user_space_video_avids(video_infos, pubdate_filter)
+                        if _should_stop_user_space_pagination(video_infos, stop_before_timestamp):
+                            break
+                    case Failure(error):
+                        Logger.error(f"获取用户空间视频列表第 {pn} 页失败：{error}")
+                        break
+            case Failure(error):
+                Logger.error(f"获取用户空间视频列表第 {pn} 页失败：{error}")
+                break
         pn += 1
-        all_avid += [BvId(video_info["bvid"]) for video_info in json_data["data"]["list"]["vlist"]]
     return all_avid
+
+
+def _parse_user_space_videos_page(json_data: Any, page_size: int) -> Result[tuple[int, list[dict[str, Any]]], str]:
+    if not isinstance(json_data, dict):
+        return Failure(f"响应数据格式异常：{json_data}")
+
+    if json_data.get("code") != 0:
+        return Failure(f"{json_data.get('message', '未知错误')}（code: {json_data.get('code')}）")
+
+    try:
+        data = cast("dict[str, Any]", json_data["data"])
+        page = cast("dict[str, Any]", data["page"])
+        video_infos = cast("list[dict[str, Any]]", data["list"]["vlist"])
+        return Success((math.ceil(page["count"] / page_size), video_infos))
+    except (KeyError, TypeError) as e:
+        return Failure(f"响应数据格式异常：{e}")
+
+
+def _filter_user_space_video_avids(
+    video_infos: list[dict[str, Any]], pubdate_filter: Callable[[int], bool] | None
+) -> list[AvId]:
+    return [
+        BvId(video_info["bvid"])
+        for video_info in video_infos
+        if pubdate_filter is None or pubdate_filter(int(video_info["created"]))
+    ]
+
+
+def _should_stop_user_space_pagination(video_infos: list[dict[str, Any]], stop_before_timestamp: int | None) -> bool:
+    return stop_before_timestamp is not None and any(
+        int(video_info["created"]) < stop_before_timestamp for video_info in video_infos
+    )
 
 
 # 个人空间·用户名
@@ -54,16 +102,20 @@ async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> s
     params = encode_wbi(params, wbi_img)
     space_info_api = "https://api.bilibili.com/x/space/wbi/acc/info"
     await Fetcher.touch_url(ctx, client, "https://www.bilibili.com")
-    user_info = await Fetcher.fetch_json(ctx, client, space_info_api, params=params)
-    assert user_info is not None
-    if user_info["code"] == -404:
-        Logger.warning(f"用户 {mid} 不存在，疑似注销或被封禁")
-        return f"「用户{mid}」"
-    elif user_info["code"] != 0:
-        Logger.error(
-            f"获取用户名失败了呢，错误信息：{user_info['message']}，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～"
-        )
-    return user_info["data"]["name"]
+    match await Fetcher.fetch_json_result(ctx, client, space_info_api, params=params):
+        case Success({"code": 0, "data": {"name": username}}):
+            return str(username)
+        case Success({"code": -404}):
+            Logger.warning(f"用户 {mid} 不存在，疑似注销或被封禁")
+        case Success({"message": message}):
+            Logger.error(
+                f"获取用户名失败了呢，错误信息：{message}，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～"
+            )
+        case Success(user_info):
+            Logger.error(f"获取用户名失败了呢，返回值异常：{user_info}")
+        case Failure(error):
+            Logger.error(f"获取用户名失败：{error}")
+    return f"「用户{mid}」"
 
 
 # 个人空间·收藏夹·信息

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
-from returns.result import Failure, Success
+from returns.result import Failure
 
 from yutto.exceptions import (
-    MaxRetryError,
     NoAccessPermissionError,
     NotFoundError,
     UnSupportedTypeError,
@@ -87,10 +86,10 @@ async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId
 async def get_ugc_video_info(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> _UgcVideoInfo:
     regex_ep = re.compile(r"https?://www\.bilibili\.com/bangumi/play/ep(?P<episode_id>\d+)")
     info_api = "http://api.bilibili.com/x/web-interface/view?aid={aid}&bvid={bvid}"
-    try:
-        res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict())))
-    except MaxRetryError as e:
-        raise NotFoundError(f"无法获取该视频 {avid} 信息") from e
+    info_result = await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict()))
+    if isinstance(info_result, Failure):
+        raise NotFoundError(f"无法获取该视频 {avid} 信息") from info_result.failure()
+    res_json = info_result.unwrap()
     res_json_data = res_json.get("data")
     if res_json["code"] == 62002:
         raise NotFoundError(f"无法下载该视频 {avid}，原因：{res_json['message']}")
@@ -148,12 +147,10 @@ async def get_ugc_video_list(ctx: FetcherContext, client: AsyncClient, avid: AvI
         "pages": [],
     }
     list_api = "https://api.bilibili.com/x/player/pagelist?aid={aid}&bvid={bvid}&jsonp=jsonp"
-    match await Fetcher.fetch_json(ctx, client, list_api.format(**avid.to_dict())):
-        case Success(res_json) if res_json.get("data") is not None:
-            pass
-        case _:
-            Logger.warning(f"啊叻？视频 {avid} 不见了诶")
-            return result
+    res_json = (await Fetcher.fetch_json(ctx, client, list_api.format(**avid.to_dict()))).value_or(None)
+    if res_json is None or res_json.get("data") is None:
+        Logger.warning(f"啊叻？视频 {avid} 不见了诶")
+        return result
 
     # 对无意义的分 p 视频名进行修改
     for i, (item, page_info) in enumerate(zip(cast("list[Any]", res_json["data"]), video_info["pages"], strict=True)):
@@ -219,12 +216,10 @@ async def get_ugc_video_playurl(
     if ai_translation_language:
         play_api += f"&cur_language={ai_translation_language}"
 
-    try:
-        resp_json = unwrap_fetch_result(
-            await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
-        )
-    except MaxRetryError as e:
-        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from e
+    play_result = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
+    if isinstance(play_result, Failure):
+        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from play_result.failure()
+    resp_json = play_result.unwrap()
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
@@ -297,11 +292,9 @@ async def get_ugc_video_subtitles(
 ) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/wbi/v2?aid={aid}&bvid={bvid}&cid={cid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    match await Fetcher.fetch_json(ctx, client, subtitle_url):
-        case Success(res_json):
-            pass
-        case Failure(_):
-            return []
+    res_json = (await Fetcher.fetch_json(ctx, client, subtitle_url)).value_or(None)
+    if res_json is None:
+        return []
     if not data_has_chained_keys(res_json, ["data", "subtitle", "subtitles"]):
         return []
     results: list[MultiLangSubtitle] = []
@@ -313,11 +306,9 @@ async def get_ugc_video_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        match await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url):
-            case Success(subtitle_text):
-                pass
-            case Failure(_):
-                continue
+        subtitle_text = (await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)).value_or(None)
+        if subtitle_text is None:
+            continue
         results.append(
             MultiLangSubtitle(
                 lang=sub_info["lan_doc"],
@@ -332,11 +323,9 @@ async def get_ugc_video_chapters(
 ) -> list[ChapterInfoData]:
     chapter_api = "https://api.bilibili.com/x/player/v2?aid={aid}&bvid={bvid}&cid={cid}"
     chapter_url = chapter_api.format(**avid.to_dict(), cid=cid)
-    match await Fetcher.fetch_json(ctx, client, chapter_url):
-        case Success(chapter_json_info):
-            pass
-        case Failure(_):
-            return []
+    chapter_json_info = (await Fetcher.fetch_json(ctx, client, chapter_url)).value_or(None)
+    if chapter_json_info is None:
+        return []
     if not data_has_chained_keys(chapter_json_info, ["data", "view_points"]):
         Logger.warning(f"无法获取该视频的章节信息（{format_ids(avid, cid)}），原因：{chapter_json_info.get('message')}")
         return []

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 from returns.result import Failure, Success
 
 from yutto.exceptions import (
+    MaxRetryError,
     NoAccessPermissionError,
     NotFoundError,
     UnSupportedTypeError,
@@ -23,7 +24,7 @@ from yutto.types import (
 )
 from yutto.utils.console.colorful import colored_string
 from yutto.utils.console.logger import Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.functional.data_access import data_has_chained_keys
 from yutto.utils.metadata import Actor, ChapterInfoData, MetaData
 from yutto.utils.time import get_time_stamp_by_now
@@ -75,11 +76,9 @@ class UgcVideoList(TypedDict):
 async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> list[str]:
     tags: list[str] = []
     tag_api = "http://api.bilibili.com/x/tag/archive/tags?aid={aid}&bvid={bvid}"
-    match await Fetcher.fetch_json(ctx, client, tag_api.format(**avid.to_dict())):
-        case Success(res_json) if res_json["code"] == 0:
-            pass
-        case _:
-            raise NotFoundError(f"无法获取视频 {avid} 标签")
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, tag_api.format(**avid.to_dict())))
+    if res_json["code"] != 0:
+        raise NotFoundError(f"无法获取视频 {avid} 标签")
     for tag in res_json["data"]:
         tags.append(tag["tag_name"])
     return tags
@@ -88,11 +87,10 @@ async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId
 async def get_ugc_video_info(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> _UgcVideoInfo:
     regex_ep = re.compile(r"https?://www\.bilibili\.com/bangumi/play/ep(?P<episode_id>\d+)")
     info_api = "http://api.bilibili.com/x/web-interface/view?aid={aid}&bvid={bvid}"
-    match await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict())):
-        case Success(res_json):
-            pass
-        case Failure(_):
-            raise NotFoundError(f"无法获取该视频 {avid} 信息")
+    try:
+        res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict())))
+    except MaxRetryError as e:
+        raise NotFoundError(f"无法获取该视频 {avid} 信息") from e
     res_json_data = res_json.get("data")
     if res_json["code"] == 62002:
         raise NotFoundError(f"无法下载该视频 {avid}，原因：{res_json['message']}")
@@ -221,11 +219,12 @@ async def get_ugc_video_playurl(
     if ai_translation_language:
         play_api += f"&cur_language={ai_translation_language}"
 
-    match await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid)):
-        case Success(resp_json):
-            pass
-        case Failure(_):
-            raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
+    try:
+        resp_json = unwrap_fetch_result(
+            await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
+        )
+    except MaxRetryError as e:
+        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from e
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
+from returns.result import Failure, Success
+
 from yutto.exceptions import (
     NoAccessPermissionError,
     NotFoundError,
@@ -73,9 +75,11 @@ class UgcVideoList(TypedDict):
 async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> list[str]:
     tags: list[str] = []
     tag_api = "http://api.bilibili.com/x/tag/archive/tags?aid={aid}&bvid={bvid}"
-    res_json = await Fetcher.fetch_json(ctx, client, tag_api.format(**avid.to_dict()))
-    if res_json is None or res_json["code"] != 0:
-        raise NotFoundError(f"无法获取视频 {avid} 标签")
+    match await Fetcher.fetch_json(ctx, client, tag_api.format(**avid.to_dict())):
+        case Success(res_json) if res_json["code"] == 0:
+            pass
+        case _:
+            raise NotFoundError(f"无法获取视频 {avid} 标签")
     for tag in res_json["data"]:
         tags.append(tag["tag_name"])
     return tags
@@ -84,9 +88,11 @@ async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId
 async def get_ugc_video_info(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> _UgcVideoInfo:
     regex_ep = re.compile(r"https?://www\.bilibili\.com/bangumi/play/ep(?P<episode_id>\d+)")
     info_api = "http://api.bilibili.com/x/web-interface/view?aid={aid}&bvid={bvid}"
-    res_json = await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict()))
-    if res_json is None:
-        raise NotFoundError(f"无法获取该视频 {avid} 信息")
+    match await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict())):
+        case Success(res_json):
+            pass
+        case Failure(_):
+            raise NotFoundError(f"无法获取该视频 {avid} 信息")
     res_json_data = res_json.get("data")
     if res_json["code"] == 62002:
         raise NotFoundError(f"无法下载该视频 {avid}，原因：{res_json['message']}")
@@ -144,10 +150,12 @@ async def get_ugc_video_list(ctx: FetcherContext, client: AsyncClient, avid: AvI
         "pages": [],
     }
     list_api = "https://api.bilibili.com/x/player/pagelist?aid={aid}&bvid={bvid}&jsonp=jsonp"
-    res_json = await Fetcher.fetch_json(ctx, client, list_api.format(**avid.to_dict()))
-    if res_json is None or res_json.get("data") is None:
-        Logger.warning(f"啊叻？视频 {avid} 不见了诶")
-        return result
+    match await Fetcher.fetch_json(ctx, client, list_api.format(**avid.to_dict())):
+        case Success(res_json) if res_json.get("data") is not None:
+            pass
+        case _:
+            Logger.warning(f"啊叻？视频 {avid} 不见了诶")
+            return result
 
     # 对无意义的分 p 视频名进行修改
     for i, (item, page_info) in enumerate(zip(cast("list[Any]", res_json["data"]), video_info["pages"], strict=True)):
@@ -213,9 +221,11 @@ async def get_ugc_video_playurl(
     if ai_translation_language:
         play_api += f"&cur_language={ai_translation_language}"
 
-    resp_json = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
-    if resp_json is None:
-        raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
+    match await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid)):
+        case Success(resp_json):
+            pass
+        case Failure(_):
+            raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）")
     if resp_json.get("data") is None:
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
@@ -288,8 +298,11 @@ async def get_ugc_video_subtitles(
 ) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/wbi/v2?aid={aid}&bvid={bvid}&cid={cid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    res_json = await Fetcher.fetch_json(ctx, client, subtitle_url)
-    assert res_json is not None, "无法获取该视频的字幕信息"
+    match await Fetcher.fetch_json(ctx, client, subtitle_url):
+        case Success(res_json):
+            pass
+        case Failure(_):
+            return []
     if not data_has_chained_keys(res_json, ["data", "subtitle", "subtitles"]):
         return []
     results: list[MultiLangSubtitle] = []
@@ -301,9 +314,11 @@ async def get_ugc_video_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        subtitle_text = await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)
-        if subtitle_text is None:
-            continue
+        match await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url):
+            case Success(subtitle_text):
+                pass
+            case Failure(_):
+                continue
         results.append(
             MultiLangSubtitle(
                 lang=sub_info["lan_doc"],
@@ -318,9 +333,11 @@ async def get_ugc_video_chapters(
 ) -> list[ChapterInfoData]:
     chapter_api = "https://api.bilibili.com/x/player/v2?aid={aid}&bvid={bvid}&cid={cid}"
     chapter_url = chapter_api.format(**avid.to_dict(), cid=cid)
-    chapter_json_info = await Fetcher.fetch_json(ctx, client, chapter_url)
-    if chapter_json_info is None:
-        return []
+    match await Fetcher.fetch_json(ctx, client, chapter_url):
+        case Success(chapter_json_info):
+            pass
+        case Failure(_):
+            return []
     if not data_has_chained_keys(chapter_json_info, ["data", "view_points"]):
         Logger.warning(f"无法获取该视频的章节信息（{format_ids(avid, cid)}），原因：{chapter_json_info.get('message')}")
         return []

--- a/src/yutto/api/user_info.py
+++ b/src/yutto/api/user_info.py
@@ -9,6 +9,8 @@ import time
 import urllib.parse
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
+from returns.result import Failure, Success
+
 from yutto.types import UserInfo
 from yutto.utils.asynclib import async_cache
 from yutto.utils.fetcher import Fetcher, create_client
@@ -43,9 +45,12 @@ def parse_user_info(res_json: dict[str, Any]) -> UserInfo:
 
 @async_cache(lambda _: "user_info")
 async def get_user_info(ctx: FetcherContext, client: AsyncClient) -> UserInfo:
-    res_json = await Fetcher.fetch_json(ctx, client, USER_INFO_API)
-    assert res_json is not None
-    return parse_user_info(res_json)
+    match await Fetcher.fetch_json(ctx, client, USER_INFO_API):
+        case Success(res_json):
+            return parse_user_info(res_json)
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 def user_info_matches(user_info: UserInfo, check_option: UserInfo) -> bool:
@@ -74,8 +79,11 @@ async def get_wbi_img(ctx: FetcherContext, client: AsyncClient) -> WbiImg:
     global wbi_img_cache
     if wbi_img_cache is not None:
         return wbi_img_cache
-    res_json = await Fetcher.fetch_json(ctx, client, USER_INFO_API)
-    assert res_json is not None
+    match await Fetcher.fetch_json(ctx, client, USER_INFO_API):
+        case Success(res_json):
+            pass
+        case Failure(error):
+            raise error
     wbi_img: WbiImg = {
         "img_key": _get_key_from_url(res_json["data"]["wbi_img"]["img_url"]),
         "sub_key": _get_key_from_url(res_json["data"]["wbi_img"]["sub_url"]),

--- a/src/yutto/api/user_info.py
+++ b/src/yutto/api/user_info.py
@@ -9,11 +9,9 @@ import time
 import urllib.parse
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
-from returns.result import Failure, Success
-
 from yutto.types import UserInfo
 from yutto.utils.asynclib import async_cache
-from yutto.utils.fetcher import Fetcher, create_client
+from yutto.utils.fetcher import Fetcher, create_client, unwrap_fetch_result
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -45,12 +43,8 @@ def parse_user_info(res_json: dict[str, Any]) -> UserInfo:
 
 @async_cache(lambda _: "user_info")
 async def get_user_info(ctx: FetcherContext, client: AsyncClient) -> UserInfo:
-    match await Fetcher.fetch_json(ctx, client, USER_INFO_API):
-        case Success(res_json):
-            return parse_user_info(res_json)
-        case Failure(error):
-            raise error
-    raise AssertionError("无法解析响应结果")
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, USER_INFO_API))
+    return parse_user_info(res_json)
 
 
 def user_info_matches(user_info: UserInfo, check_option: UserInfo) -> bool:
@@ -79,11 +73,7 @@ async def get_wbi_img(ctx: FetcherContext, client: AsyncClient) -> WbiImg:
     global wbi_img_cache
     if wbi_img_cache is not None:
         return wbi_img_cache
-    match await Fetcher.fetch_json(ctx, client, USER_INFO_API):
-        case Success(res_json):
-            pass
-        case Failure(error):
-            raise error
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, USER_INFO_API))
     wbi_img: WbiImg = {
         "img_key": _get_key_from_url(res_json["data"]["wbi_img"]["img_url"]),
         "sub_key": _get_key_from_url(res_json["data"]["wbi_img"]["sub_url"]),

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -33,7 +33,7 @@ from yutto.types import EpisodeData, ExtractorOptions
 from yutto.utils.asynclib import sleep_with_status_bar_refresh
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import DanmakuOptions
-from yutto.utils.fetcher import Fetcher, create_client
+from yutto.utils.fetcher import Fetcher, create_client, unwrap_fetch_result
 from yutto.utils.time import TIME_FULL_FMT
 from yutto.validator import validate_batch_arguments
 
@@ -191,7 +191,7 @@ class DownloadManager:
             sys.exit(ErrorCode.NOT_LOGIN_ERROR.value)
         # 重定向到可识别的 url
         try:
-            url = await Fetcher.get_redirected_url(ctx, client, url)
+            url = unwrap_fetch_result(await Fetcher.get_redirected_url(ctx, client, url))
         except httpx.InvalidURL:
             Logger.error(f"无效的 url({url})～请检查一下链接是否正确～")
             sys.exit(ErrorCode.WRONG_URL_ERROR.value)

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -13,7 +13,7 @@ from yutto.utils.asynclib import CoroutineWrapper, first_successful_with_check
 from yutto.utils.console.colorful import colored_string
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import write_danmaku
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import filter_none_values, xmerge
@@ -108,6 +108,10 @@ def create_mirrors_filter(banned_mirrors_pattern: str | None) -> Callable[[list[
     return mirrors_filter
 
 
+async def get_size(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> int | None:
+    return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
+
+
 async def download_video_and_audio(
     ctx: FetcherContext,
     client: httpx.AsyncClient,
@@ -127,7 +131,7 @@ async def download_video_and_audio(
     if video is not None:
         vbuf = await AsyncFileBuffer(video_path, overwrite=options["overwrite"])
         vsize = await first_successful_with_check(
-            [Fetcher.get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
+            [get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
         )
         video_coroutines = [
             CoroutineWrapper(
@@ -149,7 +153,7 @@ async def download_video_and_audio(
     if audio is not None:
         abuf = await AsyncFileBuffer(audio_path, overwrite=options["overwrite"])
         asize = await first_successful_with_check(
-            [Fetcher.get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
+            [get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
         )
         audio_coroutines = [
             CoroutineWrapper(

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -6,14 +6,16 @@ import re
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from returns.result import Failure
+
 from yutto.downloader.progressbar import show_progress
 from yutto.downloader.selector import select_audio, select_video
 from yutto.media.quality import audio_quality_map, video_quality_map
-from yutto.utils.asynclib import CoroutineWrapper, first_successful_with_check
+from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.colorful import colored_string
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import write_danmaku
-from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import filter_none_values, xmerge
@@ -108,10 +110,6 @@ def create_mirrors_filter(banned_mirrors_pattern: str | None) -> Callable[[list[
     return mirrors_filter
 
 
-async def get_size(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> int | None:
-    return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
-
-
 async def download_video_and_audio(
     ctx: FetcherContext,
     client: httpx.AsyncClient,
@@ -130,9 +128,16 @@ async def download_video_and_audio(
     ctx.set_download_semaphore(options["num_workers"])
     if video is not None:
         vbuf = await AsyncFileBuffer(video_path, overwrite=options["overwrite"])
-        vsize = await first_successful_with_check(
-            [get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
+        video_size_results = await asyncio.gather(
+            *[Fetcher.get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
         )
+        video_sizes = [result.unwrap() for result in video_size_results if not isinstance(result, Failure)]
+        if not video_sizes:
+            first_failure = next(result for result in video_size_results if isinstance(result, Failure))
+            raise first_failure.failure()
+        if len(set(video_sizes)) != 1:
+            raise Exception("Multiple coroutines returned different results")
+        vsize = video_sizes[0]
         video_coroutines = [
             CoroutineWrapper(
                 Fetcher.download_file_with_offset(
@@ -152,9 +157,16 @@ async def download_video_and_audio(
 
     if audio is not None:
         abuf = await AsyncFileBuffer(audio_path, overwrite=options["overwrite"])
-        asize = await first_successful_with_check(
-            [get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
+        audio_size_results = await asyncio.gather(
+            *[Fetcher.get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
         )
+        audio_sizes = [result.unwrap() for result in audio_size_results if not isinstance(result, Failure)]
+        if not audio_sizes:
+            first_failure = next(result for result in audio_size_results if isinstance(result, Failure))
+            raise first_failure.failure()
+        if len(set(audio_sizes)) != 1:
+            raise Exception("Multiple coroutines returned different results")
+        asize = audio_sizes[0]
         audio_coroutines = [
             CoroutineWrapper(
                 Fetcher.download_file_with_offset(

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -31,10 +31,6 @@ if TYPE_CHECKING:
     from yutto.utils.metadata import ChapterInfoData
 
 
-async def _unwrap_size_result(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> int | None:
-    return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
-
-
 def slice_blocks(start: int, total_size: int | None, block_size: int | None = None) -> list[tuple[int, int | None]]:
     """生成分块后的 (start, size) 序列
 
@@ -130,8 +126,10 @@ async def download_video_and_audio(
     ctx.set_download_semaphore(options["num_workers"])
     if video is not None:
         vbuf = await AsyncFileBuffer(video_path, overwrite=options["overwrite"])
-        vsize = await first_successful_with_check(
-            [_unwrap_size_result(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
+        vsize = unwrap_fetch_result(
+            await first_successful_with_check(
+                [Fetcher.get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
+            )
         )
         video_coroutines = [
             CoroutineWrapper(
@@ -152,8 +150,10 @@ async def download_video_and_audio(
 
     if audio is not None:
         abuf = await AsyncFileBuffer(audio_path, overwrite=options["overwrite"])
-        asize = await first_successful_with_check(
-            [_unwrap_size_result(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
+        asize = unwrap_fetch_result(
+            await first_successful_with_check(
+                [Fetcher.get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
+            )
         )
         audio_coroutines = [
             CoroutineWrapper(

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -124,12 +124,14 @@ async def download_video_and_audio(
     coroutines_list: list[list[CoroutineWrapper[None]]] = []
     mirrors_filter = create_mirrors_filter(options["banned_mirrors_pattern"])
     ctx.set_download_semaphore(options["num_workers"])
+
+    async def get_size(url: str) -> int | None:
+        return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
+
     if video is not None:
         vbuf = await AsyncFileBuffer(video_path, overwrite=options["overwrite"])
-        vsize = unwrap_fetch_result(
-            await first_successful_with_check(
-                [Fetcher.get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
-            )
+        vsize = await first_successful_with_check(
+            [get_size(url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
         )
         video_coroutines = [
             CoroutineWrapper(
@@ -150,10 +152,8 @@ async def download_video_and_audio(
 
     if audio is not None:
         abuf = await AsyncFileBuffer(audio_path, overwrite=options["overwrite"])
-        asize = unwrap_fetch_result(
-            await first_successful_with_check(
-                [Fetcher.get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
-            )
+        asize = await first_successful_with_check(
+            [get_size(url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
         )
         audio_coroutines = [
             CoroutineWrapper(

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -6,16 +6,14 @@ import re
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from returns.result import Failure
-
 from yutto.downloader.progressbar import show_progress
 from yutto.downloader.selector import select_audio, select_video
 from yutto.media.quality import audio_quality_map, video_quality_map
-from yutto.utils.asynclib import CoroutineWrapper
+from yutto.utils.asynclib import CoroutineWrapper, first_successful_with_check
 from yutto.utils.console.colorful import colored_string
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import write_danmaku
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import filter_none_values, xmerge
@@ -31,6 +29,10 @@ if TYPE_CHECKING:
     from yutto.types import AudioUrlMeta, DownloaderOptions, EpisodeData, VideoUrlMeta
     from yutto.utils.fetcher import FetcherContext
     from yutto.utils.metadata import ChapterInfoData
+
+
+async def _unwrap_size_result(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> int | None:
+    return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
 
 
 def slice_blocks(start: int, total_size: int | None, block_size: int | None = None) -> list[tuple[int, int | None]]:
@@ -128,16 +130,9 @@ async def download_video_and_audio(
     ctx.set_download_semaphore(options["num_workers"])
     if video is not None:
         vbuf = await AsyncFileBuffer(video_path, overwrite=options["overwrite"])
-        video_size_results = await asyncio.gather(
-            *[Fetcher.get_size(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
+        vsize = await first_successful_with_check(
+            [_unwrap_size_result(ctx, client, url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
         )
-        video_sizes = [result.unwrap() for result in video_size_results if not isinstance(result, Failure)]
-        if not video_sizes:
-            first_failure = next(result for result in video_size_results if isinstance(result, Failure))
-            raise first_failure.failure()
-        if len(set(video_sizes)) != 1:
-            raise Exception("Multiple coroutines returned different results")
-        vsize = video_sizes[0]
         video_coroutines = [
             CoroutineWrapper(
                 Fetcher.download_file_with_offset(
@@ -157,16 +152,9 @@ async def download_video_and_audio(
 
     if audio is not None:
         abuf = await AsyncFileBuffer(audio_path, overwrite=options["overwrite"])
-        audio_size_results = await asyncio.gather(
-            *[Fetcher.get_size(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
+        asize = await first_successful_with_check(
+            [_unwrap_size_result(ctx, client, url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
         )
-        audio_sizes = [result.unwrap() for result in audio_size_results if not isinstance(result, Failure)]
-        if not audio_sizes:
-            first_failure = next(result for result in audio_size_results if isinstance(result, Failure))
-            raise first_failure.failure()
-        if len(set(audio_sizes)) != 1:
-            raise Exception("Multiple coroutines returned different results")
-        asize = audio_sizes[0]
         audio_coroutines = [
             CoroutineWrapper(
                 Fetcher.download_file_with_offset(

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -14,7 +14,7 @@ from yutto.input_parser import parse_episodes_selection
 from yutto.types import MId, SeriesId
 from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import Filter
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class CollectionExtractor(BatchExtractor):
                 if not Filter.verify_timer(ugc_video_list["pubdate"]):
                     Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                     continue
-                await Fetcher.touch_url(ctx, client, avid.to_url())
+                unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
                 if len(ugc_video_list["pages"]) != 1:
                     Logger.error(f"视频合集 {collection_title} 中的视频 {item['avid']} 包含多个视频！")
                 for ugc_video_item in ugc_video_list["pages"]:

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -75,7 +75,7 @@ async def extract_bangumi_data(
         )
         metadata = bangumi_info["metadata"] if options["require_metadata"] else None
         cover_data = (
-            await Fetcher.fetch_bin(ctx, client, bangumi_info["metadata"]["thumb"])
+            (await Fetcher.fetch_bin(ctx, client, bangumi_info["metadata"]["thumb"])).value_or(None)
             if options["require_cover"]
             else None
         )
@@ -138,7 +138,9 @@ async def extract_cheese_data(
         )
         metadata = cheese_info["metadata"] if options["require_metadata"] else None
         cover_data = (
-            await Fetcher.fetch_bin(ctx, client, cheese_info["metadata"]["thumb"]) if options["require_cover"] else None
+            (await Fetcher.fetch_bin(ctx, client, cheese_info["metadata"]["thumb"])).value_or(None)
+            if options["require_cover"]
+            else None
         )
         subpath_variables_base: PathTemplateVariableDict = {
             "id": id,
@@ -204,7 +206,7 @@ async def extract_ugc_video_data(
         if metadata and chapter_info_data:
             attach_chapter_info(metadata, chapter_info_data)
         cover_data = (
-            await Fetcher.fetch_bin(ctx, client, ugc_video_info["metadata"]["thumb"])
+            (await Fetcher.fetch_bin(ctx, client, ugc_video_info["metadata"]["thumb"])).value_or(None)
             if options["require_cover"]
             else None
         )

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -13,7 +13,7 @@ from yutto.extractor.utils.favourite import normalize_favourite_video_item
 from yutto.types import FId, MId
 from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import Filter
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class FavouritesExtractor(BatchExtractor):
                 if not Filter.verify_timer(ugc_video_list["pubdate"]):
                     Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                     continue
-                await Fetcher.touch_url(ctx, client, avid.to_url())
+                unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
                 # 优先使用收藏夹 API 返回的人工标题；失效视频 title 为空时退回到 ugc 接口标题
                 favourite_title = favourite_video["title"] or ugc_video_list["title"]
                 is_single_page_video = len(ugc_video_list["pages"]) == 1

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -12,7 +12,7 @@ from yutto.extractor.common import extract_ugc_video_data
 from yutto.types import MId, SeriesId
 from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import Filter
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class SeriesExtractor(BatchExtractor):
                 if not Filter.verify_timer(ugc_video_list["pubdate"]):
                     Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                     continue
-                await Fetcher.touch_url(ctx, client, avid.to_url())
+                unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
                 for ugc_video_item in ugc_video_list["pages"]:
                     ugc_video_info_list.append(
                         (

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -12,7 +12,7 @@ from yutto.extractor.utils.favourite import normalize_favourite_video_item
 from yutto.types import MId
 from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import Filter
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
                     if not Filter.verify_timer(ugc_video_list["pubdate"]):
                         Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                         continue
-                    await Fetcher.touch_url(ctx, client, avid.to_url())
+                    unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
                     # 优先使用收藏夹 API 返回的人工标题；失效视频 title 为空时退回到 ugc 接口标题
                     favourite_title = favourite_video["title"] or ugc_video_list["title"]
                     is_single_page_video = len(ugc_video_list["pages"]) == 1

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -43,7 +43,13 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         Logger.custom(username, Badge("UP 主投稿视频", fore="black", back="cyan"))
 
         ugc_video_info_list: list[tuple[UgcVideoListItem, str, int]] = []
-        for avid in await get_user_space_all_videos_avids(ctx, client, self.mid):
+        for avid in await get_user_space_all_videos_avids(
+            ctx,
+            client,
+            self.mid,
+            pubdate_filter=Filter.verify_timer,
+            stop_before_timestamp=int(Filter.batch_filter_start_time.timestamp()),
+        ):
             try:
                 ugc_video_list = await get_ugc_video_list(ctx, client, avid)
                 if not Filter.verify_timer(ugc_video_list["pubdate"]):

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -11,7 +11,7 @@ from yutto.extractor.common import extract_ugc_video_data
 from yutto.types import MId
 from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import Filter
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
                 if not Filter.verify_timer(ugc_video_list["pubdate"]):
                     Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                     continue
-                await Fetcher.touch_url(ctx, client, avid.to_url())
+                unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
                 for ugc_video_item in ugc_video_list["pages"]:
                     ugc_video_info_list.append(
                         (

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -10,7 +10,7 @@ from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import extract_ugc_video_data
 from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import Filter
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ class UserWatchLaterExtractor(BatchExtractor):
                 if not Filter.verify_timer(ugc_video_list["pubdate"]):
                     Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                     continue
-                await Fetcher.touch_url(ctx, client, avid.to_url())
+                unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
                 for ugc_video_item in ugc_video_list["pages"]:
                     ugc_video_info_list.append(
                         (

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -177,24 +177,7 @@ class Fetcher:
             return resp.read()
 
     @staticmethod
-    @MaxRetry(2)
     async def fetch_json(
-        ctx: FetcherContext,
-        client: AsyncClient,
-        url: str,
-        *,
-        params: Mapping[str, Any] | None = None,
-    ) -> Any | None:
-        async with ctx.fetch_guard():
-            Logger.debug(f"Fetch json: {url}")
-            Logger.status.next_tick()
-            resp = await client.get(url, params=params)
-            if not resp.is_success:
-                resp.raise_for_status()
-            return resp.json()
-
-    @staticmethod
-    async def fetch_json_result(
         ctx: FetcherContext,
         client: AsyncClient,
         url: str,
@@ -202,9 +185,26 @@ class Fetcher:
         params: Mapping[str, Any] | None = None,
     ) -> Result[Any, MaxRetryError]:
         try:
-            return Success(await Fetcher.fetch_json(ctx, client, url, params=params))
+            return Success(await Fetcher._fetch_json_data(ctx, client, url, params=params))
         except MaxRetryError as e:
             return Failure(e)
+
+    @staticmethod
+    @MaxRetry(2)
+    async def _fetch_json_data(
+        ctx: FetcherContext,
+        client: AsyncClient,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> Any:
+        async with ctx.fetch_guard():
+            Logger.debug(f"Fetch json: {url}")
+            Logger.status.next_tick()
+            resp = await client.get(url, params=params)
+            if not resp.is_success:
+                resp.raise_for_status()
+            return resp.json()
 
     @staticmethod
     @MaxRetry(2)

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -159,13 +159,13 @@ class Fetcher:
         *,
         params: Mapping[str, Any] | None = None,
         encoding: str | None = None,  # TODO(SigureMo): Support this
-    ) -> str:
+    ) -> str | None:
         async with ctx.fetch_guard():
             Logger.debug(f"Fetch text: {url}")
             Logger.status.next_tick()
             resp = await client.get(url, params=params)
             if not resp.is_success:
-                resp.raise_for_status()
+                return None
             return resp.text
 
     @staticmethod
@@ -176,13 +176,13 @@ class Fetcher:
         url: str,
         *,
         params: Mapping[str, Any] | None = None,
-    ) -> bytes:
+    ) -> bytes | None:
         async with ctx.fetch_guard():
             Logger.debug(f"Fetch bin: {url}")
             Logger.status.next_tick()
             resp = await client.get(url, params=params)
             if not resp.is_success:
-                resp.raise_for_status()
+                return None
             return resp.read()
 
     @staticmethod
@@ -210,8 +210,6 @@ class Fetcher:
         # 情况需要在 av、BV 解析一部分信息后才能知道是否是番剧页面，处理起来非常麻烦（bilili 就是这么做的）
         async with ctx.fetch_guard():
             resp = await client.get(url)
-            if not resp.is_success:
-                resp.raise_for_status()
             redirected_url = str(resp.url)
             if redirected_url == url:
                 Logger.debug(f"Get redircted url: {url}")
@@ -244,9 +242,7 @@ class Fetcher:
     async def touch_url(ctx: FetcherContext, client: AsyncClient, url: str) -> None:
         async with ctx.fetch_guard():
             Logger.debug(f"Touch url: {url}")
-            resp = await client.get(url)
-            if not resp.is_success:
-                resp.raise_for_status()
+            await client.get(url)
 
     @staticmethod
     async def download_file_with_offset(

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -40,12 +40,12 @@ class MaxRetry:
 
     def __call__(
         self, connect_once: Callable[InputT, Coroutine[Any, Any, RetT]]
-    ) -> Callable[InputT, Coroutine[Any, Any, RetT]]:
-        async def connect_n_times(*args: InputT.args, **kwargs: InputT.kwargs) -> RetT:
+    ) -> Callable[InputT, Coroutine[Any, Any, Result[RetT, MaxRetryError]]]:
+        async def connect_n_times(*args: InputT.args, **kwargs: InputT.kwargs) -> Result[RetT, MaxRetryError]:
             retry = self.max_retry + 1
             while retry:
                 try:
-                    return await connect_once(*args, **kwargs)
+                    return Success(await connect_once(*args, **kwargs))
                 except httpx.TimeoutException:
                     Logger.warning(f"抓取超时，正在重试，剩余 {retry - 1} 次")
                 except (httpx.InvalidURL, httpx.UnsupportedProtocol) as e:
@@ -56,9 +56,18 @@ class MaxRetry:
                     Logger.warning(f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次")
                 finally:
                     retry -= 1
-            raise MaxRetryError("超出最大重试次数！")
+            return Failure(MaxRetryError("超出最大重试次数！"))
 
         return connect_n_times
+
+
+def unwrap_fetch_result(result: Result[RetT, MaxRetryError]) -> RetT:
+    match result:
+        case Success(value):
+            return value
+        case Failure(error):
+            raise error
+    raise AssertionError("无法解析响应结果")
 
 
 DEFAULT_PROXY = None
@@ -150,13 +159,13 @@ class Fetcher:
         *,
         params: Mapping[str, Any] | None = None,
         encoding: str | None = None,  # TODO(SigureMo): Support this
-    ) -> str | None:
+    ) -> str:
         async with ctx.fetch_guard():
             Logger.debug(f"Fetch text: {url}")
             Logger.status.next_tick()
             resp = await client.get(url, params=params)
             if not resp.is_success:
-                return None
+                resp.raise_for_status()
             return resp.text
 
     @staticmethod
@@ -167,31 +176,18 @@ class Fetcher:
         url: str,
         *,
         params: Mapping[str, Any] | None = None,
-    ) -> bytes | None:
+    ) -> bytes:
         async with ctx.fetch_guard():
             Logger.debug(f"Fetch bin: {url}")
             Logger.status.next_tick()
             resp = await client.get(url, params=params)
             if not resp.is_success:
-                return None
+                resp.raise_for_status()
             return resp.read()
 
     @staticmethod
-    async def fetch_json(
-        ctx: FetcherContext,
-        client: AsyncClient,
-        url: str,
-        *,
-        params: Mapping[str, Any] | None = None,
-    ) -> Result[Any, MaxRetryError]:
-        try:
-            return Success(await Fetcher._fetch_json_data(ctx, client, url, params=params))
-        except MaxRetryError as e:
-            return Failure(e)
-
-    @staticmethod
     @MaxRetry(2)
-    async def _fetch_json_data(
+    async def fetch_json(
         ctx: FetcherContext,
         client: AsyncClient,
         url: str,
@@ -214,6 +210,8 @@ class Fetcher:
         # 情况需要在 av、BV 解析一部分信息后才能知道是否是番剧页面，处理起来非常麻烦（bilili 就是这么做的）
         async with ctx.fetch_guard():
             resp = await client.get(url)
+            if not resp.is_success:
+                resp.raise_for_status()
             redirected_url = str(resp.url)
             if redirected_url == url:
                 Logger.debug(f"Get redircted url: {url}")
@@ -246,7 +244,9 @@ class Fetcher:
     async def touch_url(ctx: FetcherContext, client: AsyncClient, url: str) -> None:
         async with ctx.fetch_guard():
             Logger.debug(f"Touch url: {url}")
-            await client.get(url)
+            resp = await client.get(url)
+            if not resp.is_success:
+                resp.raise_for_status()
 
     @staticmethod
     async def download_file_with_offset(

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, unquote, urlparse
 
 import h2.exceptions
 import httpx
+from returns.result import Failure, Result, Success
 from typing_extensions import ParamSpec
 
 from yutto.exceptions import MaxRetryError
@@ -147,7 +148,7 @@ class Fetcher:
         client: AsyncClient,
         url: str,
         *,
-        params: Mapping[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
         encoding: str | None = None,  # TODO(SigureMo): Support this
     ) -> str | None:
         async with ctx.fetch_guard():
@@ -165,7 +166,7 @@ class Fetcher:
         client: AsyncClient,
         url: str,
         *,
-        params: Mapping[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> bytes | None:
         async with ctx.fetch_guard():
             Logger.debug(f"Fetch bin: {url}")
@@ -182,7 +183,7 @@ class Fetcher:
         client: AsyncClient,
         url: str,
         *,
-        params: Mapping[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
     ) -> Any | None:
         async with ctx.fetch_guard():
             Logger.debug(f"Fetch json: {url}")
@@ -191,6 +192,19 @@ class Fetcher:
             if not resp.is_success:
                 resp.raise_for_status()
             return resp.json()
+
+    @staticmethod
+    async def fetch_json_result(
+        ctx: FetcherContext,
+        client: AsyncClient,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+    ) -> Result[Any, MaxRetryError]:
+        try:
+            return Success(await Fetcher.fetch_json(ctx, client, url, params=params))
+        except MaxRetryError as e:
+            return Failure(e)
 
     @staticmethod
     @MaxRetry(2)

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -189,7 +189,7 @@ class Fetcher:
             Logger.status.next_tick()
             resp = await client.get(url, params=params)
             if not resp.is_success:
-                return None
+                resp.raise_for_status()
             return resp.json()
 
     @staticmethod

--- a/tests/test_api/test_space.py
+++ b/tests/test_api/test_space.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+import httpx
 import pytest
 from returns.result import Failure, Success
 
@@ -15,7 +16,6 @@ from yutto.api.space import (
     get_user_name,
     get_user_space_all_videos_avids,
 )
-from yutto.exceptions import MaxRetryError
 from yutto.types import AId, BvId, FId, MId, SeriesId
 from yutto.utils.fetcher import Fetcher, FetcherContext, create_client
 from yutto.utils.functional import as_sync
@@ -119,15 +119,12 @@ async def test_get_user_space_all_videos_avids_stops_on_api_error(monkeypatch: p
 
 @pytest.mark.api
 @as_sync
-async def test_fetch_json_wraps_max_retry_error(monkeypatch: pytest.MonkeyPatch):
-    async def fake_fetch_json_data(
-        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, str] | None = None
-    ) -> Any:
-        raise MaxRetryError("超出最大重试次数！")
+async def test_fetch_json_wraps_max_retry_error():
+    class TimeoutClient:
+        async def get(self, url: str, *, params: dict[str, str] | None = None) -> None:
+            raise httpx.ReadTimeout("timeout")
 
-    monkeypatch.setattr(Fetcher, "_fetch_json_data", fake_fetch_json_data)
-
-    match await Fetcher.fetch_json(FetcherContext(), cast("Any", object()), "https://example.com"):
+    match await Fetcher.fetch_json(FetcherContext(), cast("Any", TimeoutClient()), "https://example.com"):
         case Failure(error):
             assert error.message == "超出最大重试次数！"
         case result:
@@ -142,8 +139,8 @@ async def test_get_user_name_returns_fallback_on_api_error(monkeypatch: pytest.M
     async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
         return object()
 
-    async def fake_touch_url(ctx: FetcherContextType, client: Any, url: str) -> None:
-        return None
+    async def fake_touch_url(ctx: FetcherContextType, client: Any, url: str):
+        return Success(None)
 
     async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
         return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})

--- a/tests/test_api/test_space.py
+++ b/tests/test_api/test_space.py
@@ -47,9 +47,7 @@ async def test_get_user_space_all_videos_avids_filters_with_space_pubdate(monkey
     def fake_encode_wbi(params: dict[str, Any], wbi_img: object) -> dict[str, Any]:
         return params
 
-    async def fake_fetch_json_result(
-        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None
-    ):
+    async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
         assert params is not None
         pn = int(params["pn"])
         calls.append(pn)
@@ -83,7 +81,7 @@ async def test_get_user_space_all_videos_avids_filters_with_space_pubdate(monkey
 
     monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
     monkeypatch.setattr(space_module, "encode_wbi", fake_encode_wbi)
-    monkeypatch.setattr(space_module.Fetcher, "fetch_json_result", fake_fetch_json_result)
+    monkeypatch.setattr(space_module.Fetcher, "fetch_json", fake_fetch_json)
 
     all_avid = await get_user_space_all_videos_avids(
         FetcherContext(),
@@ -105,14 +103,12 @@ async def test_get_user_space_all_videos_avids_stops_on_api_error(monkeypatch: p
     async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
         return object()
 
-    async def fake_fetch_json_result(
-        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None
-    ):
+    async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
         return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})
 
     monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
     monkeypatch.setattr(space_module, "encode_wbi", lambda params, wbi_img: params)
-    monkeypatch.setattr(space_module.Fetcher, "fetch_json_result", fake_fetch_json_result)
+    monkeypatch.setattr(space_module.Fetcher, "fetch_json", fake_fetch_json)
     monkeypatch.setattr(space_module.Logger, "error", errors.append)
 
     all_avid = await get_user_space_all_videos_avids(FetcherContext(), cast("Any", object()), mid=MId("2147413451"))
@@ -123,15 +119,15 @@ async def test_get_user_space_all_videos_avids_stops_on_api_error(monkeypatch: p
 
 @pytest.mark.api
 @as_sync
-async def test_fetch_json_result_wraps_max_retry_error(monkeypatch: pytest.MonkeyPatch):
-    async def fake_fetch_json(
+async def test_fetch_json_wraps_max_retry_error(monkeypatch: pytest.MonkeyPatch):
+    async def fake_fetch_json_data(
         ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, str] | None = None
     ) -> Any:
         raise MaxRetryError("超出最大重试次数！")
 
-    monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
+    monkeypatch.setattr(Fetcher, "_fetch_json_data", fake_fetch_json_data)
 
-    match await Fetcher.fetch_json_result(FetcherContext(), cast("Any", object()), "https://example.com"):
+    match await Fetcher.fetch_json(FetcherContext(), cast("Any", object()), "https://example.com"):
         case Failure(error):
             assert error.message == "超出最大重试次数！"
         case result:
@@ -149,15 +145,13 @@ async def test_get_user_name_returns_fallback_on_api_error(monkeypatch: pytest.M
     async def fake_touch_url(ctx: FetcherContextType, client: Any, url: str) -> None:
         return None
 
-    async def fake_fetch_json_result(
-        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None
-    ):
+    async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
         return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})
 
     monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
     monkeypatch.setattr(space_module, "encode_wbi", lambda params, wbi_img: params)
     monkeypatch.setattr(space_module.Fetcher, "touch_url", fake_touch_url)
-    monkeypatch.setattr(space_module.Fetcher, "fetch_json_result", fake_fetch_json_result)
+    monkeypatch.setattr(space_module.Fetcher, "fetch_json", fake_fetch_json)
     monkeypatch.setattr(space_module.Logger, "error", errors.append)
 
     username = await get_user_name(FetcherContext(), cast("Any", object()), mid=MId("2147413451"))

--- a/tests/test_api/test_space.py
+++ b/tests/test_api/test_space.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING, Any, cast
 
+import pytest
+from returns.result import Failure, Success
+
+from yutto.api import space as space_module
 from yutto.api.space import (
     get_all_favourites,
     get_favourite_avids,
@@ -11,9 +15,13 @@ from yutto.api.space import (
     get_user_name,
     get_user_space_all_videos_avids,
 )
+from yutto.exceptions import MaxRetryError
 from yutto.types import AId, BvId, FId, MId, SeriesId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import Fetcher, FetcherContext, create_client
 from yutto.utils.functional import as_sync
+
+if TYPE_CHECKING:
+    from yutto.utils.fetcher import FetcherContext as FetcherContextType
 
 
 @pytest.mark.api
@@ -26,6 +34,138 @@ async def test_get_user_space_all_videos_avids():
         all_avid = await get_user_space_all_videos_avids(ctx, client, mid=mid)
         assert len(all_avid) > 0
         assert AId("371660125") in all_avid or BvId("BV1vZ4y1M7mQ") in all_avid
+
+
+@pytest.mark.api
+@as_sync
+async def test_get_user_space_all_videos_avids_filters_with_space_pubdate(monkeypatch: pytest.MonkeyPatch):
+    calls: list[int] = []
+
+    async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
+        return object()
+
+    def fake_encode_wbi(params: dict[str, Any], wbi_img: object) -> dict[str, Any]:
+        return params
+
+    async def fake_fetch_json_result(
+        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None
+    ):
+        assert params is not None
+        pn = int(params["pn"])
+        calls.append(pn)
+        pages = {
+            1: {
+                "code": 0,
+                "data": {
+                    "page": {"count": 90},
+                    "list": {
+                        "vlist": [
+                            {"bvid": "BVnew", "created": 250},
+                            {"bvid": "BVhit1", "created": 150},
+                        ]
+                    },
+                },
+            },
+            2: {
+                "code": 0,
+                "data": {
+                    "page": {"count": 90},
+                    "list": {
+                        "vlist": [
+                            {"bvid": "BVhit2", "created": 100},
+                            {"bvid": "BVold", "created": 99},
+                        ]
+                    },
+                },
+            },
+        }
+        return Success(pages[pn])
+
+    monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
+    monkeypatch.setattr(space_module, "encode_wbi", fake_encode_wbi)
+    monkeypatch.setattr(space_module.Fetcher, "fetch_json_result", fake_fetch_json_result)
+
+    all_avid = await get_user_space_all_videos_avids(
+        FetcherContext(),
+        cast("Any", object()),
+        mid=MId("2147413451"),
+        pubdate_filter=lambda timestamp: 100 <= timestamp < 200,
+        stop_before_timestamp=100,
+    )
+
+    assert all_avid == [BvId("BVhit1"), BvId("BVhit2")]
+    assert calls == [1, 2]
+
+
+@pytest.mark.api
+@as_sync
+async def test_get_user_space_all_videos_avids_stops_on_api_error(monkeypatch: pytest.MonkeyPatch):
+    errors: list[str] = []
+
+    async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
+        return object()
+
+    async def fake_fetch_json_result(
+        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None
+    ):
+        return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})
+
+    monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
+    monkeypatch.setattr(space_module, "encode_wbi", lambda params, wbi_img: params)
+    monkeypatch.setattr(space_module.Fetcher, "fetch_json_result", fake_fetch_json_result)
+    monkeypatch.setattr(space_module.Logger, "error", errors.append)
+
+    all_avid = await get_user_space_all_videos_avids(FetcherContext(), cast("Any", object()), mid=MId("2147413451"))
+
+    assert all_avid == []
+    assert errors == ["获取用户空间视频列表第 1 页失败：风控校验失败（code: -352）"]
+
+
+@pytest.mark.api
+@as_sync
+async def test_fetch_json_result_wraps_max_retry_error(monkeypatch: pytest.MonkeyPatch):
+    async def fake_fetch_json(
+        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, str] | None = None
+    ) -> Any:
+        raise MaxRetryError("超出最大重试次数！")
+
+    monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
+
+    match await Fetcher.fetch_json_result(FetcherContext(), cast("Any", object()), "https://example.com"):
+        case Failure(error):
+            assert error.message == "超出最大重试次数！"
+        case result:
+            pytest.fail(f"expected Failure, got {result}")
+
+
+@pytest.mark.api
+@as_sync
+async def test_get_user_name_returns_fallback_on_api_error(monkeypatch: pytest.MonkeyPatch):
+    errors: list[str] = []
+
+    async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
+        return object()
+
+    async def fake_touch_url(ctx: FetcherContextType, client: Any, url: str) -> None:
+        return None
+
+    async def fake_fetch_json_result(
+        ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None
+    ):
+        return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})
+
+    monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
+    monkeypatch.setattr(space_module, "encode_wbi", lambda params, wbi_img: params)
+    monkeypatch.setattr(space_module.Fetcher, "touch_url", fake_touch_url)
+    monkeypatch.setattr(space_module.Fetcher, "fetch_json_result", fake_fetch_json_result)
+    monkeypatch.setattr(space_module.Logger, "error", errors.append)
+
+    username = await get_user_name(FetcherContext(), cast("Any", object()), mid=MId("2147413451"))
+
+    assert username == "「用户2147413451」"
+    assert errors == [
+        "获取用户名失败了呢，错误信息：风控校验失败，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～"
+    ]
 
 
 @pytest.mark.api

--- a/tests/test_api/test_space.py
+++ b/tests/test_api/test_space.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
-
-import httpx
 import pytest
-from returns.result import Failure, Success
 
-from yutto.api import space as space_module
 from yutto.api.space import (
     get_all_favourites,
     get_favourite_avids,
@@ -17,11 +12,8 @@ from yutto.api.space import (
     get_user_space_all_videos_avids,
 )
 from yutto.types import AId, BvId, FId, MId, SeriesId
-from yutto.utils.fetcher import Fetcher, FetcherContext, create_client
+from yutto.utils.fetcher import FetcherContext, create_client
 from yutto.utils.functional import as_sync
-
-if TYPE_CHECKING:
-    from yutto.utils.fetcher import FetcherContext as FetcherContextType
 
 
 @pytest.mark.api
@@ -34,129 +26,6 @@ async def test_get_user_space_all_videos_avids():
         all_avid = await get_user_space_all_videos_avids(ctx, client, mid=mid)
         assert len(all_avid) > 0
         assert AId("371660125") in all_avid or BvId("BV1vZ4y1M7mQ") in all_avid
-
-
-@pytest.mark.api
-@as_sync
-async def test_get_user_space_all_videos_avids_filters_with_space_pubdate(monkeypatch: pytest.MonkeyPatch):
-    calls: list[int] = []
-
-    async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
-        return object()
-
-    def fake_encode_wbi(params: dict[str, Any], wbi_img: object) -> dict[str, Any]:
-        return params
-
-    async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
-        assert params is not None
-        pn = int(params["pn"])
-        calls.append(pn)
-        pages = {
-            1: {
-                "code": 0,
-                "data": {
-                    "page": {"count": 90},
-                    "list": {
-                        "vlist": [
-                            {"bvid": "BVnew", "created": 250},
-                            {"bvid": "BVhit1", "created": 150},
-                        ]
-                    },
-                },
-            },
-            2: {
-                "code": 0,
-                "data": {
-                    "page": {"count": 90},
-                    "list": {
-                        "vlist": [
-                            {"bvid": "BVhit2", "created": 100},
-                            {"bvid": "BVold", "created": 99},
-                        ]
-                    },
-                },
-            },
-        }
-        return Success(pages[pn])
-
-    monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
-    monkeypatch.setattr(space_module, "encode_wbi", fake_encode_wbi)
-    monkeypatch.setattr(space_module.Fetcher, "fetch_json", fake_fetch_json)
-
-    all_avid = await get_user_space_all_videos_avids(
-        FetcherContext(),
-        cast("Any", object()),
-        mid=MId("2147413451"),
-        pubdate_filter=lambda timestamp: 100 <= timestamp < 200,
-        stop_before_timestamp=100,
-    )
-
-    assert all_avid == [BvId("BVhit1"), BvId("BVhit2")]
-    assert calls == [1, 2]
-
-
-@pytest.mark.api
-@as_sync
-async def test_get_user_space_all_videos_avids_stops_on_api_error(monkeypatch: pytest.MonkeyPatch):
-    errors: list[str] = []
-
-    async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
-        return object()
-
-    async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
-        return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})
-
-    monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
-    monkeypatch.setattr(space_module, "encode_wbi", lambda params, wbi_img: params)
-    monkeypatch.setattr(space_module.Fetcher, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(space_module.Logger, "error", errors.append)
-
-    all_avid = await get_user_space_all_videos_avids(FetcherContext(), cast("Any", object()), mid=MId("2147413451"))
-
-    assert all_avid == []
-    assert errors == ["获取用户空间视频列表第 1 页失败：风控校验失败（code: -352）"]
-
-
-@pytest.mark.api
-@as_sync
-async def test_fetch_json_wraps_max_retry_error():
-    class TimeoutClient:
-        async def get(self, url: str, *, params: dict[str, str] | None = None) -> None:
-            raise httpx.ReadTimeout("timeout")
-
-    match await Fetcher.fetch_json(FetcherContext(), cast("Any", TimeoutClient()), "https://example.com"):
-        case Failure(error):
-            assert error.message == "超出最大重试次数！"
-        case result:
-            pytest.fail(f"expected Failure, got {result}")
-
-
-@pytest.mark.api
-@as_sync
-async def test_get_user_name_returns_fallback_on_api_error(monkeypatch: pytest.MonkeyPatch):
-    errors: list[str] = []
-
-    async def fake_get_wbi_img(ctx: FetcherContextType, client: Any) -> object:
-        return object()
-
-    async def fake_touch_url(ctx: FetcherContextType, client: Any, url: str):
-        return Success(None)
-
-    async def fake_fetch_json(ctx: FetcherContextType, client: Any, url: str, *, params: dict[str, Any] | None = None):
-        return Success({"code": -352, "message": "风控校验失败", "data": {"v_voucher": "voucher"}})
-
-    monkeypatch.setattr(space_module, "get_wbi_img", fake_get_wbi_img)
-    monkeypatch.setattr(space_module, "encode_wbi", lambda params, wbi_img: params)
-    monkeypatch.setattr(space_module.Fetcher, "touch_url", fake_touch_url)
-    monkeypatch.setattr(space_module.Fetcher, "fetch_json", fake_fetch_json)
-    monkeypatch.setattr(space_module.Logger, "error", errors.append)
-
-    username = await get_user_name(FetcherContext(), cast("Any", object()), mid=MId("2147413451"))
-
-    assert username == "「用户2147413451」"
-    assert errors == [
-        "获取用户名失败了呢，错误信息：风控校验失败，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～"
-    ]
 
 
 @pytest.mark.api

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -7,7 +7,7 @@ import pytest
 
 from yutto.downloader.downloader import slice_blocks
 from yutto.utils.asynclib import CoroutineWrapper
-from yutto.utils.fetcher import Fetcher, FetcherContext, create_client
+from yutto.utils.fetcher import Fetcher, FetcherContext, create_client, unwrap_fetch_result
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import as_sync
 
@@ -28,7 +28,7 @@ async def test_150_kB_downloader():
             timeout=httpx.Timeout(7, connect=3),
         ) as client:
             ctx.set_download_semaphore(4)
-            size = await Fetcher.get_size(ctx, client, url)
+            size = unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
             coroutines = [
                 CoroutineWrapper(Fetcher.download_file_with_offset(ctx, client, url, [], buffer, offset, block_size))
                 for offset, block_size in slice_blocks(buffer.written_size, size, 1 * 1024 * 1024)
@@ -53,7 +53,7 @@ async def test_150_kB_no_slice_downloader():
             timeout=httpx.Timeout(7, connect=3),
         ) as client:
             ctx.set_download_semaphore(4)
-            size = await Fetcher.get_size(ctx, client, url)
+            size = unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
             coroutines = [CoroutineWrapper(Fetcher.download_file_with_offset(ctx, client, url, [], buffer, 0, size))]
 
             print("开始下载……")

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -4,9 +4,12 @@ import asyncio
 import ssl
 from typing import Any, Protocol, cast
 
+import httpx
 import pytest
+from returns.result import Failure, Success
 
-from yutto.utils.fetcher import FetcherContext, create_client, create_sync_client, resolve_proxy
+from yutto.utils.fetcher import Fetcher, FetcherContext, create_client, create_sync_client, resolve_proxy
+from yutto.utils.functional import as_sync
 
 
 class _HasSSLContext(Protocol):
@@ -76,3 +79,47 @@ def test_create_sync_client_can_enable_tls_verification():
         assert ssl_context.check_hostname
     finally:
         client.close()
+
+
+class _StatusClient:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        return httpx.Response(self.status_code, request=httpx.Request("GET", url), content=b"failed")
+
+
+@as_sync
+async def test_fetch_bin_keeps_non_success_status_as_success_none():
+    match await Fetcher.fetch_bin(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+        case Success(None):
+            pass
+        case result:
+            pytest.fail(f"expected Success(None), got {result}")
+
+
+@as_sync
+async def test_fetch_json_retries_non_success_status():
+    match await Fetcher.fetch_json(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+        case Failure(error):
+            assert error.message == "超出最大重试次数！"
+        case result:
+            pytest.fail(f"expected Failure, got {result}")
+
+
+@as_sync
+async def test_get_redirected_url_keeps_non_success_status_as_url():
+    match await Fetcher.get_redirected_url(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+        case Success(url):
+            assert url == "https://example.com"
+        case result:
+            pytest.fail(f"expected Success, got {result}")
+
+
+@as_sync
+async def test_touch_url_keeps_non_success_status_as_success_none():
+    match await Fetcher.touch_url(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+        case Success(None):
+            pass
+        case result:
+            pytest.fail(f"expected Success(None), got {result}")


### PR DESCRIPTION
## 动机

fixes #552

`yutto -b https://space.bilibili.com/xxx` 批量下载用户空间视频时偶发 `AssertionError` 崩溃。

根因：B 站 `api.bilibili.com/x/space/wbi/arc/search` 接口偶发返回 HTTP 412 风控拦截（HTML 页面），`fetch_json()` 因 `resp.is_success=False` 返回 `None`，随后 `assert json_data is not None` 直接崩溃。此前 `MaxRetry` 只重试网络异常，对非 2xx 响应不做重试。

## 解决方案

1. `src/yutto/utils/fetcher.py` `fetch_json`：`return None` → `resp.raise_for_status()`，使非 2xx 响应被 `@MaxRetry(2)` 捕获并重试（最多 3 次，每次间隔 0.5s）
2. `src/yutto/api/space.py` `get_user_space_all_videos_avids`：包裹 `try/except MaxRetryError`，重试耗尽后打印错误日志并返回空列表，优雅降级不再崩溃

### 重试成功时

```
 UP 主投稿视频  xxx
 WARN  抓取失败（HTTPStatusError），正在重试，剩余 2 次
 WARN  抓取失败（HTTPStatusError），正在重试，剩余 1 次
 1/1  xxxxxx
 INFO  开始处理视频 xxxxxx
 ...
```

### 重试耗尽时

```
 UP 主投稿视频  xxx
 WARN  抓取失败（HTTPStatusError），正在重试，剩余 2 次
 WARN  抓取失败（HTTPStatusError），正在重试，剩余 1 次
 WARN  抓取失败（HTTPStatusError），正在重试，剩余 0 次
 ERROR  获取用户空间视频列表失败：超出最大重试次数！
```

## 类型

-  [x] :bug: fix: 修复 bug