### PR TITLE
💬 chore: update default `User-Agent`

### DIFF
--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -73,7 +73,7 @@ def unwrap_fetch_result(result: Result[RetT, MaxRetryError]) -> RetT:
 DEFAULT_PROXY = None
 DEFAULT_TRUST_ENV = True
 DEFAULT_HEADERS: dict[str, str] = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
     "Referer": "https://www.bilibili.com",
 }
 DEFAULT_COOKIES = httpx.Cookies()


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

默认请求头中的 User-Agent 仍使用较旧的 Chrome 134 字符串，需要更新到新的桌面 Chrome User-Agent。

## 解决方案

- 将 `src/yutto/utils/fetcher.py` 中默认 `User-Agent` 更新为 Chrome 149 字符串。
- 全仓搜索确认没有其它默认 UA 常量、fallback、测试快照或文档说明需要同步更新。

## 验证

- `just fmt`
- `just lint`
- `uv run pytest tests/test_utils/test_fetcher.py`
- `git diff --check`

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
