### PR TITLE
👷 ci: parallelize latest release smoke tests

### DIFF
--- a/.github/workflows/latest-release-test.yml
+++ b/.github/workflows/latest-release-test.yml
@@ -30,23 +30,28 @@ jobs:
           sudo apt update
           sudo apt install ffmpeg
 
-      - name: Test yutto from source
-        run: |
-          uv cache clean
-          uvx --no-binary-package=yutto yutto@latest -v
-          uvx --no-binary-package=yutto yutto@latest -h
-          uvx --no-binary-package=yutto yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress
+      - parallel:
+          - name: Test yutto from source
+            env:
+              UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-yutto-source
+            run: |
+              uv cache clean
+              uvx --no-binary-package=yutto yutto@latest -v
+              uvx --no-binary-package=yutto yutto@latest -h
+              uvx --no-binary-package=yutto yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress
 
-      - name: Test yutto from wheel
-        run: |
-          uv cache clean
-          uvx yutto@latest -v
-          uvx yutto@latest -h
-          uvx yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress
+          - name: Test yutto from wheel
+            env:
+              UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-yutto-wheel
+            run: |
+              uv cache clean
+              uvx yutto@latest -v
+              uvx yutto@latest -h
+              uvx yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress
 
-      - name: Prepare data for biliass
-        run: |
-          git clone https://github.com/yutto-dev/biliass-corpus.git --depth 1
+          - name: Prepare data for biliass
+            run: |
+              git clone https://github.com/yutto-dev/biliass-corpus.git --depth 1
 
       - name: Test biliass from source
         run: |


### PR DESCRIPTION
## 动机

GitHub Actions 已支持 step-level parallelism。本 PR 先对 nightly latest release test 做小范围、保守接入：并行互相独立的 yutto source/wheel smoke test 与 biliass corpus clone，减少单个 matrix job 中的串行等待。

## 解决方案

- 在 `.github/workflows/latest-release-test.yml` 中使用 `parallel:` 包住：
  - `Test yutto from source`
  - `Test yutto from wheel`
  - `Prepare data for biliass`
- 为两个并行 yutto 测试分别设置独立的 `UV_CACHE_DIR`，保留原有 `uv cache clean`，避免并发清理同一个 uv cache。
- 不改动 e2e、release/publish 相关 workflow，保持本次 PR 聚焦。

验证：

- `just fmt`
- `just lint`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/latest-release-test.yml"); puts "YAML OK"'`
- 自定义结构检查：确认 parallel group 包含上述 3 个 step，且两个 yutto step 均有独立 `UV_CACHE_DIR`

验证边界：`actionlint` v1.7.12 目前尚未识别 2026-06-25 新增的 `parallel` step 语法，会把 `parallel` 误报为缺少 `run`/`uses`，因此本地只做 YAML/结构级验证；最终语法接受情况需要以 GitHub Actions 端为准。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
