### PR TITLE
👷 ci: isolate latest release smoke test temp dirs

### DIFF
--- a/.github/workflows/latest-release-test.yml
+++ b/.github/workflows/latest-release-test.yml
@@ -34,20 +34,30 @@ jobs:
           - name: Test yutto from source
             env:
               UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-yutto-source
+              TMPDIR: ${{ runner.temp }}/tmp-yutto-source
+              TEMP: ${{ runner.temp }}/tmp-yutto-source
+              TMP: ${{ runner.temp }}/tmp-yutto-source
+              YUTTO_OUTPUT_DIR: ${{ runner.temp }}/output-yutto-source
             run: |
+              mkdir -p "$TMPDIR" "$YUTTO_OUTPUT_DIR"
               uv cache clean
               uvx --no-binary-package=yutto yutto@latest -v
               uvx --no-binary-package=yutto yutto@latest -h
-              uvx --no-binary-package=yutto yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress
+              uvx --no-binary-package=yutto yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress --dir "$YUTTO_OUTPUT_DIR" --tmp-dir "$TMPDIR"
 
           - name: Test yutto from wheel
             env:
               UV_CACHE_DIR: ${{ runner.temp }}/uv-cache-yutto-wheel
+              TMPDIR: ${{ runner.temp }}/tmp-yutto-wheel
+              TEMP: ${{ runner.temp }}/tmp-yutto-wheel
+              TMP: ${{ runner.temp }}/tmp-yutto-wheel
+              YUTTO_OUTPUT_DIR: ${{ runner.temp }}/output-yutto-wheel
             run: |
+              mkdir -p "$TMPDIR" "$YUTTO_OUTPUT_DIR"
               uv cache clean
               uvx yutto@latest -v
               uvx yutto@latest -h
-              uvx yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress
+              uvx yutto@latest https://www.bilibili.com/video/BV1AZ4y147Yg -w --no-progress --dir "$YUTTO_OUTPUT_DIR" --tmp-dir "$TMPDIR"
 
           - name: Prepare data for biliass
             run: |


### PR DESCRIPTION
## 动机

Follow-up to #732.

最新 `Latest Release Test` scheduled run 中，`Test yutto from source` 与 `Test yutto from wheel` 并行下载同一个视频时仍共享工作目录/临时文件名，其中 Python 3.12 job 的 wheel step 在 cleanup 阶段报错：

```text
FileNotFoundError: [Errno 2] No such file or directory: '就这？真就1秒！B站最短视频，就尼玛离离离谱！_video.m4s'
```

失败 job: https://github.com/yutto-dev/yutto/actions/runs/28276338134/job/83783580555

## 解决方案

- 保留 #732 中已加入的独立 `UV_CACHE_DIR`。
- 为两个并行 yutto smoke test 分别设置独立 `TMPDIR` / `TEMP` / `TMP`。
- 为下载命令显式传入独立 `--tmp-dir` 与 `--dir`，避免 yutto 的临时分片文件和输出文件在并行 step 间互踩。

## 验证

- `just fmt`
- `just lint`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/latest-release-test.yml"); puts "YAML OK"'`
- 自定义结构检查：确认 parallel group 仍包含 3 个目标 step，两个 yutto step 均设置 `UV_CACHE_DIR`、`TMPDIR`、`TEMP`、`TMP`、`YUTTO_OUTPUT_DIR`，且下载命令包含 `--dir "$YUTTO_OUTPUT_DIR"` 与 `--tmp-dir "$TMPDIR"`
- `git diff --check`

验证边界：`actionlint` v1.7.12 仍未识别 GitHub Actions 新增的 `parallel` step 语法，本地语义校验以 YAML/结构检查为主；最终需要通过 GitHub Actions scheduled run 验证。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
