### PR TITLE
🔨 chore: move docs pnpm peer rules to workspace config

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,15 +27,5 @@
     "vitepress-plugin-llms": "^1.13.2",
     "vue": "^3.5.39"
   },
-  "packageManager": "pnpm@11.9.0",
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search",
-        "react",
-        "react-dom",
-        "@types/react"
-      ]
-    }
-  }
+  "packageManager": "pnpm@11.9.0"
 }

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,2 +1,9 @@
 allowBuilds:
   esbuild: true
+
+peerDependencyRules:
+  ignoreMissing:
+    - '@algolia/client-search'
+    - react
+    - react-dom
+    - '@types/react'


### PR DESCRIPTION
## 动机

pnpm 现在不再读取 `package.json` 中的 `pnpm` 字段，导致 docs 安装依赖时出现如下 warning，并让 `peerDependencyRules` 配置被忽略：

```text
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.peerDependencyRules".
```

## 解决方案

将 docs 的 `peerDependencyRules.ignoreMissing` 从 `docs/package.json` 迁移到 `docs/pnpm-workspace.yaml`，和现有 `allowBuilds` 一起放在 pnpm workspace 配置中。

## 验证

- `cd docs && pnpm install --frozen-lockfile`（无 `pnpm` field warning）
- `just docs-build`

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
