### PR TITLE
👷 ci: skip CodSpeed benchmarks on forks

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         if: ${{ matrix.python-version == '3.14' && github.event_name != 'merge_group' }}
+        continue-on-error: ${{ github.event.repository.fork }}
         with:
           mode: simulation
           run: uv run -p ${{ matrix.python-version }} pytest --codspeed

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,8 +48,7 @@ jobs:
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
-        if: ${{ matrix.python-version == '3.14' && github.event_name != 'merge_group' }}
-        continue-on-error: ${{ github.event.repository.fork }}
+        if: ${{ matrix.python-version == '3.14' && github.event_name != 'merge_group' && !github.event.repository.fork }}
         with:
           mode: simulation
           run: uv run -p ${{ matrix.python-version }} pytest --codspeed


### PR DESCRIPTION
## 动机

在 fork 仓库中，Python 3.14 的 Unit Test 可能在测试和 CodSpeed benchmark 本身都通过后，因为 CodSpeed 上传阶段没有对应仓库权限而失败。

这次是在 [ShigureNyako/yutto run 28392407209](https://github.com/ShigureNyako/yutto/actions/runs/28392407209) 里看到 `Failed to retrieve upload data: 401 Unauthorized`。之前误在 fork 仓库开了 [ShigureNyako/yutto#2](https://github.com/ShigureNyako/yutto/pull/2)，关闭后 @SigureMo 提醒可以向上游提交 PR。

## 解决方案

当当前仓库本身是 fork 时，直接跳过 CodSpeed benchmark step。

这样 fork 仓库不会因为 CodSpeed 外部上传权限阻塞 CI，也不会运行一个最终无法上传结果的 benchmark；上游非 fork 仓库中 `github.event.repository.fork` 为 `false`，CodSpeed 仍会正常运行并阻塞真实失败。

验证：

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/unit-test.yml"); puts "yaml ok"'`

@SigureMo 请 review。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
