### PR TITLE
🔧 chore: migrate pytest config to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ biliass = { workspace = true }
 [tool.uv.workspace]
 members = ["packages/*"]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 markers = ["api", "e2e", "processor", "biliass", "ignore", "ci_skip", "ci_only"]
 
 [tool.ruff]


### PR DESCRIPTION
## 动机

pytest 9 已支持在 `pyproject.toml` 的 `[tool.pytest]` 下使用 native TOML configuration；当前项目 dev 依赖为 `pytest>=9.1.1`，可以迁移掉兼容 INI 语义的 `[tool.pytest.ini_options]`。

## 解决方案

- 将 `pyproject.toml` 中的 `[tool.pytest.ini_options]` 改为 `[tool.pytest]`
- 保持现有 `markers` 列表不变，继续以 TOML 字符串数组注册 pytest markers

## 验证

- `uv run pytest --markers | grep -E '^@pytest\.mark\.(api|e2e|processor|biliass|ignore|ci_skip|ci_only)'`
- `just fmt`
- `just lint`
- `uv run pytest -q --strict-markers --collect-only -m '(api or e2e or processor or biliass) and not (ci_only or ignore)'`
- `uv run pytest -q --strict-markers -m processor tests/test_processor/test_path_resolver.py tests/test_processor/test_selector.py`

补充：本地运行 `just test` 时，`tests/test_processor/test_downloader.py` 的两个外部下载用例失败，原因是远端样例文件 HEAD/下载大小不一致（期望 `1570024`，实际下载 `1441792`），与本次 pytest 配置迁移无关。

## 兼容性说明

- pytest native TOML configuration 在 pytest 9 中可用；本仓库当前 dev 依赖/锁文件使用 `pytest>=9.1.1` / `pytest 9.1.1`。
- native TOML 模式保留 TOML 原生类型；`markers` 的配置类型是 `linelist`，在 native TOML 中应提供字符串数组，本 PR 保持原值形态不变。
- 不再同时保留 `[tool.pytest.ini_options]`，避免 pytest 对 native TOML 与 INI 兼容配置混用时报错。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [x] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
