### PR TITLE
🌐 feat: surface the effective proxy in logs and retry errors

### DIFF
--- a/src/yutto/server/service.py
+++ b/src/yutto/server/service.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, TypeAlias, TypeVar
 from pydantic import BaseModel
 
 from yutto.auth import load_auth
-from yutto.utils.fetcher import FetcherContext
+from yutto.utils.fetcher import FetcherContext, sanitize_proxy_url
 
 if TYPE_CHECKING:
     from yutto.core.request import DownloadRequest
@@ -303,7 +303,7 @@ def _to_json_value(value: object) -> JsonValue:
             if _is_credential_field(json_key):
                 continue
             if json_key.casefold() == "proxy" and isinstance(item, str):
-                result[json_key] = _sanitize_proxy(item)
+                result[json_key] = sanitize_proxy_url(item)
                 continue
             result[json_key] = _to_json_value(item)
         return result
@@ -317,19 +317,3 @@ def _is_credential_field(field: str) -> bool:
     return normalized in _CREDENTIAL_FIELDS or normalized.endswith(
         ("_api_key", "_cookie", "_credential", "_password", "_secret", "_token")
     )
-
-
-def _sanitize_proxy(proxy: str) -> str:
-    scheme_separator = proxy.find("://")
-    if scheme_separator < 0:
-        return proxy
-
-    authority_start = scheme_separator + 3
-    authority_end = len(proxy)
-    for separator in "/?#":
-        if (index := proxy.find(separator, authority_start)) >= 0:
-            authority_end = min(authority_end, index)
-    credential_separator = proxy.rfind("@", authority_start, authority_end)
-    if credential_separator < 0:
-        return proxy
-    return f"{proxy[: scheme_separator + 3]}{proxy[credential_separator + 1 :]}"

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -99,24 +99,85 @@ def resolve_proxy(proxy: str) -> tuple[str | None, bool]:
     return proxy, False
 
 
-_ENV_PROXY_NAMES = ("ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY", "all_proxy", "https_proxy", "http_proxy")
+def sanitize_proxy_url(proxy: str) -> str:
+    """移除代理 URL 中的 userinfo（用户名/密码），避免凭据进入日志等对外输出"""
+    scheme_separator = proxy.find("://")
+    if scheme_separator < 0:
+        return proxy
+
+    authority_start = scheme_separator + 3
+    authority_end = len(proxy)
+    for separator in "/?#":
+        if (index := proxy.find(separator, authority_start)) >= 0:
+            authority_end = min(authority_end, index)
+    credential_separator = proxy.rfind("@", authority_start, authority_end)
+    if credential_separator < 0:
+        return proxy
+    return f"{proxy[: scheme_separator + 3]}{proxy[credential_separator + 1 :]}"
 
 
-def describe_effective_proxy(proxy: str | None, trust_env: bool) -> str | None:
-    """请求实际经由的代理描述，用于日志与错误提示。
+def _collect_environment_proxies(environ: Mapping[str, str]) -> dict[str, tuple[str, str]]:
+    """收集环境变量代理，返回 scheme -> (代理 URL, 来源变量名)
 
-    显式代理直接返回；trust_env 下 httpx 会静默使用环境变量代理，
-    此时把变量名一并带上，便于用户定位到底是谁配置了代理。
+    对齐 urllib `getproxies_environment` 的两遍扫描语义：第一遍不区分大小写，
+    第二遍仅字面小写后缀的变量参与覆盖，因此同名时小写变量优先，
+    且空值的小写变量会移除对应代理。
+    """
+    collected: dict[str, tuple[str, str]] = {}
+    for name, value in environ.items():
+        lowered = name.lower()
+        if value and lowered.endswith("_proxy"):
+            collected[lowered[:-6]] = (value, name)
+    for name, value in environ.items():
+        if name.endswith("_proxy"):
+            scheme = name[:-6].lower()
+            if value:
+                collected[scheme] = (value, name)
+            else:
+                collected.pop(scheme, None)
+    return collected
+
+
+def describe_effective_proxy(
+    proxy: str | None, trust_env: bool, environ: Mapping[str, str] | None = None
+) -> str | None:
+    """请求将经由的代理描述（凭据已脱敏），用于日志提示。
+
+    显式代理直接返回；trust_env 下对齐 httpx 的环境代理选择语义：
+    请求按自身 scheme 在 HTTPS_PROXY / HTTP_PROXY 与 ALL_PROXY 之间选择（scheme 专属变量优先）、
+    NO_PROXY 含 `*` 时完全禁用环境代理、同名小写变量覆盖大写变量；
+    并把来源变量名一并带上，便于用户定位到底是谁配置了代理。
     """
     if proxy is not None:
-        return proxy
+        return sanitize_proxy_url(proxy)
     if not trust_env:
         return None
-    for name in _ENV_PROXY_NAMES:
-        value = os.environ.get(name)
-        if value:
-            return f"{value}（来自环境变量 {name}）"
-    return None
+    collected = _collect_environment_proxies(os.environ if environ is None else environ)
+    no_proxy = collected.pop("no", None)
+    if no_proxy is not None and any(host.strip() == "*" for host in no_proxy[0].split(",")):
+        # httpx 语义：NO_PROXY 含 * 时完全不使用环境代理
+        return None
+    mounts: dict[str, tuple[str, str]] = {}
+    for scheme in ("https", "http"):
+        entry = collected.get(scheme) or collected.get("all")
+        if entry is not None:
+            url, source = entry
+            # httpx 会为无 scheme 的代理值补全 http://
+            mounts[scheme] = (url if "://" in url else f"http://{url}", source)
+    if not mounts:
+        return None
+    if len(mounts) == 2 and mounts["https"][0] == mounts["http"][0]:
+        url = mounts["https"][0]
+        sources = list(dict.fromkeys((mounts["https"][1], mounts["http"][1])))
+        description = f"{sanitize_proxy_url(url)}（来自环境变量 {'、'.join(sources)}）"
+    else:
+        description = "；".join(
+            f"{scheme.upper()} 请求 → {sanitize_proxy_url(url)}（来自环境变量 {source}）"
+            for scheme, (url, source) in mounts.items()
+        )
+    if no_proxy is not None:
+        description += f"；NO_PROXY={no_proxy[0]} 命中的主机将直连"
+    return description
 
 
 _logged_proxy_descriptions: set[str] = set()

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import random
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -44,20 +45,24 @@ class MaxRetry:
     ) -> Callable[InputT, Coroutine[Any, Any, Result[RetT, MaxRetryError]]]:
         async def connect_n_times(*args: InputT.args, **kwargs: InputT.kwargs) -> Result[RetT, MaxRetryError]:
             retry = self.max_retry + 1
+            last_error: str | None = None
             while retry:
                 try:
                     return Success(await connect_once(*args, **kwargs))
                 except httpx.TimeoutException:
+                    last_error = "抓取超时"
                     Logger.warning(f"抓取超时，正在重试，剩余 {retry - 1} 次")
                 except (httpx.InvalidURL, httpx.UnsupportedProtocol) as e:
                     raise e
                 except httpx.HTTPError as e:
                     await asyncio.sleep(0.5)
                     error_type = e.__class__.__name__
+                    last_error = error_type
                     Logger.warning(f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次")
                 finally:
                     retry -= 1
-            return Failure(MaxRetryError("超出最大重试次数！"))
+            message = "超出最大重试次数！" if last_error is None else f"超出最大重试次数！（最后错误：{last_error}）"
+            return Failure(MaxRetryError(message))
 
         return connect_n_times
 
@@ -92,6 +97,39 @@ def resolve_proxy(proxy: str) -> tuple[str | None, bool]:
     if not parsed.scheme or parsed.scheme not in SUPPORTED_PROXY_SCHEMES:
         raise ValueError(f"proxy 参数值（{proxy}）错误啦！")
     return proxy, False
+
+
+_ENV_PROXY_NAMES = ("ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY", "all_proxy", "https_proxy", "http_proxy")
+
+
+def describe_effective_proxy(proxy: str | None, trust_env: bool) -> str | None:
+    """请求实际经由的代理描述，用于日志与错误提示。
+
+    显式代理直接返回；trust_env 下 httpx 会静默使用环境变量代理，
+    此时把变量名一并带上，便于用户定位到底是谁配置了代理。
+    """
+    if proxy is not None:
+        return proxy
+    if not trust_env:
+        return None
+    for name in _ENV_PROXY_NAMES:
+        value = os.environ.get(name)
+        if value:
+            return f"{value}（来自环境变量 {name}）"
+    return None
+
+
+_logged_proxy_descriptions: set[str] = set()
+
+
+def _log_effective_proxy_once(proxy: str | None, trust_env: bool) -> None:
+    # 环境变量代理不可用时用户只能看到裸的 ConnectError，
+    # 因此在创建 client 时把实际代理来源说清楚（每种来源只提示一次）。
+    description = describe_effective_proxy(proxy, trust_env)
+    if description is None or description in _logged_proxy_descriptions:
+        return
+    _logged_proxy_descriptions.add(description)
+    Logger.info(f"网络请求将经由代理：{description}（如需直连可使用 --proxy no）")
 
 
 class FetcherContext:
@@ -346,6 +384,7 @@ def create_client(
     http2: bool = True,
     verify: bool = False,
 ) -> AsyncClient:
+    _log_effective_proxy_once(proxy, trust_env)
     client = httpx.AsyncClient(
         **_client_kwargs(
             headers=headers,
@@ -370,6 +409,7 @@ def create_sync_client(
     http2: bool = True,
     verify: bool = False,
 ) -> httpx.Client:
+    _log_effective_proxy_once(proxy, trust_env)
     client = httpx.Client(
         **_client_kwargs(
             headers=headers,

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -16,6 +16,7 @@ from yutto.utils.fetcher import (
     create_sync_client,
     describe_effective_proxy,
     resolve_proxy,
+    sanitize_proxy_url,
 )
 from yutto.utils.functional import as_sync
 
@@ -162,7 +163,16 @@ async def test_touch_url_cache_is_scoped_to_context_and_client():
     assert second_client.calls == 1
 
 
-_PROXY_ENV_NAMES = ("ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY", "all_proxy", "https_proxy", "http_proxy")
+_PROXY_ENV_NAMES = (
+    "ALL_PROXY",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+    "all_proxy",
+    "https_proxy",
+    "http_proxy",
+    "no_proxy",
+)
 
 
 def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -179,7 +189,7 @@ def test_describe_effective_proxy_prefers_explicit_proxy(monkeypatch: pytest.Mon
 def test_describe_effective_proxy_names_the_env_variable(monkeypatch: pytest.MonkeyPatch):
     _clear_proxy_env(monkeypatch)
     monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:3067")
-    assert describe_effective_proxy(None, True) == "http://127.0.0.1:3067（来自环境变量 HTTPS_PROXY）"
+    assert describe_effective_proxy(None, True) == "HTTPS 请求 → http://127.0.0.1:3067（来自环境变量 HTTPS_PROXY）"
 
 
 def test_describe_effective_proxy_ignores_env_without_trust_env(monkeypatch: pytest.MonkeyPatch):
@@ -192,6 +202,78 @@ def test_describe_effective_proxy_ignores_env_without_trust_env(monkeypatch: pyt
 def test_describe_effective_proxy_without_any_proxy(monkeypatch: pytest.MonkeyPatch):
     _clear_proxy_env(monkeypatch)
     assert describe_effective_proxy(None, True) is None
+
+
+def test_describe_effective_proxy_masks_credentials():
+    # 显式代理与环境代理的 userinfo 都不能进入描述（进而不能进入日志与去重 key）
+    assert describe_effective_proxy("http://user:secret@10.0.0.1:8080", True) == "http://10.0.0.1:8080"
+    description = describe_effective_proxy(None, True, environ={"ALL_PROXY": "http://user:secret@127.0.0.1:7890"})
+    assert description == "http://127.0.0.1:7890（来自环境变量 ALL_PROXY）"
+    assert "secret" not in description and "user" not in description
+
+
+def test_describe_effective_proxy_scheme_specific_beats_all_proxy():
+    # httpx 语义：HTTPS 请求优先用 HTTPS_PROXY，ALL_PROXY 仅兜底其余 scheme
+    description = describe_effective_proxy(
+        None,
+        True,
+        environ={"HTTPS_PROXY": "http://10.0.0.2:8080", "ALL_PROXY": "http://10.0.0.3:8080"},
+    )
+    assert description == (
+        "HTTPS 请求 → http://10.0.0.2:8080（来自环境变量 HTTPS_PROXY）；"
+        "HTTP 请求 → http://10.0.0.3:8080（来自环境变量 ALL_PROXY）"
+    )
+
+
+def test_describe_effective_proxy_merges_same_proxy_for_both_schemes():
+    description = describe_effective_proxy(
+        None,
+        True,
+        environ={"HTTPS_PROXY": "http://127.0.0.1:7890", "HTTP_PROXY": "http://127.0.0.1:7890"},
+    )
+    assert description == "http://127.0.0.1:7890（来自环境变量 HTTPS_PROXY、HTTP_PROXY）"
+
+
+def test_describe_effective_proxy_no_proxy_wildcard_disables_env_proxies():
+    # httpx 语义：NO_PROXY 含 * 时完全不使用环境代理
+    assert describe_effective_proxy(None, True, environ={"ALL_PROXY": "http://127.0.0.1:7890", "NO_PROXY": "*"}) is None
+
+
+def test_describe_effective_proxy_mentions_no_proxy_exceptions():
+    description = describe_effective_proxy(
+        None,
+        True,
+        environ={"ALL_PROXY": "http://127.0.0.1:7890", "NO_PROXY": "localhost,.example.com"},
+    )
+    assert description == (
+        "http://127.0.0.1:7890（来自环境变量 ALL_PROXY）；NO_PROXY=localhost,.example.com 命中的主机将直连"
+    )
+
+
+def test_describe_effective_proxy_lowercase_overrides_uppercase():
+    # urllib getproxies_environment 语义：小写变量覆盖大写变量，空值小写变量则移除代理
+    description = describe_effective_proxy(
+        None,
+        True,
+        environ={"HTTP_PROXY": "http://10.0.0.4:8080", "http_proxy": "http://10.0.0.5:8080"},
+    )
+    assert description == "HTTP 请求 → http://10.0.0.5:8080（来自环境变量 http_proxy）"
+    assert describe_effective_proxy(None, True, environ={"HTTPS_PROXY": "http://10.0.0.6:8080", "https_proxy": ""}) is (
+        None
+    )
+
+
+def test_describe_effective_proxy_normalizes_schemeless_values():
+    # httpx 会为无 scheme 的代理值补全 http://
+    description = describe_effective_proxy(None, True, environ={"ALL_PROXY": "127.0.0.1:7890"})
+    assert description == "http://127.0.0.1:7890（来自环境变量 ALL_PROXY）"
+
+
+def test_sanitize_proxy_url():
+    assert sanitize_proxy_url("http://user:secret@10.0.0.1:8080") == "http://10.0.0.1:8080"
+    assert sanitize_proxy_url("socks5://user@127.0.0.1:1080") == "socks5://127.0.0.1:1080"
+    assert sanitize_proxy_url("http://127.0.0.1:8080") == "http://127.0.0.1:8080"
+    assert sanitize_proxy_url("127.0.0.1:7890") == "127.0.0.1:7890"
 
 
 @as_sync

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -8,7 +8,15 @@ import httpx
 import pytest
 from returns.result import Failure, Success
 
-from yutto.utils.fetcher import Fetcher, FetcherContext, create_client, create_sync_client, resolve_proxy
+from yutto.utils.fetcher import (
+    Fetcher,
+    FetcherContext,
+    MaxRetry,
+    create_client,
+    create_sync_client,
+    describe_effective_proxy,
+    resolve_proxy,
+)
 from yutto.utils.functional import as_sync
 
 
@@ -102,7 +110,7 @@ async def test_fetch_bin_keeps_non_success_status_as_success_none():
 async def test_fetch_json_retries_non_success_status():
     match await Fetcher.fetch_json(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
         case Failure(error):
-            assert error.message == "超出最大重试次数！"
+            assert error.message == "超出最大重试次数！（最后错误：HTTPStatusError）"
         case result:
             pytest.fail(f"expected Failure, got {result}")
 
@@ -152,3 +160,49 @@ async def test_touch_url_cache_is_scoped_to_context_and_client():
     )
     assert first_client.calls == 2
     assert second_client.calls == 1
+
+
+_PROXY_ENV_NAMES = ("ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY", "all_proxy", "https_proxy", "http_proxy")
+
+
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _PROXY_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_describe_effective_proxy_prefers_explicit_proxy(monkeypatch: pytest.MonkeyPatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1080")
+    assert describe_effective_proxy("http://10.0.0.1:8080", True) == "http://10.0.0.1:8080"
+
+
+def test_describe_effective_proxy_names_the_env_variable(monkeypatch: pytest.MonkeyPatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:3067")
+    assert describe_effective_proxy(None, True) == "http://127.0.0.1:3067（来自环境变量 HTTPS_PROXY）"
+
+
+def test_describe_effective_proxy_ignores_env_without_trust_env(monkeypatch: pytest.MonkeyPatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:3067")
+    assert describe_effective_proxy(None, False) is None
+    assert describe_effective_proxy(None, True) is not None
+
+
+def test_describe_effective_proxy_without_any_proxy(monkeypatch: pytest.MonkeyPatch):
+    _clear_proxy_env(monkeypatch)
+    assert describe_effective_proxy(None, True) is None
+
+
+@as_sync
+async def test_max_retry_failure_carries_last_error_type():
+    @MaxRetry(max_retry=0)
+    async def always_connect_error() -> None:
+        raise httpx.ConnectError("")
+
+    result = await always_connect_error()
+    match result:
+        case Failure(error):
+            assert "ConnectError" in str(error)
+        case _:
+            pytest.fail(f"expected Failure, got {result}")


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## 动机

httpx 在 `trust_env`（即默认的 `--proxy auto`）下会静默读取 `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` 环境变量。当环境里残留了一个不可用的代理（常见于代理客户端退出后没清理环境变量、或 shell 配置里写死了 export）时，yutto 的所有请求都会走这个坏代理，而用户能看到的只有裸的 `ConnectError` 重试与「超出最大重试次数！」——日志里没有任何信息指向代理，非常难排查（我们在 yutto-uiya 的用户环境里实际踩到：代理客户端已关闭，但 `HTTPS_PROXY` 仍指向已失效的 `127.0.0.1:3067`，解析随机失败，排查了很久才定位到环境变量）。

### 复现

```bash
# 设置一个并不存在的环境变量代理（模拟代理客户端退出后残留）
export HTTPS_PROXY=http://127.0.0.1:9999   # Windows: set HTTPS_PROXY=http://127.0.0.1:9999

yutto "https://www.bilibili.com/video/BV1..."
```

修改前的输出（完全看不出代理参与其中）：

```
 WARN  抓取失败（ConnectError），正在重试，剩余 2 次
 WARN  抓取失败（ConnectError），正在重试，剩余 1 次
 ERROR 超出最大重试次数！
```

## 解决方案

两处小改动，都在 `utils/fetcher.py`：

1. **创建 client 时把实际生效的代理说清楚**（`create_client` / `create_sync_client` 各一行调用）：显式 `--proxy` 直接展示；`trust_env` 下命中环境变量时把变量名一并带上。同一来源只提示一次，不刷屏。
2. **`MaxRetryError` 携带最后一次底层错误类型**：重试循环记录最后一次失败原因（`ConnectError` / 抓取超时 等），最终错误从「超出最大重试次数！」变为「超出最大重试次数！（最后错误：ConnectError）」。CLI 与 server 模式的任务级错误信息同样受益。

修改后的输出（同样的复现命令）：

```
 INFO  网络请求将经由代理：http://127.0.0.1:9999（来自环境变量 HTTPS_PROXY）（如需直连可使用 --proxy no）
 WARN  抓取失败（ConnectError），正在重试，剩余 2 次
 WARN  抓取失败（ConnectError），正在重试，剩余 1 次
 ERROR 超出最大重试次数！（最后错误：ConnectError）
```

用户行为无任何变化：不新增参数、不改变代理选择逻辑，只是把「正在用哪个代理、从哪来的、最后到底怎么失败的」讲出来。

测试：`tests/test_utils/test_fetcher.py` 新增 4 个用例覆盖 `describe_effective_proxy`（显式代理优先 / 命中环境变量并标注变量名 / 非 trust_env 忽略环境变量 / 无代理返回 None），并覆盖重试错误消息；本地 17/17 通过，ruff 无告警。

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
