### PR TITLE
✨ feat: stream item_listed while batch extraction is still running

### DIFF
--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -118,7 +118,7 @@ yutto serve \
 
 `request` 与 `download.start` 使用完全相同的请求模型。解析任务运行在独立的单 worker runtime 中，轻量的列表解析不会排在长下载任务之后；`task.get` / `task.list` / `task.cancel` / `task.subscribe` 对两类任务统一路由。
 
-解析过程中每列出一个条目会推送一条 `item_listed` 事件，任务完成后 `result.items` 包含全部条目。条目与 `item_listed` 事件的 `data` 携带相同字段：
+解析过程中每列出一个条目会推送一条 `item_listed` 事件。对合集 / 收藏夹 / 视频列表 / 空间投稿 / 稍后再看这类列表型批量来源，事件在解析进行中就按各视频完成的先后逐条推送（长列表边解析边出现，不必等整批完成），因此事件的到达顺序可能与最终顺序不同；每个条目恰好推送一次。任务完成后 `result.items` 仍按来源的原始顺序包含全部条目，需要稳定顺序的客户端应以 `result.items` 为准。条目与 `item_listed` 事件的 `data` 携带相同字段：
 
 - `avid` / `cid`：条目标识；
 - `url`：单集原子 URL，可直接用于后续 `download.start`；

--- a/src/yutto/core/operation.py
+++ b/src/yutto/core/operation.py
@@ -5,13 +5,21 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from yutto.core.events import DownloadEvent, DownloadEventSink
     from yutto.exceptions import YuttoBaseException
+    from yutto.types import ResolvableEpisode
 
 _event_sink: ContextVar[DownloadEventSink | None] = ContextVar("yutto_download_event_sink", default=None)
 _resolve_failures: ContextVar[list[YuttoBaseException] | None] = ContextVar("yutto_resolve_failures", default=None)
+
+# resolve 模式的逐条列举钩子：batch 提取器在每个视频解析完成时把它的分集推给
+# 钩子，长列表就能边解析边在前端出现，而不是全部完成后一次性倾倒。未绑定时
+# （下载路径、未流式化的提取器）保持原有整批行为。
+_episode_listed_hook: ContextVar[Callable[[ResolvableEpisode], None] | None] = ContextVar(
+    "yutto_episode_listed_hook", default=None
+)
 
 
 @contextmanager
@@ -49,3 +57,18 @@ def report_resolve_failure(error: YuttoBaseException) -> None:
     failures = _resolve_failures.get()
     if failures is not None:
         failures.append(error)
+
+
+@contextmanager
+def bind_episode_listed_hook(hook: Callable[[ResolvableEpisode], None]) -> Iterator[None]:
+    token = _episode_listed_hook.set(hook)
+    try:
+        yield
+    finally:
+        _episode_listed_hook.reset(token)
+
+
+def notify_episode_listed(episode: ResolvableEpisode) -> None:
+    hook = _episode_listed_hook.get()
+    if hook is not None:
+        hook(episode)

--- a/src/yutto/core/operation.py
+++ b/src/yutto/core/operation.py
@@ -61,6 +61,7 @@ def report_resolve_failure(error: YuttoBaseException) -> None:
 
 @contextmanager
 def bind_episode_listed_hook(hook: Callable[[ResolvableEpisode], None]) -> Iterator[None]:
+    """在解析期间绑定逐条列举钩子；仅 resolve 路径绑定，下载路径不绑定、行为不变"""
     token = _episode_listed_hook.set(hook)
     try:
         yield
@@ -69,6 +70,11 @@ def bind_episode_listed_hook(hook: Callable[[ResolvableEpisode], None]) -> Itera
 
 
 def notify_episode_listed(episode: ResolvableEpisode) -> None:
+    """流式提取器在单个视频解析完成时立即逐条交出分集。
+
+    钩子未绑定时（下载路径、未流式化的提取器）为 no-op；resolve_items 收尾补发时
+    会跳过已经推送过的条目，每个条目恰好对外产生一次 item_listed。
+    """
     hook = _episode_listed_hook.get()
     if hook is not None:
         hook(episode)

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -9,7 +9,7 @@ from biliass import BlockOptions
 
 from yutto.api.user_info import validate_user_info
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.operation import collect_resolve_failures, emit_download_event
+from yutto.core.operation import bind_episode_listed_hook, collect_resolve_failures, emit_download_event
 from yutto.core.result import DownloadResult, ItemResult, ResolvedItem, ResolveFailure, ResolveResult
 from yutto.downloader.downloader import process_download
 from yutto.exceptions import NotLoginError, ResolveFailedError, WrongArgumentError, WrongUrlError
@@ -83,6 +83,42 @@ def show_batch_episode_title(
     return current_display_group
 
 
+def _resolved_item_from(episode: ResolvableEpisode) -> ResolvedItem:
+    info = episode.info
+    return ResolvedItem(
+        avid=str(info["avid"]),
+        cid=str(info["cid"]),
+        url=info["url"],
+        name=info["name"],
+        title=info["title"],
+        cover_url=info["cover_url"],
+        planned_path=info["path"],
+        display_group=info["display_group"],
+        uploader=info["uploader"],
+        description=info["description"],
+        tags=tuple(info["tags"]),
+    )
+
+
+def _emit_item_listed(episode: ResolvableEpisode) -> None:
+    item = _resolved_item_from(episode)
+    emit_download_event(
+        DownloadItemListed(
+            avid=item.avid,
+            cid=item.cid,
+            url=item.url,
+            name=item.name,
+            title=item.title,
+            cover_url=item.cover_url,
+            planned_path=item.planned_path,
+            display_group=item.display_group,
+            uploader=item.uploader,
+            description=item.description,
+            tags=item.tags,
+        )
+    )
+
+
 class DownloadManager:
     """Execute download requests sequentially in one shared network session."""
 
@@ -136,54 +172,31 @@ class DownloadManager:
         """List the stable episode snapshots of one request; the volatile data is never fetched.
 
         返回的 planned_path 是模板解析出的计划路径；实际下载时可能因去重而调整。
+        item_listed 逐条推送：支持流式的 batch 提取器在每个视频解析完成时经
+        notify_episode_listed 交出分集（长列表边解析边出现在前端），提取结束后
+        这里只补发未流式推送过的条目；返回列表始终保持提取器的原始顺序。
         """
-        episode_list = await self.resolve_request(client, ctx, request)
-        return await self._resolved_items_from_episodes(episode_list)
+        streamed: set[int] = set()
 
-    async def _resolved_items_from_episodes(
-        self,
-        episode_list: list[ResolvableEpisode | None],
-    ) -> list[ResolvedItem]:
+        def stream_episode(episode: ResolvableEpisode) -> None:
+            streamed.add(id(episode))
+            _emit_item_listed(episode)
+
+        with bind_episode_listed_hook(stream_episode):
+            episode_list = await self.resolve_request(client, ctx, request)
         items: list[ResolvedItem] = []
         for episode in episode_list:
             if episode is None:
                 continue
             # resolve 模式不解析 data，关闭懒协程以免其永远不被 await
             episode.data_coro.coro.close()
-            info = episode.info
-            item = ResolvedItem(
-                avid=str(info["avid"]),
-                cid=str(info["cid"]),
-                url=info["url"],
-                name=info["name"],
-                title=info["title"],
-                cover_url=info["cover_url"],
-                planned_path=info["path"],
-                display_group=info["display_group"],
-                uploader=info["uploader"],
-                description=info["description"],
-                tags=tuple(info["tags"]),
-            )
-            emit_download_event(
-                DownloadItemListed(
-                    avid=item.avid,
-                    cid=item.cid,
-                    url=item.url,
-                    name=item.name,
-                    title=item.title,
-                    cover_url=item.cover_url,
-                    planned_path=item.planned_path,
-                    display_group=item.display_group,
-                    uploader=item.uploader,
-                    description=item.description,
-                    tags=item.tags,
-                )
-            )
-            items.append(item)
-            # 大列表会在无 await 的循环里同步产生大量 item_listed；让出控制权给
-            # 事件消费者（如 server 每连接的 sender），否则超出其发送队列容量的
-            # 部分会触发 slow-consumer 断连
-            await asyncio.sleep(0)
+            if id(episode) not in streamed:
+                _emit_item_listed(episode)
+                # 未流式化的提取器仍会在这个无 await 的循环里整批产出 item_listed；
+                # 逐条让出控制权给事件消费者（如 server 每连接的 sender），
+                # 避免超出其发送队列容量触发 slow-consumer 断连
+                await asyncio.sleep(0)
+            items.append(_resolved_item_from(episode))
         return items
 
     async def process_request(

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -66,7 +66,7 @@ class CollectionExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
             if ugc_video_list is None:
                 return
             if len(ugc_video_list["pages"]) != 1:
@@ -90,6 +90,7 @@ class CollectionExtractor(BatchExtractor):
                     "{series_title}/{title}",
                 )
                 notify_episode_listed(episode)
+                await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from yutto.api.collection import get_collection_details
 from yutto.api.space import get_user_name
+from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -16,8 +17,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoListItem
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -55,50 +56,48 @@ class CollectionExtractor(BatchExtractor):
         collection_title = collection_details["title"]
         Logger.custom(collection_title, Badge("视频合集", fore="black", back="cyan"))
 
-        ugc_video_info_list: list[tuple[UgcVideoListItem, str, int]] = []
-
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(collection_details["pages"]))
         collection_details["pages"] = list(filter(lambda item: item["id"] in episodes, collection_details["pages"]))
 
         items = collection_details["pages"]
         avids = [item["avid"] for item in items]
-        ugc_video_lists = await resolve_ugc_video_lists(
+
+        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
+
+        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+            if ugc_video_list is None:
+                return
+            if len(ugc_video_list["pages"]) != 1:
+                Logger.error(f"视频合集 {collection_title} 中的视频 {items[index]['avid']} 包含多个视频！")
+            built: list[ResolvableEpisode] = []
+            for ugc_video_item in ugc_video_list["pages"]:
+                episode = make_ugc_video_episode(
+                    ctx,
+                    client,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    options,
+                    {
+                        # TODO: 关于对于 id 的优化
+                        # TODO: 关于对于 title 的优化（最好使用合集标题，而不是原来的视频标题）
+                        "series_title": collection_title,
+                        "username": username,  # 虽然默认模板的用不上，但这里可以提供一下
+                        "title": ugc_video_list["title"],
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    "{series_title}/{title}",
+                )
+                notify_episode_listed(episode)
+                built.append(episode)
+            episodes_by_index[index] = built
+
+        await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=options["publication_time_filter"],
+            on_resolved=build_episodes,
         )
-        for item, ugc_video_list in zip(items, ugc_video_lists, strict=True):
-            if ugc_video_list is None:
-                continue
-            if len(ugc_video_list["pages"]) != 1:
-                Logger.error(f"视频合集 {collection_title} 中的视频 {item['avid']} 包含多个视频！")
-            for ugc_video_item in ugc_video_list["pages"]:
-                ugc_video_info_list.append(
-                    (
-                        ugc_video_item,
-                        ugc_video_list["title"],
-                        ugc_video_list["pubdate"],
-                    )
-                )
-
-        return [
-            make_ugc_video_episode(
-                ctx,
-                client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    # TODO: 关于对于 id 的优化
-                    # TODO: 关于对于 title 的优化（最好使用合集标题，而不是原来的视频标题）
-                    "series_title": collection_title,
-                    "username": username,  # 虽然默认模板的用不上，但这里可以提供一下
-                    "title": title,
-                    "pubdate": pubdate,
-                },
-                "{series_title}/{title}",
-            )
-            for ugc_video_item, title, pubdate in ugc_video_info_list
-        ]
+        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -5,6 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_favourite_info, get_favourite_items, get_user_name
+from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -15,8 +16,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoListItem
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -45,53 +46,51 @@ class FavouritesExtractor(BatchExtractor):
         )
         Logger.custom(favourite_info["title"], Badge("收藏夹", fore="black", back="cyan"))
 
-        ugc_video_info_list: list[tuple[UgcVideoListItem, str, int, str, str | None]] = []
-
         favourite_videos = await get_favourite_items(ctx, client, self.fid)
         avids = [favourite_video["avid"] for favourite_video in favourite_videos]
-        ugc_video_lists = await resolve_ugc_video_lists(
-            ctx,
-            client,
-            avids,
-            publication_time_filter=options["publication_time_filter"],
-        )
-        for favourite_video, ugc_video_list in zip(favourite_videos, ugc_video_lists, strict=True):
+
+        # 每个视频解析完成即构建其分集并通过 notify_episode_listed 推流（resolve
+        # 模式下前端逐条看到列表）；完成顺序与收藏夹顺序无关，最终按 index 重排。
+        episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
+
+        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
             if ugc_video_list is None:
-                continue
+                return
+            favourite_video = favourite_videos[index]
             # 优先使用收藏夹 API 返回的人工标题；失效视频 title 为空时退回到 ugc 接口标题
             favourite_title = favourite_video["title"] or ugc_video_list["title"]
             is_single_page_video = len(ugc_video_list["pages"]) == 1
+            episodes: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 resolved_video_item, auto_subpath_template, display_group = normalize_favourite_video_item(
                     ugc_video_item,
                     favourite_title,
                     is_single_page_video=is_single_page_video,
                 )
-                ugc_video_info_list.append(
-                    (
-                        resolved_video_item,
-                        favourite_title,
-                        ugc_video_list["pubdate"],
-                        auto_subpath_template,
-                        display_group,
-                    )
+                episode = make_ugc_video_episode(
+                    ctx,
+                    client,
+                    resolved_video_item["avid"],
+                    resolved_video_item,
+                    options,
+                    {
+                        "title": favourite_title,
+                        "username": username,
+                        "series_title": favourite_info["title"],
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    auto_subpath_template,
+                    display_group=display_group,
                 )
+                notify_episode_listed(episode)
+                episodes.append(episode)
+            episodes_by_index[index] = episodes
 
-        return [
-            make_ugc_video_episode(
-                ctx,
-                client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    "title": title,
-                    "username": username,
-                    "series_title": favourite_info["title"],
-                    "pubdate": pubdate,
-                },
-                auto_subpath_template,
-                display_group=display_group,
-            )
-            for ugc_video_item, title, pubdate, auto_subpath_template, display_group in ugc_video_info_list
-        ]
+        await resolve_ugc_video_lists(
+            ctx,
+            client,
+            avids,
+            publication_time_filter=options["publication_time_filter"],
+            on_resolved=build_episodes,
+        )
+        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -53,7 +53,7 @@ class FavouritesExtractor(BatchExtractor):
         # 模式下前端逐条看到列表）；完成顺序与收藏夹顺序无关，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
             if ugc_video_list is None:
                 return
             favourite_video = favourite_videos[index]
@@ -83,6 +83,7 @@ class FavouritesExtractor(BatchExtractor):
                     display_group=display_group,
                 )
                 notify_episode_listed(episode)
+                await asyncio.sleep(0)
                 episodes.append(episode)
             episodes_by_index[index] = episodes
 

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -50,7 +50,7 @@ class SeriesExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
             if ugc_video_list is None:
                 return
             built: list[ResolvableEpisode] = []
@@ -70,6 +70,7 @@ class SeriesExtractor(BatchExtractor):
                     "{series_title}/{title}/{name}",
                 )
                 notify_episode_listed(episode)
+                await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -5,6 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_medialist_avids, get_medialist_title, get_user_name
+from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -14,8 +15,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoListItem
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -44,39 +45,39 @@ class SeriesExtractor(BatchExtractor):
         )
         Logger.custom(series_title, Badge("视频列表", fore="black", back="cyan"))
 
-        ugc_video_info_list: list[tuple[UgcVideoListItem, str, int]] = []
         avids = await get_medialist_avids(ctx, client, self.series_id, self.mid)
-        for ugc_video_list in await resolve_ugc_video_lists(
+
+        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
+
+        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+            if ugc_video_list is None:
+                return
+            built: list[ResolvableEpisode] = []
+            for ugc_video_item in ugc_video_list["pages"]:
+                episode = make_ugc_video_episode(
+                    ctx,
+                    client,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    options,
+                    {
+                        "series_title": series_title,
+                        "username": username,  # 虽然默认模板的用不上，但这里可以提供一下
+                        "title": ugc_video_list["title"],
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    "{series_title}/{title}/{name}",
+                )
+                notify_episode_listed(episode)
+                built.append(episode)
+            episodes_by_index[index] = built
+
+        await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=options["publication_time_filter"],
-        ):
-            if ugc_video_list is None:
-                continue
-            for ugc_video_item in ugc_video_list["pages"]:
-                ugc_video_info_list.append(
-                    (
-                        ugc_video_item,
-                        ugc_video_list["title"],
-                        ugc_video_list["pubdate"],
-                    )
-                )
-
-        return [
-            make_ugc_video_episode(
-                ctx,
-                client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    "series_title": series_title,
-                    "username": username,  # 虽然默认模板的用不上，但这里可以提供一下
-                    "title": title,
-                    "pubdate": pubdate,
-                },
-                "{series_title}/{title}/{name}",
-            )
-            for ugc_video_item, title, pubdate in ugc_video_info_list
-        ]
+            on_resolved=build_episodes,
+        )
+        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -4,6 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_all_favourites, get_favourite_items, get_user_name
+from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -14,8 +15,9 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoListItem
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.api.space import FavouriteVideoData
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -39,57 +41,66 @@ class UserAllFavouritesExtractor(BatchExtractor):
         username = await get_user_name(ctx, client, self.mid)
         Logger.custom(username, Badge("用户收藏夹", fore="black", back="cyan"))
 
-        ugc_video_info_list: list[tuple[UgcVideoListItem, str, int, str, str, str | None]] = []
+        all_episodes: list[ResolvableEpisode | None] = []
 
         for fav in await get_all_favourites(ctx, client, self.mid):
             series_title = fav["title"]
             fid = fav["fid"]
             favourite_videos = await get_favourite_items(ctx, client, fid)
             avids = [favourite_video["avid"] for favourite_video in favourite_videos]
-            ugc_video_lists = await resolve_ugc_video_lists(
-                ctx,
-                client,
-                avids,
-                publication_time_filter=options["publication_time_filter"],
-            )
-            for favourite_video, ugc_video_list in zip(favourite_videos, ugc_video_lists, strict=True):
+
+            # 逐视频解析完成即构建分集并推流（notify_episode_listed），收藏夹内按 index 重排。
+            # 回调在本轮循环内就被消费；循环变量经默认参数绑定（B023）。
+            episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
+
+            def build_episodes(
+                index: int,
+                _avid: AvId,
+                ugc_video_list: UgcVideoList | None,
+                *,
+                _favourite_videos: list[FavouriteVideoData] = favourite_videos,
+                _series_title: str = series_title,
+                _episodes_by_index: dict[int, list[ResolvableEpisode]] = episodes_by_index,
+            ) -> None:
                 if ugc_video_list is None:
-                    continue
+                    return
+                favourite_video = _favourite_videos[index]
                 # 优先使用收藏夹 API 返回的人工标题；失效视频 title 为空时退回到 ugc 接口标题
                 favourite_title = favourite_video["title"] or ugc_video_list["title"]
                 is_single_page_video = len(ugc_video_list["pages"]) == 1
+                built: list[ResolvableEpisode] = []
                 for ugc_video_item in ugc_video_list["pages"]:
                     resolved_video_item, auto_subpath_template, display_group = normalize_favourite_video_item(
                         ugc_video_item,
                         favourite_title,
                         is_single_page_video=is_single_page_video,
                     )
-                    ugc_video_info_list.append(
-                        (
-                            resolved_video_item,
-                            favourite_title,
-                            ugc_video_list["pubdate"],
-                            series_title,
-                            auto_subpath_template,
-                            display_group,
-                        )
+                    episode = make_ugc_video_episode(
+                        ctx,
+                        client,
+                        resolved_video_item["avid"],
+                        resolved_video_item,
+                        options,
+                        {
+                            "title": favourite_title,
+                            "username": username,
+                            "series_title": _series_title,
+                            "pubdate": ugc_video_list["pubdate"],
+                        },
+                        auto_subpath_template,
+                        display_group=display_group,
                     )
+                    notify_episode_listed(episode)
+                    built.append(episode)
+                _episodes_by_index[index] = built
 
-        return [
-            make_ugc_video_episode(
+            await resolve_ugc_video_lists(
                 ctx,
                 client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    "title": title,
-                    "username": username,
-                    "series_title": series_title,
-                    "pubdate": pubdate,
-                },
-                auto_subpath_template,
-                display_group=display_group,
+                avids,
+                publication_time_filter=options["publication_time_filter"],
+                on_resolved=build_episodes,
             )
-            for ugc_video_item, title, pubdate, series_title, auto_subpath_template, display_group in ugc_video_info_list
-        ]
+            all_episodes.extend(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, []))
+
+        return all_episodes

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import TYPE_CHECKING
 
@@ -53,7 +54,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
             # 回调在本轮循环内就被消费；循环变量经默认参数绑定（B023）。
             episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-            def build_episodes(
+            async def build_episodes(
                 index: int,
                 _avid: AvId,
                 ugc_video_list: UgcVideoList | None,
@@ -91,6 +92,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
                         display_group=display_group,
                     )
                     notify_episode_listed(episode)
+                    await asyncio.sleep(0)
                     built.append(episode)
                 _episodes_by_index[index] = built
 

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import TYPE_CHECKING
 
@@ -51,7 +52,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
             if ugc_video_list is None:
                 return
             built: list[ResolvableEpisode] = []
@@ -70,6 +71,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
                     "{username}的全部投稿视频/{title}/{name}",
                 )
                 notify_episode_listed(episode)
+                await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -4,6 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_user_name, get_user_space_all_videos_avids
+from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -13,8 +14,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoListItem
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -38,7 +39,6 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         username = await get_user_name(ctx, client, self.mid)
         Logger.custom(username, Badge("UP 主投稿视频", fore="black", back="cyan"))
 
-        ugc_video_info_list: list[tuple[UgcVideoListItem, str, int]] = []
         publication_time_filter = options["publication_time_filter"]
         avids = await get_user_space_all_videos_avids(
             ctx,
@@ -47,36 +47,37 @@ class UserAllUgcVideosExtractor(BatchExtractor):
             pubdate_filter=publication_time_filter.matches,
             stop_before_timestamp=publication_time_filter.start_timestamp,
         )
-        for ugc_video_list in await resolve_ugc_video_lists(
+
+        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
+
+        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+            if ugc_video_list is None:
+                return
+            built: list[ResolvableEpisode] = []
+            for ugc_video_item in ugc_video_list["pages"]:
+                episode = make_ugc_video_episode(
+                    ctx,
+                    client,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    options,
+                    {
+                        "title": ugc_video_list["title"],
+                        "username": username,
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    "{username}的全部投稿视频/{title}/{name}",
+                )
+                notify_episode_listed(episode)
+                built.append(episode)
+            episodes_by_index[index] = built
+
+        await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=publication_time_filter,
-        ):
-            if ugc_video_list is None:
-                continue
-            for ugc_video_item in ugc_video_list["pages"]:
-                ugc_video_info_list.append(
-                    (
-                        ugc_video_item,
-                        ugc_video_list["title"],
-                        ugc_video_list["pubdate"],
-                    )
-                )
-
-        return [
-            make_ugc_video_episode(
-                ctx,
-                client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    "title": title,
-                    "username": username,
-                    "pubdate": pubdate,
-                },
-                "{username}的全部投稿视频/{title}/{name}",
-            )
-            for ugc_video_item, title, pubdate in ugc_video_info_list
-        ]
+            on_resolved=build_episodes,
+        )
+        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import TYPE_CHECKING
 
@@ -46,7 +47,7 @@ class UserWatchLaterExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
             if ugc_video_list is None:
                 return
             built: list[ResolvableEpisode] = []
@@ -66,6 +67,7 @@ class UserWatchLaterExtractor(BatchExtractor):
                     "稍后再看/{title}/{name}",
                 )
                 notify_episode_listed(episode)
+                await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -4,7 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_watch_later_avids
-from yutto.core.operation import report_resolve_failure
+from yutto.core.operation import notify_episode_listed, report_resolve_failure
 from yutto.exceptions import NotLoginError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
@@ -14,8 +14,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoListItem
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -36,8 +36,6 @@ class UserWatchLaterExtractor(BatchExtractor):
     ) -> list[ResolvableEpisode | None]:
         Logger.custom("当前用户", Badge("稍后再看", fore="black", back="cyan"))
 
-        ugc_video_info_list: list[tuple[UgcVideoListItem, str, int, str]] = []
-
         try:
             avid_list = await get_watch_later_avids(ctx, client)
         except NotLoginError as e:
@@ -45,38 +43,37 @@ class UserWatchLaterExtractor(BatchExtractor):
             report_resolve_failure(e)
             return []
 
-        for ugc_video_list in await resolve_ugc_video_lists(
+        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
+
+        def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
+            if ugc_video_list is None:
+                return
+            built: list[ResolvableEpisode] = []
+            for ugc_video_item in ugc_video_list["pages"]:
+                episode = make_ugc_video_episode(
+                    ctx,
+                    client,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    options,
+                    {
+                        "title": ugc_video_list["title"],
+                        "username": "",
+                        "series_title": "稍后再看",
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    "稍后再看/{title}/{name}",
+                )
+                notify_episode_listed(episode)
+                built.append(episode)
+            episodes_by_index[index] = built
+
+        await resolve_ugc_video_lists(
             ctx,
             client,
             avid_list,
             publication_time_filter=options["publication_time_filter"],
-        ):
-            if ugc_video_list is None:
-                continue
-            for ugc_video_item in ugc_video_list["pages"]:
-                ugc_video_info_list.append(
-                    (
-                        ugc_video_item,
-                        ugc_video_list["title"],
-                        ugc_video_list["pubdate"],
-                        "稍后再看",
-                    )
-                )
-
-        return [
-            make_ugc_video_episode(
-                ctx,
-                client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    "title": title,
-                    "username": "",
-                    "series_title": series_title,
-                    "pubdate": pubdate,
-                },
-                "稍后再看/{title}/{name}",
-            )
-            for ugc_video_item, title, pubdate, series_title in ugc_video_info_list
-        ]
+            on_resolved=build_episodes,
+        )
+        return [episode for index in range(len(avid_list)) for episode in episodes_by_index.get(index, [])]

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -32,13 +32,16 @@ async def resolve_ugc_video_lists(
 
     并发度由 ctx 中已有的 fetch semaphore 控制（Fetcher 的每个请求都会经过 ctx.fetch_guard()），
     这里无需额外限流；被时间过滤或解析失败（NotFoundError / NoAccessPermissionError /
-    MaxRetryError）的视频以 None 占位，不会中断整批解析，其余未预期的异常仍会向外抛出。
+    MaxRetryError）的视频以 None 占位，不会中断整批解析。
 
-    on_resolved 在每个视频解析完成时按完成顺序被 await（参数为 (index, avid, result)，
-    index 是该 avid 在入参列表中的位置）——提取器用它把已就绪的条目立即推流给前端，
-    不必等整批 gather 结束。回调约定在每推送一个分集后让出一次控制权（内置提取器均如此），
-    事件生产对消费者（如 server 每连接的 sender）始终可调度，单个超多分 P 的视频
-    也不会产生超出发送队列容量的同步 burst。
+    on_resolved 由单一 publisher 串行 await：解析仍然并发，但已完成的结果按完成顺序
+    逐个交付（参数为 (index, avid, result)，index 是该 avid 在入参列表中的位置）。
+    多个同时就绪的视频不会并发发布、多分 P 视频的事件不会彼此穿插；回调约定在每推送
+    一个分集后让出一次控制权（内置提取器均如此），因此事件生产对消费者（如 server
+    每连接的 sender）始终可调度，不受同时完成的视频数或单视频分 P 数影响。
+
+    任何未预期的异常（包括回调自身抛出的）会先取消并等待其余子任务再向外抛出——
+    函数返回或抛错后不会再有回调或事件发生；单个异常直接抛原始异常，保持稳定错误码。
     """
 
     async def resolve_one(avid: AvId) -> UgcVideoList | None:
@@ -60,10 +63,30 @@ async def resolve_ugc_video_lists(
             report_resolve_failure(e)
             return None
 
-    async def resolve_and_notify(index: int, avid: AvId) -> UgcVideoList | None:
-        result = await resolve_one(avid)
-        if on_resolved is not None:
-            await on_resolved(index, avid, result)
-        return result
+    results: list[UgcVideoList | None] = [None] * len(avids)
+    completed: asyncio.Queue[tuple[int, AvId, UgcVideoList | None]] = asyncio.Queue()
 
-    return await asyncio.gather(*[resolve_and_notify(index, avid) for index, avid in enumerate(avids)])
+    async def resolve_into(index: int, avid: AvId) -> None:
+        result = await resolve_one(avid)
+        results[index] = result
+        completed.put_nowait((index, avid, result))
+
+    async def publish_completed(deliver: Callable[[int, AvId, UgcVideoList | None], Awaitable[None]]) -> None:
+        # 单一 producer：完成一个交付一个，publisher 的每次 await 都给消费者排空队列的机会
+        for _ in range(len(avids)):
+            index, avid, result = await completed.get()
+            await deliver(index, avid, result)
+
+    try:
+        async with asyncio.TaskGroup() as task_group:
+            for index, avid in enumerate(avids):
+                task_group.create_task(resolve_into(index, avid))
+            if on_resolved is not None:
+                task_group.create_task(publish_completed(on_resolved))
+    except ExceptionGroup as error_group:
+        # 与先前的 gather 语义对齐：单个失败直接抛原始异常（wire 上保留其稳定错误码），
+        # 仅多个子任务同时失败时才抛出 ExceptionGroup
+        if len(error_group.exceptions) == 1:
+            raise error_group.exceptions[0] from None
+        raise
+    return results

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -10,6 +10,8 @@ from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
@@ -24,12 +26,17 @@ async def resolve_ugc_video_lists(
     avids: list[AvId],
     *,
     publication_time_filter: PublicationTimeFilter,
+    on_resolved: Callable[[int, AvId, UgcVideoList | None], None] | None = None,
 ) -> list[UgcVideoList | None]:
     """并发解析一批视频的分 P 列表，结果顺序与 avids 一致
 
     并发度由 ctx 中已有的 fetch semaphore 控制（Fetcher 的每个请求都会经过 ctx.fetch_guard()），
     这里无需额外限流；被时间过滤或解析失败（NotFoundError / NoAccessPermissionError /
-    MaxRetryError）的视频以 None 占位，不会中断整批解析，其余未预期的异常仍会向外抛出
+    MaxRetryError）的视频以 None 占位，不会中断整批解析，其余未预期的异常仍会向外抛出。
+
+    on_resolved 在**每个视频解析完成时**按完成顺序被调用（参数为 (index, avid, result)，
+    index 是该 avid 在入参列表中的位置）——提取器用它把已就绪的条目立即推流给前端，
+    不必等整批 gather 结束。
     """
 
     async def resolve_one(avid: AvId) -> UgcVideoList | None:
@@ -51,4 +58,13 @@ async def resolve_ugc_video_lists(
             report_resolve_failure(e)
             return None
 
-    return await asyncio.gather(*[resolve_one(avid) for avid in avids])
+    async def resolve_and_notify(index: int, avid: AvId) -> UgcVideoList | None:
+        result = await resolve_one(avid)
+        if on_resolved is not None:
+            on_resolved(index, avid, result)
+            # 回调内的逐分集推流是同步的；每个视频之后让出控制权，
+            # 给事件消费者（如 server 的 sender）排空发送队列的机会
+            await asyncio.sleep(0)
+        return result
+
+    return await asyncio.gather(*[resolve_and_notify(index, avid) for index, avid in enumerate(avids)])

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -34,7 +34,7 @@ async def resolve_ugc_video_lists(
     这里无需额外限流；被时间过滤或解析失败（NotFoundError / NoAccessPermissionError /
     MaxRetryError）的视频以 None 占位，不会中断整批解析，其余未预期的异常仍会向外抛出。
 
-    on_resolved 在**每个视频解析完成时**按完成顺序被 await（参数为 (index, avid, result)，
+    on_resolved 在每个视频解析完成时按完成顺序被 await（参数为 (index, avid, result)，
     index 是该 avid 在入参列表中的位置）——提取器用它把已就绪的条目立即推流给前端，
     不必等整批 gather 结束。回调约定在每推送一个分集后让出一次控制权（内置提取器均如此），
     事件生产对消费者（如 server 每连接的 sender）始终可调度，单个超多分 P 的视频

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -10,7 +10,7 @@ from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
 
     import httpx
 
@@ -26,7 +26,7 @@ async def resolve_ugc_video_lists(
     avids: list[AvId],
     *,
     publication_time_filter: PublicationTimeFilter,
-    on_resolved: Callable[[int, AvId, UgcVideoList | None], None] | None = None,
+    on_resolved: Callable[[int, AvId, UgcVideoList | None], Awaitable[None]] | None = None,
 ) -> list[UgcVideoList | None]:
     """并发解析一批视频的分 P 列表，结果顺序与 avids 一致
 
@@ -34,9 +34,11 @@ async def resolve_ugc_video_lists(
     这里无需额外限流；被时间过滤或解析失败（NotFoundError / NoAccessPermissionError /
     MaxRetryError）的视频以 None 占位，不会中断整批解析，其余未预期的异常仍会向外抛出。
 
-    on_resolved 在**每个视频解析完成时**按完成顺序被调用（参数为 (index, avid, result)，
+    on_resolved 在**每个视频解析完成时**按完成顺序被 await（参数为 (index, avid, result)，
     index 是该 avid 在入参列表中的位置）——提取器用它把已就绪的条目立即推流给前端，
-    不必等整批 gather 结束。
+    不必等整批 gather 结束。回调约定在每推送一个分集后让出一次控制权（内置提取器均如此），
+    事件生产对消费者（如 server 每连接的 sender）始终可调度，单个超多分 P 的视频
+    也不会产生超出发送队列容量的同步 burst。
     """
 
     async def resolve_one(avid: AvId) -> UgcVideoList | None:
@@ -61,10 +63,7 @@ async def resolve_ugc_video_lists(
     async def resolve_and_notify(index: int, avid: AvId) -> UgcVideoList | None:
         result = await resolve_one(avid)
         if on_resolved is not None:
-            on_resolved(index, avid, result)
-            # 回调内的逐分集推流是同步的；每个视频之后让出控制权，
-            # 给事件消费者（如 server 的 sender）排空发送队列的机会
-            await asyncio.sleep(0)
+            await on_resolved(index, avid, result)
         return result
 
     return await asyncio.gather(*[resolve_and_notify(index, avid) for index, avid in enumerate(avids)])

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -9,7 +9,12 @@ from returns.result import Success
 
 import yutto.download_manager as download_manager_module
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.operation import bind_download_event_sink, collect_resolve_failures, report_resolve_failure
+from yutto.core.operation import (
+    bind_download_event_sink,
+    collect_resolve_failures,
+    notify_episode_listed,
+    report_resolve_failure,
+)
 from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem, ResolveFailure, ResolveResult
 from yutto.download_manager import DownloadManager
@@ -132,6 +137,61 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
             tags=("标签A", "标签B"),
         ),
     ]
+
+
+@as_sync
+async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypatch: pytest.MonkeyPatch):
+    """流式提取器经 notify_episode_listed 提前推送的条目不会被收尾补发重复。"""
+
+    async def noop() -> EpisodeData | None:
+        return None
+
+    streamed = ResolvableEpisode(info=make_info("P1", display_group="标题"), data_coro=CoroutineWrapper(noop()))
+    late = ResolvableEpisode(info=make_info("P2", display_group="标题"), data_coro=CoroutineWrapper(noop()))
+
+    class FakeExtractor:
+        def resolve_shortcut(self, url: str) -> tuple[bool, str]:
+            return True, f"https://example.com/{url}"
+
+        def match(self, url: str) -> bool:
+            return url == "https://example.com/BV1stream"
+
+        async def __call__(
+            self,
+            ctx: FetcherContext,
+            client: httpx.AsyncClient,
+            options: ExtractorOptions,
+        ) -> list[ResolvableEpisode | None]:
+            # 流式提取器：解析过程中先推送 P1；P2 留给 resolve_items 收尾补发
+            notify_episode_listed(streamed)
+            return [streamed, late]
+
+    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+        return True
+
+    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+        return Success(url)
+
+    monkeypatch.setattr(download_manager_module, "UgcVideoExtractor", FakeExtractor)
+    monkeypatch.setattr(download_manager_module, "validate_user_info", fake_validate_user_info)
+    monkeypatch.setattr(Fetcher, "get_redirected_url", fake_get_redirected_url)
+
+    manager = DownloadManager()
+    sink = RecordingEventSink()
+    client = cast("httpx.AsyncClient", object())
+    request = DownloadRequest.model_validate({"source": {"url": "BV1stream"}})
+
+    with bind_download_event_sink(sink):
+        items = await manager.resolve_items(client, FetcherContext(), request)
+
+    listed = [event for event in sink.events if isinstance(event, DownloadItemListed)]
+    # 每条恰好一次：流式推送的 P1 在前（提取中），P2 收尾补发
+    assert [event.name for event in listed] == ["P1", "P2"]
+    # 返回列表保持提取器给出的顺序
+    assert [item.name for item in items] == ["P1", "P2"]
+    # 两个懒协程都被关闭
+    assert inspect.getcoroutinestate(streamed.data_coro.coro) == inspect.CORO_CLOSED
+    assert inspect.getcoroutinestate(late.data_coro.coro) == inspect.CORO_CLOSED
 
 
 class _FakeClientContext:

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -371,6 +372,40 @@ async def test_resolve_ugc_video_lists_reports_expected_failures(monkeypatch: py
     # 失败以 None 占位、顺序保持，同时结构化上报 —— 收藏夹等批量 extractor 丢弃 None 前信息不再丢失
     assert results == [None, fake_list]
     assert [type(error).__name__ for error in failures] == ["MaxRetryError"]
+
+
+@as_sync
+async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pytest.MonkeyPatch):
+    fake_list = {"title": "视频", "pubdate": 1700000000, "avid": AId("2"), "pages": []}
+
+    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+        return fake_list
+
+    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+        return Success(None)
+
+    monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
+    monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
+
+    calls: list[tuple[int, str, bool]] = []
+
+    async def on_resolved(index: int, avid: object, result: object) -> None:
+        calls.append((index, str(avid), result is not None))
+        # 契约：回调是异步的，逐分集的让出由回调自身负责（内置提取器均如此）
+        await asyncio.sleep(0)
+
+    client = cast("httpx.AsyncClient", object())
+    results = await resolve_ugc_video_lists(
+        FetcherContext(),
+        client,
+        [AId("1"), AId("2")],
+        publication_time_filter=PublicationTimeFilter.from_strings(None, None),
+        on_resolved=on_resolved,
+    )
+
+    # 每个视频恰好触发一次 await 回调，携带 (入参序 index, avid, 解析结果)
+    assert len(results) == 2
+    assert sorted(calls) == [(0, "1", True), (1, "2", True)]
 
 
 @as_sync

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -409,6 +409,81 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
 
 
 @as_sync
+async def test_resolve_ugc_video_lists_cancels_siblings_on_fatal_error(monkeypatch: pytest.MonkeyPatch):
+    first_started = asyncio.Event()
+
+    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+        if str(avid) == "1":
+            first_started.set()
+            await asyncio.sleep(0.05)
+            return {"title": "视频 1", "pubdate": 1700000000, "avid": AId("1"), "pages": []}
+        raise RuntimeError("boom")
+
+    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+        return Success(None)
+
+    monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
+    monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
+
+    calls: list[int] = []
+
+    async def on_resolved(index: int, avid: object, result: object) -> None:
+        calls.append(index)
+
+    client = cast("httpx.AsyncClient", object())
+    # 单个未预期异常直接抛原始异常（而非 ExceptionGroup），wire 错误类型保持稳定
+    with pytest.raises(RuntimeError, match="boom"):
+        await resolve_ugc_video_lists(
+            FetcherContext(),
+            client,
+            [AId("1"), AId("2")],
+            publication_time_filter=PublicationTimeFilter.from_strings(None, None),
+            on_resolved=on_resolved,
+        )
+
+    # fatal error 会取消并等待兄弟协程：函数抛错后不会再有任何回调发生
+    assert first_started.is_set()
+    assert calls == []
+    await asyncio.sleep(0.1)
+    assert calls == []
+
+
+@as_sync
+async def test_resolve_ugc_video_lists_cancels_workers_when_callback_fails(monkeypatch: pytest.MonkeyPatch):
+    resolved: list[str] = []
+
+    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+        if str(avid) == "2":
+            await asyncio.sleep(0.05)
+        resolved.append(str(avid))
+        return {"title": str(avid), "pubdate": 1700000000, "avid": avid, "pages": []}
+
+    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+        return Success(None)
+
+    monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
+    monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
+
+    async def on_resolved(index: int, avid: object, result: object) -> None:
+        raise RuntimeError("callback boom")
+
+    client = cast("httpx.AsyncClient", object())
+    with pytest.raises(RuntimeError, match="callback boom"):
+        await resolve_ugc_video_lists(
+            FetcherContext(),
+            client,
+            [AId("1"), AId("2")],
+            publication_time_filter=PublicationTimeFilter.from_strings(None, None),
+            on_resolved=on_resolved,
+        )
+
+    # 回调自身失败同样取消其余 worker：慢的 avid 2 不会再完成解析
+    assert resolved == ["1"]
+    await asyncio.sleep(0.1)
+    assert resolved == ["1"]
+
+
+@as_sync
 async def test_execute_resolve_keeps_genuinely_empty_source_as_success(monkeypatch: pytest.MonkeyPatch):
     class EmptySourceExtractor(_ShortcutExtractorBase):
         async def __call__(

--- a/tests/test_server/test_websocket.py
+++ b/tests/test_server/test_websocket.py
@@ -7,12 +7,14 @@ from itertools import count
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
+from returns.result import Success
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 from websockets.typing import Origin
 
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ResolveResult
+from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.runtime import TaskContext, TaskRuntime, TaskSnapshot, TaskState, monotonic_seq_allocator
 from yutto.server.websocket import (
     WebSocketServerOptions,
@@ -20,6 +22,9 @@ from yutto.server.websocket import (
     _SlowConsumerCloser,
     _task_snapshot_order,
 )
+from yutto.types import AId
+from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
 pytestmark = pytest.mark.processor
@@ -111,6 +116,45 @@ class FakeResolveTaskApi:
             # 与修复后的 DownloadManager.resolve_items 一致：事件生产逐条让出控制权
             await asyncio.sleep(0)
         return ResolveResult(items=())
+
+
+class BatchStreamingResolveApi(FakeResolveTaskApi):
+    """经真实 resolve_ugc_video_lists 推流的 resolve 服务，复现生产端的完整事件路径"""
+
+    def __init__(self, *, video_count: int, pages_per_video: int) -> None:
+        super().__init__()
+        self.video_count = video_count
+        self.pages_per_video = pages_per_video
+
+    async def _run(self, request: DownloadRequest, context: TaskContext) -> ResolveResult:
+        await self.release.wait()
+
+        async def on_resolved(index: int, avid: object, result: object) -> None:
+            # 模拟内置提取器的回调：逐分集 emit 并让出控制权
+            for page in range(self.pages_per_video):
+                context.emit("item_listed", {"avid": str(avid), "page": page})
+                await asyncio.sleep(0)
+
+        await resolve_ugc_video_lists(
+            FetcherContext(),
+            cast("Any", object()),
+            [AId(str(index + 1)) for index in range(self.video_count)],
+            publication_time_filter=PublicationTimeFilter.from_strings(None, None),
+            on_resolved=on_resolved,
+        )
+        return ResolveResult(items=())
+
+
+def _patch_batch_listing(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_ugc_video_list(ctx: FetcherContext, client: Any, avid: Any):
+        # 立即返回：所有视频几乎同时就绪，复现并发完成的最坏情况
+        return {"title": str(avid), "pubdate": 1700000000, "avid": avid, "pages": []}
+
+    async def fake_touch_url(ctx: FetcherContext, client: Any, url: str):
+        return Success(None)
+
+    monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
+    monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
 
 def rpc_request(request_id: int, method: str, params: object | None = None) -> str:
@@ -449,6 +493,76 @@ async def test_item_listed_burst_beyond_event_queue_is_fully_delivered():
                         break
             # 事件生产逐条让出控制权后，超过每连接发送队列（event_queue_size=128）的
             # 列表也能完整送达，而不是在第 129 条触发 slow-consumer 断连
+            assert delivered == 200
+    finally:
+        await server.close()
+
+
+@pytest.mark.processor
+@as_sync
+async def test_simultaneously_completed_videos_stream_fully_over_websocket(monkeypatch: pytest.MonkeyPatch):
+    _patch_batch_listing(monkeypatch)
+    resolve = BatchStreamingResolveApi(video_count=200, pages_per_video=1)
+    server, _, uri = await start_server(resolve_service=resolve)
+    try:
+        async with connect(uri, proxy=None) as connection:
+            await connection.send(rpc_request(1, "server.authenticate", {"token": "test-token"}))
+            await receive_json(connection)
+            await connection.send(
+                rpc_request(2, "resolve.start", {"request": {"source": {"url": "https://www.bilibili.com/video/BV1s"}}})
+            )
+            await receive_json(connection)
+            await connection.send(rpc_request(3, "task.subscribe", {"task_id": "resolve-1", "after_seq": 0}))
+            await receive_json(connection)
+
+            resolve.release.set()
+            delivered = 0
+            async with asyncio.timeout(30):
+                while True:
+                    notification = await receive_json(connection)
+                    if notification.get("method") != "task.event":
+                        continue
+                    params = notification["params"]
+                    if params["kind"] == "item_listed":
+                        delivered += 1
+                    elif params["kind"] == "state" and params["state"] == "completed":
+                        break
+            # 200 个视频同时就绪：单一 publisher 串行发布，事件不再在 sender 运行前灌满队列
+            assert delivered == 200
+    finally:
+        await server.close()
+
+
+@pytest.mark.processor
+@as_sync
+async def test_single_video_with_more_pages_than_queue_streams_fully(monkeypatch: pytest.MonkeyPatch):
+    _patch_batch_listing(monkeypatch)
+    resolve = BatchStreamingResolveApi(video_count=1, pages_per_video=200)
+    server, _, uri = await start_server(resolve_service=resolve)
+    try:
+        async with connect(uri, proxy=None) as connection:
+            await connection.send(rpc_request(1, "server.authenticate", {"token": "test-token"}))
+            await receive_json(connection)
+            await connection.send(
+                rpc_request(2, "resolve.start", {"request": {"source": {"url": "https://www.bilibili.com/video/BV1p"}}})
+            )
+            await receive_json(connection)
+            await connection.send(rpc_request(3, "task.subscribe", {"task_id": "resolve-1", "after_seq": 0}))
+            await receive_json(connection)
+
+            resolve.release.set()
+            delivered = 0
+            async with asyncio.timeout(30):
+                while True:
+                    notification = await receive_json(connection)
+                    if notification.get("method") != "task.event":
+                        continue
+                    params = notification["params"]
+                    if params["kind"] == "item_listed":
+                        delivered += 1
+                    elif params["kind"] == "state" and params["state"] == "completed":
+                        break
+            # 单视频 200 分 P（> event_queue_size=128）：逐分集让出使事件全部送达
             assert delivered == 200
     finally:
         await server.close()


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## 动机

#757 的 resolve 对合集 / 收藏夹 / 空间投稿这类列表型来源要等提取器把整个列表解析完，才一次性发出全部 `item_listed`——长列表在前端长时间空白，解析中途出错时已解析的部分也从未被交出（#757 评论区预告过的 follow-up）。

本 PR 让这些来源边解析边推流：每个视频解析完成时其分集立即以 `item_listed` 交出，前端可以在解析进行中渐进渲染列表。

## 解决方案

- `core/operation` 新增 resolve 专用的逐条列举钩子（ContextVar，与事件 sink 同一模式）：`bind_episode_listed_hook` / `notify_episode_listed`。下载路径不绑定钩子，行为不变；
- `resolve_ugc_video_lists` 增加 `on_resolved` 异步回调：解析并发进行，已完成的结果交给**单一 publisher 串行发布**——按完成顺序逐视频 await 回调，多个同时就绪的视频不会并发发布、多分 P 事件不彼此穿插；回调约定在每推送一个分集后让出一次控制权（六个内置提取器均如此）。事件生产因此对消费者始终可调度，不受同时完成的视频数或单视频分 P 数影响（延续 #757 的背压约定）；
- 生命周期：整批工作运行在 `asyncio.TaskGroup` 中，任何未预期异常（包括回调自身抛出的）先取消并等待其余子任务再向外抛出——函数返回或抛错后不再有回调或事件；单个异常直接抛原始异常，保持 #757 的稳定错误码语义；
- 六个列表型批量提取器（合集 / 收藏夹 / 全部收藏夹 / 视频列表 / 空间投稿 / 稍后再看）在回调里逐视频构建分集并 `notify_episode_listed`，最终仍按 `index` 重排——`result.items` 保持来源原始顺序；
- `resolve_items` 绑定钩子并在收尾时只补发未流式推送过的条目（`id` 去重）：每个条目恰好产生一次 `item_listed`，未流式化的提取器（单集 / 番剧 / 课程 / 多分 P 投稿）走原有整批路径，逐条让出控制权的行为保持不变；
- 与 #757 的结构化失败语义正交：`report_resolve_failure` 各上报位点不受影响，流式推送过的条目在中途失败的请求里也已经交到了前端手上；
- **文档同步**：`docs/guide/server.md` 明确流式交付语义——事件按各视频完成先后到达（到达顺序可能与最终顺序不同）、每条恰好一次、需要稳定顺序的客户端以 `result.items` 为准；钩子函数的 docstring 记录同一契约。

### 验证

- `test_resolve_items_streams_hooked_episodes_without_duplicates`：流式推送过的条目不会被收尾补发重复，返回列表保持提取器原始顺序，懒协程全部关闭；
- `test_resolve_ugc_video_lists_awaits_async_on_resolved`：异步回调契约——每个视频恰好被 await 一次，携带 (入参序 index, avid, 解析结果)；
- 真实 wire 回归（经真实 `resolve_ugc_video_lists` + 真实 WebSocket server）：200 个视频同时就绪、以及单视频 200 分 P（均 > `event_queue_size=128`），事件全部送达、连接不发生 1013 断连；
- 生命周期回归：某个 resolver 抛未预期异常、或回调自身抛异常时，其余子任务被取消并等待，函数抛错后（含再等待 100ms）不再有任何回调发生，且单个异常抛出的是原始异常类型；
- `resolve_ugc_video_lists` 的失败上报用例在流式改造后保持通过（失败仍以 `None` 占位、结构化上报、顺序保持）；
- #757 全部既有契约测试（错误语义矩阵、WebSocket 路由 / kind / burst / 共享 seq）在本分支上保持通过；本地离线套件 194 通过 / 0 失败，ruff / ty 无新增告警。

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
