### PR TITLE
♻️ refactor: defer coroutine creation

### DIFF
--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -188,8 +188,6 @@ class DownloadManager:
         for episode in episode_list:
             if episode is None:
                 continue
-            # resolve 模式不解析 data，关闭懒协程以免其永远不被 await
-            episode.data_coro.coro.close()
             if id(episode) not in streamed:
                 _emit_item_listed(episode)
                 # 未流式化的提取器仍会在这个无 await 的循环里整批产出 item_listed；
@@ -233,7 +231,7 @@ class DownloadManager:
                 await sleep_with_status_bar_refresh(request.network.download_interval)
 
             # 这时候才真正开始解析链接
-            episode_data = await episode.data_coro
+            episode_data = await episode.resolve_data()
             if episode_data is None:
                 continue
             # 保证路径唯一

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -17,7 +17,7 @@ from yutto.downloader.progressbar import show_progress
 from yutto.downloader.selector import select_audio, select_video
 from yutto.exceptions import PostprocessingError
 from yutto.media.quality import audio_quality_map, video_quality_map
-from yutto.utils.asynclib import CoroutineWrapper, first_successful_with_check
+from yutto.utils.asynclib import first_successful_with_check, make_coroutine_factory
 from yutto.utils.console.colorful import colored_string
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import write_danmaku
@@ -29,9 +29,9 @@ from yutto.utils.metadata import write_chapter_info, write_metadata
 from yutto.utils.subtitle import write_subtitle
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Iterable
+    from collections.abc import Callable, Coroutine, Iterable
     from pathlib import Path
-    from typing import Protocol
+    from typing import Any, Protocol
 
     import httpx
 
@@ -123,13 +123,20 @@ def create_mirrors_filter(banned_mirrors_pattern: str | None) -> Callable[[list[
 
 
 async def _run_download_lifecycle(
-    coroutines: Iterable[Awaitable[None]],
+    coroutine_factories: Iterable[Callable[[], Coroutine[Any, Any, None]]],
     buffers: Iterable[_DownloadBuffer],
 ) -> None:
-    """运行一次下载所需的协程，并统一回收任务与文件缓冲区。"""
-    tasks = [asyncio.ensure_future(coroutine) for coroutine in coroutines]
+    """按需创建下载任务，并统一回收任务与文件缓冲区。"""
+    tasks: list[asyncio.Task[None]] = []
     buffer_list = list(buffers)
     try:
+        for create_coroutine in coroutine_factories:
+            coroutine = create_coroutine()
+            try:
+                tasks.append(asyncio.create_task(coroutine))
+            except BaseException:
+                coroutine.close()
+                raise
         await asyncio.gather(*tasks)
         for buffer in buffer_list:
             buffer.ensure_flushed()
@@ -155,13 +162,16 @@ async def download_video_and_audio(
 
     buffers: list[AsyncFileBuffer | None] = [None, None]
     sizes: list[int | None] = [None, None]
-    coroutines_list: list[list[CoroutineWrapper[None]]] = []
-    scheduled = False
+    coroutine_factories_list: list[list[Callable[[], Coroutine[Any, Any, None]]]] = []
+    lifecycle_started = False
     mirrors_filter = create_mirrors_filter(options["banned_mirrors_pattern"])
     ctx.set_download_semaphore(options["num_workers"])
 
     async def get_size(url: str) -> int | None:
         return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
+
+    defer_download_file = make_coroutine_factory(Fetcher.download_file_with_offset)
+    defer_progress = make_coroutine_factory(show_progress)
 
     try:
         if video is not None:
@@ -171,21 +181,19 @@ async def download_video_and_audio(
                 [get_size(url) for url in [video["url"], *mirrors_filter(video["mirrors"])]]
             )
             sizes[0] = vsize
-            video_coroutines = [
-                CoroutineWrapper(
-                    Fetcher.download_file_with_offset(
-                        ctx,
-                        client,
-                        video["url"],
-                        mirrors_filter(video["mirrors"]),
-                        vbuf,
-                        offset,
-                        block_size,
-                    )
+            video_coroutine_factories: list[Callable[[], Coroutine[Any, Any, None]]] = [
+                defer_download_file(
+                    ctx,
+                    client,
+                    video["url"],
+                    mirrors_filter(video["mirrors"]),
+                    vbuf,
+                    offset,
+                    block_size,
                 )
                 for offset, block_size in slice_blocks(vbuf.written_size, vsize, options["block_size"])
             ]
-            coroutines_list.append(video_coroutines)
+            coroutine_factories_list.append(video_coroutine_factories)
 
         if audio is not None:
             abuf = await AsyncFileBuffer(audio_path, overwrite=options["overwrite"])
@@ -194,36 +202,32 @@ async def download_video_and_audio(
                 [get_size(url) for url in [audio["url"], *mirrors_filter(audio["mirrors"])]]
             )
             sizes[1] = asize
-            audio_coroutines = [
-                CoroutineWrapper(
-                    Fetcher.download_file_with_offset(
-                        ctx,
-                        client,
-                        audio["url"],
-                        mirrors_filter(audio["mirrors"]),
-                        abuf,
-                        offset,
-                        block_size,
-                    )
+            audio_coroutine_factories: list[Callable[[], Coroutine[Any, Any, None]]] = [
+                defer_download_file(
+                    ctx,
+                    client,
+                    audio["url"],
+                    mirrors_filter(audio["mirrors"]),
+                    abuf,
+                    offset,
+                    block_size,
                 )
                 for offset, block_size in slice_blocks(abuf.written_size, asize, options["block_size"])
             ]
-            coroutines_list.append(audio_coroutines)
+            coroutine_factories_list.append(audio_coroutine_factories)
 
         # 为保证音频流和视频流尽可能并行，因此将两者混合一下～
-        coroutines = list(xmerge(*coroutines_list))
-        coroutines.insert(
-            0, CoroutineWrapper(show_progress(list(filter_none_values(buffers)), sum(filter_none_values(sizes))))
+        coroutine_factories = list(xmerge(*coroutine_factories_list))
+        coroutine_factories.insert(
+            0,
+            defer_progress(list(filter_none_values(buffers)), sum(filter_none_values(sizes))),
         )
-        scheduled = True
         Logger.info("开始下载……")
-        await _run_download_lifecycle(coroutines, filter_none_values(buffers))
+        lifecycle_started = True
+        await _run_download_lifecycle(coroutine_factories, filter_none_values(buffers))
         Logger.info("下载完成！")
     finally:
-        if not scheduled:
-            for coroutine_group in coroutines_list:
-                for coroutine in coroutine_group:
-                    coroutine.coro.close()
+        if not lifecycle_started:
             for buffer in filter_none_values(buffers):
                 await buffer.close()
 

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -25,7 +25,7 @@ from yutto.path_templates import (
     resolve_path_template,
 )
 from yutto.types import EpisodeData, EpisodeInfo, ResolvableEpisode, format_ids
-from yutto.utils.asynclib import CoroutineWrapper
+from yutto.utils.asynclib import make_coroutine_factory
 from yutto.utils.console.logger import Logger
 from yutto.utils.danmaku import EmptyDanmakuData
 from yutto.utils.fetcher import Fetcher
@@ -150,7 +150,7 @@ def make_bangumi_episode(
     info = build_bangumi_info(bangumi_info, options, subpath_variables, auto_subpath_template)
     return ResolvableEpisode(
         info=info,
-        data_coro=CoroutineWrapper(extract_bangumi_data(ctx, client, info, bangumi_info, options)),
+        resolve_data=make_coroutine_factory(extract_bangumi_data)(ctx, client, info, bangumi_info, options),
     )
 
 
@@ -247,7 +247,7 @@ def make_cheese_episode(
     info = build_cheese_info(cheese_info, options, subpath_variables, auto_subpath_template)
     return ResolvableEpisode(
         info=info,
-        data_coro=CoroutineWrapper(extract_cheese_data(ctx, client, episode_id, info, cheese_info, options)),
+        resolve_data=make_coroutine_factory(extract_cheese_data)(ctx, client, episode_id, info, cheese_info, options),
     )
 
 
@@ -358,5 +358,5 @@ def make_ugc_video_episode(
     info = build_ugc_video_info(avid, ugc_video_info, options, subpath_variables, auto_subpath_template, display_group)
     return ResolvableEpisode(
         info=info,
-        data_coro=CoroutineWrapper(extract_ugc_video_data(ctx, client, info, ugc_video_info, options)),
+        resolve_data=make_coroutine_factory(extract_ugc_video_data)(ctx, client, info, ugc_video_info, options),
     )

--- a/src/yutto/types.py
+++ b/src/yutto/types.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
     from pathlib import Path
+    from typing import Any
 
     from yutto.media.codec import AudioCodec, VideoCodec
     from yutto.media.quality import AudioQuality, VideoQuality
-    from yutto.utils.asynclib import CoroutineWrapper
     from yutto.utils.danmaku import DanmakuData, DanmakuOptions, DanmakuSaveType
     from yutto.utils.filter import PublicationTimeFilter
     from yutto.utils.metadata import ChapterInfoData, MetaData
@@ -259,10 +260,10 @@ class EpisodeData(TypedDict):
 
 
 class ResolvableEpisode(NamedTuple):
-    """listing 阶段产出的条目：info 立即可用，data 经由懒协程在下载前按需解析"""
+    """listing 阶段产出的条目：info 立即可用，data 在下载前按需创建并解析"""
 
     info: EpisodeInfo
-    data_coro: CoroutineWrapper[EpisodeData | None]
+    resolve_data: Callable[[], Coroutine[Any, Any, EpisodeData | None]]
 
 
 class DownloaderOptions(TypedDict):

--- a/src/yutto/utils/asynclib.py
+++ b/src/yutto/utils/asynclib.py
@@ -4,31 +4,29 @@ import asyncio
 import inspect
 import time
 import types
-from functools import wraps
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from functools import partial, wraps
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from typing_extensions import ParamSpec
 
 from yutto.utils.console.logger import Logger
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Generator, Iterable
+    from collections.abc import Callable, Coroutine, Iterable
 
 RetT = TypeVar("RetT")
 P = ParamSpec("P")
 
 
-class CoroutineWrapper(Generic[RetT]):
-    coro: Coroutine[Any, Any, RetT]
+def make_coroutine_factory(
+    fn: Callable[P, Coroutine[Any, Any, RetT]],
+) -> Callable[P, Callable[[], Coroutine[Any, Any, RetT]]]:
+    """绑定 coroutine function 的参数，延迟到 factory 调用时才创建 coroutine。"""
 
-    def __init__(self, coro: Coroutine[Any, Any, RetT]):
-        self.coro = coro
+    def bind(*args: P.args, **kwargs: P.kwargs) -> Callable[[], Coroutine[Any, Any, RetT]]:
+        return partial(fn, *args, **kwargs)
 
-    def __await__(self) -> Generator[Any, None, RetT]:
-        return (yield from self.coro.__await__())
-
-    def __del__(self):
-        self.coro.close()
+    return bind
 
 
 async def sleep_with_status_bar_refresh(seconds: float):

--- a/tests/test_processor/test_download_lifecycle.py
+++ b/tests/test_processor/test_download_lifecycle.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from yutto.downloader.downloader import _run_download_lifecycle
+from yutto.utils.asynclib import make_coroutine_factory
 from yutto.utils.functional import as_sync
 
 pytestmark = pytest.mark.processor
@@ -23,6 +24,25 @@ class FakeBuffer:
 
     async def close(self) -> None:
         self.closed = True
+
+
+@as_sync
+async def test_make_coroutine_factory_defers_coroutine_creation():
+    created: list[int] = []
+
+    async def resolve(value: int) -> int:
+        return value
+
+    def create_coroutine(value: int):
+        created.append(value)
+        return resolve(value)
+
+    factory = make_coroutine_factory(create_coroutine)(42)
+    assert created == []
+
+    coroutine = factory()
+    assert created == [42]
+    assert await coroutine == 42
 
 
 @pytest.mark.processor
@@ -54,7 +74,7 @@ async def test_download_lifecycle_failure_cancels_siblings_and_closes_buffers():
             sibling_cancelled.set()
 
     with pytest.raises(RuntimeError, match="block failed"):
-        await _run_download_lifecycle([progress(), failing_block(), sibling_block()], [buffer])
+        await _run_download_lifecycle([progress, failing_block, sibling_block], [buffer])
 
     assert progress_cancelled.is_set()
     assert sibling_cancelled.is_set()
@@ -70,7 +90,7 @@ async def test_download_lifecycle_success_closes_buffers_as_flushed():
     async def complete_block():
         await asyncio.sleep(0)
 
-    await _run_download_lifecycle([complete_block()], [buffer])
+    await _run_download_lifecycle([complete_block], [buffer])
 
     assert buffer.closed is True
     assert buffer.ensure_flushed_calls == 1
@@ -85,7 +105,7 @@ async def test_download_lifecycle_unflushed_success_is_an_error_and_still_closes
         await asyncio.sleep(0)
 
     with pytest.raises(RuntimeError, match="buffer 尚未清空"):
-        await _run_download_lifecycle([complete_block()], [buffer])
+        await _run_download_lifecycle([complete_block], [buffer])
 
     assert buffer.closed is True
     assert buffer.ensure_flushed_calls == 1
@@ -105,7 +125,7 @@ async def test_download_lifecycle_cancellation_cancels_children_and_closes_buffe
         finally:
             block_cancelled.set()
 
-    lifecycle_task = asyncio.create_task(_run_download_lifecycle([block()], [buffer]))
+    lifecycle_task = asyncio.create_task(_run_download_lifecycle([block], [buffer]))
     await block_started.wait()
     lifecycle_task.cancel()
 

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -6,7 +6,6 @@ import httpx
 import pytest
 
 from yutto.downloader.downloader import slice_blocks
-from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.fetcher import Fetcher, FetcherContext, create_client, unwrap_fetch_result
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import as_sync
@@ -30,14 +29,14 @@ async def test_150_kB_downloader():
             ctx.set_download_semaphore(4)
             size = unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
             coroutines = [
-                CoroutineWrapper(Fetcher.download_file_with_offset(ctx, client, url, [], buffer, offset, block_size))
+                Fetcher.download_file_with_offset(ctx, client, url, [], buffer, offset, block_size)
                 for offset, block_size in slice_blocks(buffer.written_size, size, 1 * 1024 * 1024)
             ]
 
             print("开始下载……")
             await asyncio.gather(*coroutines)
             print("下载完成！")
-            assert size == file_path.stat().st_size, "文件大小与实际大小不符"
+    assert size == file_path.stat().st_size, "文件大小与实际大小不符"
 
 
 @pytest.mark.processor
@@ -54,9 +53,9 @@ async def test_150_kB_no_slice_downloader():
         ) as client:
             ctx.set_download_semaphore(4)
             size = unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
-            coroutines = [CoroutineWrapper(Fetcher.download_file_with_offset(ctx, client, url, [], buffer, 0, size))]
+            coroutines = [Fetcher.download_file_with_offset(ctx, client, url, [], buffer, 0, size)]
 
             print("开始下载……")
             await asyncio.gather(*coroutines)
             print("下载完成！")
-            assert size == file_path.stat().st_size, "文件大小与实际大小不符"
+    assert size == file_path.stat().st_size, "文件大小与实际大小不符"

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -17,9 +17,8 @@ from yutto.download_manager import (
     ensure_unique_path,
     show_batch_episode_title,
 )
-from yutto.exceptions import WrongArgumentError
+from yutto.exceptions import NotLoginError, WrongArgumentError
 from yutto.types import AId, CId, ResolvableEpisode
-from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.fetcher import Fetcher, FetcherContext
 from yutto.utils.filter import PublicationTimeFilter
@@ -151,7 +150,7 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
             async def resolve_episode() -> EpisodeData | None:
                 return episode
 
-            return [ResolvableEpisode(info=episode["info"], data_coro=CoroutineWrapper(resolve_episode()))]
+            return [ResolvableEpisode(info=episode["info"], resolve_data=resolve_episode)]
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
         validation_requirements.append(requirements)
@@ -245,6 +244,64 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
         },
     }
     assert result == (ItemResult(state=ItemState.DONE, output_path=Path("downloads/series/episode.mkv")),)
+
+
+@as_sync
+async def test_process_request_does_not_create_unreached_episode_coroutines(monkeypatch: pytest.MonkeyPatch):
+    first_episode = make_episode("series/first")
+    second_episode = make_episode("series/second")
+    created_coroutines: list[str] = []
+
+    def make_resolver(name: str, episode: EpisodeData):
+        def resolve_data():
+            created_coroutines.append(name)
+
+            async def resolve_episode() -> EpisodeData:
+                return episode
+
+            return resolve_episode()
+
+        return resolve_data
+
+    episodes: list[ResolvableEpisode | None] = [
+        ResolvableEpisode(info=first_episode["info"], resolve_data=make_resolver("first", first_episode)),
+        ResolvableEpisode(info=second_episode["info"], resolve_data=make_resolver("second", second_episode)),
+    ]
+    validation_results = iter([True, False])
+
+    async def fake_resolve_request(
+        client: httpx.AsyncClient,
+        ctx: FetcherContext,
+        request: DownloadRequest,
+    ) -> list[ResolvableEpisode | None]:
+        return episodes
+
+    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+        return next(validation_results)
+
+    async def fake_process_download(
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        episode_data: EpisodeData,
+        options: DownloaderOptions,
+    ) -> ItemResult:
+        return ItemResult(state=ItemState.DONE, output_path=episode_data["info"]["path"])
+
+    manager = DownloadManager()
+    monkeypatch.setattr(manager, "resolve_request", fake_resolve_request)
+    monkeypatch.setattr(download_manager_module, "validate_user_info", fake_validate_user_info)
+    monkeypatch.setattr(download_manager_module, "process_download", fake_process_download)
+    monkeypatch.setattr(Logger, "new_line", lambda: None)
+
+    with pytest.raises(NotLoginError):
+        await manager.process_request(
+            cast("httpx.AsyncClient", object()),
+            FetcherContext(),
+            make_request(None),
+        )
+
+    # 第二个条目在校验失败前从未进入解析，因此连 coroutine 对象都不会创建。
+    assert created_coroutines == ["first"]
 
 
 @as_sync

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -22,7 +21,6 @@ from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, MaxRetryError, NotFoundError, NotLoginError, ResolveFailedError
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId, CId, ResolvableEpisode
-from yutto.utils.asynclib import CoroutineWrapper
 from yutto.utils.fetcher import Fetcher, FetcherContext
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
@@ -68,9 +66,8 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
         executed.append("ran")
         return None
 
-    data_coro = resolve_episode()
     info = make_info("P1", display_group="标题")
-    resolvable = ResolvableEpisode(info=info, data_coro=CoroutineWrapper(data_coro))
+    resolvable = ResolvableEpisode(info=info, resolve_data=resolve_episode)
 
     class FakeExtractor:
         def resolve_shortcut(self, url: str) -> tuple[bool, str]:
@@ -119,9 +116,8 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
         tags=("标签A", "标签B"),
     )
     assert items == [expected_item]
-    # data 懒协程从未执行，且已被关闭，不会留下 un-awaited 警告
+    # data resolver 从未调用，因此没有未 await 的 coroutine 需要清理
     assert executed == []
-    assert inspect.getcoroutinestate(data_coro) == inspect.CORO_CLOSED
     assert sink.events == [
         DownloadStageChanged(name=DownloadStage.RESOLVING),
         DownloadItemListed(
@@ -144,11 +140,14 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
 async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypatch: pytest.MonkeyPatch):
     """流式提取器经 notify_episode_listed 提前推送的条目不会被收尾补发重复。"""
 
+    resolved: list[str] = []
+
     async def noop() -> EpisodeData | None:
+        resolved.append("ran")
         return None
 
-    streamed = ResolvableEpisode(info=make_info("P1", display_group="标题"), data_coro=CoroutineWrapper(noop()))
-    late = ResolvableEpisode(info=make_info("P2", display_group="标题"), data_coro=CoroutineWrapper(noop()))
+    streamed = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+    late = ResolvableEpisode(info=make_info("P2", display_group="标题"), resolve_data=noop)
 
     class FakeExtractor:
         def resolve_shortcut(self, url: str) -> tuple[bool, str]:
@@ -190,9 +189,8 @@ async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypa
     assert [event.name for event in listed] == ["P1", "P2"]
     # 返回列表保持提取器给出的顺序
     assert [item.name for item in items] == ["P1", "P2"]
-    # 两个懒协程都被关闭
-    assert inspect.getcoroutinestate(streamed.data_coro.coro) == inspect.CORO_CLOSED
-    assert inspect.getcoroutinestate(late.data_coro.coro) == inspect.CORO_CLOSED
+    # resolve-only 路径不会调用 data resolver，也不会提前创建 coroutine
+    assert resolved == []
 
 
 class _FakeClientContext:
@@ -292,7 +290,7 @@ async def test_execute_resolve_reports_partial_failures(monkeypatch: pytest.Monk
     async def resolve_episode() -> EpisodeData | None:
         return None
 
-    resolvable = ResolvableEpisode(info=make_info("P1"), data_coro=CoroutineWrapper(resolve_episode()))
+    resolvable = ResolvableEpisode(info=make_info("P1"), resolve_data=resolve_episode)
 
     class PartialExtractor(_ShortcutExtractorBase):
         async def __call__(


### PR DESCRIPTION
## 动机

`CoroutineWrapper` 最初用于在析构时关闭未被 await 的 coroutine，避免批量下载中途退出时产生 `was never awaited` warning。随着 listing/data 分离和 resolve-only 模式加入，继续提前创建 coroutine 会让未触达条目的生命周期依赖 `__del__`，同时自定义 awaitable 也无法直接交给 `asyncio.create_task()`。

related to #137

## 解决方案

- 将 `ResolvableEpisode` 改为保存 `resolve_data` factory，只在真正下载条目时创建 coroutine。
- 新增类型安全的 `make_coroutine_factory(fn)(*args)`，集中表达“现在绑定参数、稍后创建 coroutine”的语义。
- 下载生命周期接收 coroutine factory，在统一持有任务所有权后创建原生 `Task`，并保留失败、取消和 buffer 回收行为。
- 删除 `CoroutineWrapper`、`data_coro`、`ensure_future` 以及显式穿透 `.coro.close()` 的清理代码。
- 补充中途认证失败、resolve-only、任务失败和取消的回归测试；将下载测试的文件大小断言移动到 buffer 关闭刷新之后。

## 验证

- `just fmt`
- `just lint`
- `uv run pytest -q tests/test_processor`（71 passed）

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol xhigh)</sup>
</div>
