### PR TITLE
♻️ refactor: make resolve outcomes explicit

### DIFF
--- a/src/yutto/core/operation.py
+++ b/src/yutto/core/operation.py
@@ -5,21 +5,11 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Iterator
 
     from yutto.core.events import DownloadEvent, DownloadEventSink
-    from yutto.exceptions import YuttoBaseException
-    from yutto.types import ResolvableEpisode
 
 _event_sink: ContextVar[DownloadEventSink | None] = ContextVar("yutto_download_event_sink", default=None)
-_resolve_failures: ContextVar[list[YuttoBaseException] | None] = ContextVar("yutto_resolve_failures", default=None)
-
-# resolve 模式的逐条列举钩子：batch 提取器在每个视频解析完成时把它的分集推给
-# 钩子，长列表就能边解析边在前端出现，而不是全部完成后一次性倾倒。未绑定时
-# （下载路径、未流式化的提取器）保持原有整批行为。
-_episode_listed_hook: ContextVar[Callable[[ResolvableEpisode], None] | None] = ContextVar(
-    "yutto_episode_listed_hook", default=None
-)
 
 
 @contextmanager
@@ -35,46 +25,3 @@ def emit_download_event(event: DownloadEvent) -> None:
     sink = _event_sink.get()
     if sink is not None:
         sink.emit(event)
-
-
-@contextmanager
-def collect_resolve_failures() -> Iterator[list[YuttoBaseException]]:
-    """采集本次解析过程中 extractor 上报的预期内失败"""
-    failures: list[YuttoBaseException] = []
-    token = _resolve_failures.set(failures)
-    try:
-        yield failures
-    finally:
-        _resolve_failures.reset(token)
-
-
-def report_resolve_failure(error: YuttoBaseException) -> None:
-    """extractor 在把预期失败吞成 None / 空列表之前上报结构化原因。
-
-    仅在解析路径（collect_resolve_failures 绑定期间）生效；下载路径为 no-op，
-    行为不受影响。
-    """
-    failures = _resolve_failures.get()
-    if failures is not None:
-        failures.append(error)
-
-
-@contextmanager
-def bind_episode_listed_hook(hook: Callable[[ResolvableEpisode], None]) -> Iterator[None]:
-    """在解析期间绑定逐条列举钩子；仅 resolve 路径绑定，下载路径不绑定、行为不变"""
-    token = _episode_listed_hook.set(hook)
-    try:
-        yield
-    finally:
-        _episode_listed_hook.reset(token)
-
-
-def notify_episode_listed(episode: ResolvableEpisode) -> None:
-    """流式提取器在单个视频解析完成时立即逐条交出分集。
-
-    钩子未绑定时（下载路径、未流式化的提取器）为 no-op；resolve_items 收尾补发时
-    会跳过已经推送过的条目，每个条目恰好对外产生一次 item_listed。
-    """
-    hook = _episode_listed_hook.get()
-    if hook is not None:
-        hook(episode)

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -28,6 +28,7 @@ from yutto.extractor import (
     UserAllUgcVideosExtractor,
     UserWatchLaterExtractor,
 )
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.path_templates import create_unique_path_resolver
 from yutto.types import EpisodeData, ExtractorOptions
 from yutto.utils.asynclib import sleep_with_status_bar_refresh
@@ -319,7 +320,7 @@ class DownloadManager:
         request: DownloadRequest,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         """Match the request to an extractor and run its listing phase."""
         publication_time_filter = PublicationTimeFilter.from_strings(
             request.selection.start_time,
@@ -379,26 +380,25 @@ class DownloadManager:
         # 提取信息，构造解析任务～
         for extractor in extractors:
             if extractor.match(url):
-                download_list = await extractor(
-                    ctx,
-                    client,
-                    ExtractorOptions(
-                        episodes=request.selection.episodes,
-                        with_section=request.scope.with_section,
-                        require_video=request.resources.video,
-                        require_audio=request.resources.audio,
-                        require_danmaku=request.resources.danmaku,
-                        require_subtitle=request.resources.subtitle,
-                        require_metadata=request.resources.metadata,
-                        require_cover=request.resources.cover,
-                        require_chapter_info=request.resources.chapter_info,
-                        danmaku_format=request.danmaku.format,
-                        subpath_template=request.output.subpath_template,
-                        ai_translation_language=request.resources.ai_translation_language,
-                        publication_time_filter=publication_time_filter,
-                    ),
-                    on_item=on_item,
+                extractor_options = ExtractorOptions(
+                    episodes=request.selection.episodes,
+                    with_section=request.scope.with_section,
+                    require_video=request.resources.video,
+                    require_audio=request.resources.audio,
+                    require_danmaku=request.resources.danmaku,
+                    require_subtitle=request.resources.subtitle,
+                    require_metadata=request.resources.metadata,
+                    require_cover=request.resources.cover,
+                    require_chapter_info=request.resources.chapter_info,
+                    danmaku_format=request.danmaku.format,
+                    subpath_template=request.output.subpath_template,
+                    ai_translation_language=request.resources.ai_translation_language,
+                    publication_time_filter=publication_time_filter,
                 )
+                if on_item is not None and isinstance(extractor, StreamingBatchExtractor):
+                    download_list = await extractor(ctx, client, extractor_options, on_item=on_item)
+                else:
+                    download_list = await extractor(ctx, client, extractor_options)
                 break
         else:
             if request.scope.batch:

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -9,7 +10,7 @@ from biliass import BlockOptions
 
 from yutto.api.user_info import validate_user_info
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.operation import bind_episode_listed_hook, collect_resolve_failures, emit_download_event
+from yutto.core.operation import emit_download_event
 from yutto.core.result import DownloadResult, ItemResult, ResolvedItem, ResolveFailure, ResolveResult
 from yutto.downloader.downloader import process_download
 from yutto.exceptions import NotLoginError, ResolveFailedError, WrongArgumentError, WrongUrlError
@@ -43,6 +44,9 @@ if TYPE_CHECKING:
     from httpx import AsyncClient
 
     from yutto.core.request import DanmakuRequestOptions, DownloadRequest
+    from yutto.exceptions import YuttoBaseException
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor.outcome import ResolveOutcome
     from yutto.types import EpisodeData, EpisodeInfo, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -119,6 +123,24 @@ def _emit_item_listed(episode: ResolvableEpisode) -> None:
     )
 
 
+def _resolved_item_key(episode: ResolvableEpisode) -> tuple[str, str, str, Path, str | None]:
+    """Return a stable occurrence key for matching streamed and final items."""
+    info = episode.info
+    return (
+        str(info["avid"]),
+        str(info["cid"]),
+        info["url"],
+        info["path"],
+        info["display_group"],
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedItemsOutcome:
+    items: tuple[ResolvedItem, ...]
+    failures: tuple[YuttoBaseException, ...]
+
+
 class DownloadManager:
     """Execute download requests sequentially in one shared network session."""
 
@@ -141,61 +163,67 @@ class DownloadManager:
     async def execute_resolve(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> ResolveResult:
         """Enumerate episodes for requests in order without downloading anything."""
         items: list[ResolvedItem] = []
+        failures: list[YuttoBaseException] = []
         ctx.set_fetch_semaphore(fetch_workers=ctx.fetch_workers)
-        with collect_resolve_failures() as collected:
-            async with create_client(
-                cookies=ctx.cookies,
-                trust_env=ctx.trust_env,
-                proxy=ctx.proxy,
-            ) as client:
-                for request in requests:
-                    items.extend(await self.resolve_items(client, ctx, request))
-        if collected and not items:
+        async with create_client(
+            cookies=ctx.cookies,
+            trust_env=ctx.trust_env,
+            proxy=ctx.proxy,
+        ) as client:
+            for request in requests:
+                outcome = await self.resolve_items(client, ctx, request)
+                items.extend(outcome.items)
+                failures.extend(outcome.failures)
+        if failures and not items:
             # 存在预期内失败且没有任何条目解析成功：任务失败而非空成功。
             # 单一失败直接抛原始异常，wire 上保留其稳定错误码（如 not found）；
             # 纯过滤导致的空结果（无失败上报，如时间过滤/空收藏夹）仍是 completed 空结果
-            if len(collected) == 1:
-                raise collected[0]
-            raise ResolveFailedError(f"解析未得到任何条目：{len(collected)} 个来源/条目解析失败（详见 server 日志）")
-        failures = tuple(
+            if len(failures) == 1:
+                raise failures[0]
+            raise ResolveFailedError(f"解析未得到任何条目：{len(failures)} 个来源/条目解析失败（详见 server 日志）")
+        resolved_failures = tuple(
             ResolveFailure(type=type(error).__name__, message=error.message, code=error.code.value)
-            for error in collected
+            for error in failures
         )
-        return ResolveResult(items=tuple(items), failures=failures)
+        return ResolveResult(items=tuple(items), failures=resolved_failures)
 
     async def resolve_items(
         self,
         client: AsyncClient,
         ctx: FetcherContext,
         request: DownloadRequest,
-    ) -> list[ResolvedItem]:
+    ) -> _ResolvedItemsOutcome:
         """List the stable episode snapshots of one request; the volatile data is never fetched.
 
         返回的 planned_path 是模板解析出的计划路径；实际下载时可能因去重而调整。
-        item_listed 逐条推送：支持流式的 batch 提取器在每个视频解析完成时经
-        notify_episode_listed 交出分集（长列表边解析边出现在前端），提取结束后
-        这里只补发未流式推送过的条目；返回列表始终保持提取器的原始顺序。
+        item_listed 逐条推送：支持流式的 batch 提取器通过显式 on_item 回调在
+        每个视频解析完成时交出分集，提取结束后这里只补发未流式推送过的条目；
+        返回列表始终保持提取器的原始顺序。
         """
-        streamed: set[int] = set()
+        emitted: set[tuple[str, str, str, Path, str | None]] = set()
 
-        def stream_episode(episode: ResolvableEpisode) -> None:
-            streamed.add(id(episode))
+        async def stream_episode(episode: ResolvableEpisode) -> None:
+            key = _resolved_item_key(episode)
+            if key in emitted:
+                await asyncio.sleep(0)
+                return
+            emitted.add(key)
             _emit_item_listed(episode)
+            await asyncio.sleep(0)
 
-        with bind_episode_listed_hook(stream_episode):
-            episode_list = await self.resolve_request(client, ctx, request)
+        outcome = await self.resolve_request(client, ctx, request, on_item=stream_episode)
         items: list[ResolvedItem] = []
-        for episode in episode_list:
-            if episode is None:
-                continue
-            if id(episode) not in streamed:
+        for episode in outcome.items:
+            key = _resolved_item_key(episode)
+            if key not in emitted:
+                emitted.add(key)
                 _emit_item_listed(episode)
                 # 未流式化的提取器仍会在这个无 await 的循环里整批产出 item_listed；
                 # 逐条让出控制权给事件消费者（如 server 每连接的 sender），
                 # 避免超出其发送队列容量触发 slow-consumer 断连
                 await asyncio.sleep(0)
             items.append(_resolved_item_from(episode))
-        return items
+        return _ResolvedItemsOutcome(items=tuple(items), failures=outcome.failures)
 
     async def process_request(
         self,
@@ -203,7 +231,8 @@ class DownloadManager:
         ctx: FetcherContext,
         request: DownloadRequest,
     ) -> tuple[ItemResult, ...]:
-        download_list = await self.resolve_request(client, ctx, request)
+        outcome = await self.resolve_request(client, ctx, request)
+        download_list = outcome.items
 
         item_results: list[ItemResult] = []
         previous_result: ItemResult | None = None
@@ -211,9 +240,6 @@ class DownloadManager:
 
         # 下载～
         for i, episode in enumerate(download_list):
-            if episode is None:
-                continue
-
             # 中途校验基于请求级缓存的用户信息（见 get_user_info），不会重复请求；
             # 凭据若在过程中失效，需等缓存所在的 FetcherContext 重建后才能被发现
             if not await validate_user_info(
@@ -291,7 +317,9 @@ class DownloadManager:
         client: AsyncClient,
         ctx: FetcherContext,
         request: DownloadRequest,
-    ) -> list[ResolvableEpisode | None]:
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         """Match the request to an extractor and run its listing phase."""
         publication_time_filter = PublicationTimeFilter.from_strings(
             request.selection.start_time,
@@ -369,6 +397,7 @@ class DownloadManager:
                         ai_translation_language=request.resources.ai_translation_language,
                         publication_time_filter=publication_time_filter,
                     ),
+                    on_item=on_item,
                 )
                 break
         else:

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -28,7 +28,7 @@ from yutto.extractor import (
     UserAllUgcVideosExtractor,
     UserWatchLaterExtractor,
 )
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.path_templates import create_unique_path_resolver
 from yutto.types import EpisodeData, ExtractorOptions
 from yutto.utils.asynclib import sleep_with_status_bar_refresh
@@ -395,7 +395,7 @@ class DownloadManager:
                     ai_translation_language=request.resources.ai_translation_language,
                     publication_time_filter=publication_time_filter,
                 )
-                if on_item is not None and isinstance(extractor, StreamingBatchExtractor):
+                if isinstance(extractor, BatchExtractor):
                     download_list = await extractor(ctx, client, extractor_options, on_item=on_item)
                 else:
                     download_list = await extractor(ctx, client, extractor_options)

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -198,17 +199,21 @@ class DownloadManager:
 
         返回的 planned_path 是模板解析出的计划路径；实际下载时可能因去重而调整。
         item_listed 逐条推送：支持流式的 batch 提取器通过显式 on_item 回调在
-        每个视频解析完成时交出分集，提取结束后这里只补发未流式推送过的条目；
-        返回列表始终保持提取器的原始顺序。
+        每个视频解析完成时交出分集，提取结束后按稳定键逐次消费已推送 occurrence，
+        再补发剩余条目；等值但独立的 occurrence 不会被合并，返回列表始终保持
+        提取器的原始顺序。
         """
-        emitted: set[tuple[str, str, str, Path, str | None]] = set()
+        streamed_by_key: dict[tuple[str, str, str, Path, str | None], deque[ResolvableEpisode]] = {}
 
         async def stream_episode(episode: ResolvableEpisode) -> None:
             key = _resolved_item_key(episode)
-            if key in emitted:
+            streamed = streamed_by_key.setdefault(key, deque())
+            # 防御同一 occurrence 的重复 callback；不同对象即使 snapshot 等值，
+            # 仍代表两个合法 occurrence，必须分别发送事件。
+            if any(item is episode for item in streamed):
                 await asyncio.sleep(0)
                 return
-            emitted.add(key)
+            streamed.append(episode)
             _emit_item_listed(episode)
             await asyncio.sleep(0)
 
@@ -216,8 +221,10 @@ class DownloadManager:
         items: list[ResolvedItem] = []
         for episode in outcome.items:
             key = _resolved_item_key(episode)
-            if key not in emitted:
-                emitted.add(key)
+            streamed = streamed_by_key.get(key)
+            if streamed:
+                streamed.popleft()
+            else:
                 _emit_item_listed(episode)
                 # 未流式化的提取器仍会在这个无 await 的循环里整批产出 item_listed；
                 # 逐条让出控制权给事件消费者（如 server 每连接的 sender），

--- a/src/yutto/extractor/_abc.py
+++ b/src/yutto/extractor/_abc.py
@@ -2,18 +2,22 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from yutto.types import ResolvableEpisode
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     import httpx
 
+    from yutto.exceptions import YuttoBaseException
     from yutto.extractor.outcome import ResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
-T = TypeVar("T")
+    ExtractorResolveOutcome: TypeAlias = ResolveOutcome[ResolvableEpisode, YuttoBaseException]
+
 EpisodeListedCallback = Callable[[ResolvableEpisode], Awaitable[None]]
 
 
@@ -33,9 +37,7 @@ class Extractor(metaclass=ABCMeta):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         raise NotImplementedError
 
 
@@ -45,10 +47,8 @@ class SingleExtractor(Extractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
-        return await self.extract(ctx, client, options, on_item=on_item)
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
+        return await self.extract(ctx, client, options)
 
     @abstractmethod
     async def extract(
@@ -56,9 +56,7 @@ class SingleExtractor(Extractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         raise NotImplementedError
 
 
@@ -68,9 +66,28 @@ class BatchExtractor(Extractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
+        return await self.extract(ctx, client, options)
+
+    @abstractmethod
+    async def extract(
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
+        raise NotImplementedError
+
+
+class StreamingBatchExtractor(BatchExtractor):
+    async def __call__(
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         return await self.extract(ctx, client, options, on_item=on_item)
 
     @abstractmethod
@@ -81,5 +98,5 @@ class BatchExtractor(Extractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         raise NotImplementedError

--- a/src/yutto/extractor/_abc.py
+++ b/src/yutto/extractor/_abc.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, TypeVar
+
+from yutto.types import ResolvableEpisode
 
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.extractor.outcome import ResolveOutcome
+    from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 T = TypeVar("T")
+EpisodeListedCallback = Callable[[ResolvableEpisode], Awaitable[None]]
 
 
 class Extractor(metaclass=ABCMeta):
@@ -24,32 +29,57 @@ class Extractor(metaclass=ABCMeta):
 
     @abstractmethod
     async def __call__(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         raise NotImplementedError
 
 
 class SingleExtractor(Extractor):
     async def __call__(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
-        return [await self.extract(ctx, client, options)]
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
+        return await self.extract(ctx, client, options, on_item=on_item)
 
     @abstractmethod
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> ResolvableEpisode | None:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         raise NotImplementedError
 
 
 class BatchExtractor(Extractor):
     async def __call__(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
-        return await self.extract(ctx, client, options)
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
+        return await self.extract(ctx, client, options, on_item=on_item)
 
     @abstractmethod
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         raise NotImplementedError

--- a/src/yutto/extractor/_abc.py
+++ b/src/yutto/extractor/_abc.py
@@ -66,25 +66,6 @@ class BatchExtractor(Extractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
-        return await self.extract(ctx, client, options)
-
-    @abstractmethod
-    async def extract(
-        self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
-        options: ExtractorOptions,
-    ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
-        raise NotImplementedError
-
-
-class StreamingBatchExtractor(BatchExtractor):
-    async def __call__(
-        self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
-        options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:

--- a/src/yutto/extractor/bangumi.py
+++ b/src/yutto/extractor/bangumi.py
@@ -20,7 +20,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -54,9 +54,7 @@ class BangumiExtractor(SingleExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         season_id = await get_season_id_by_episode_id(ctx, client, self.episode_id)
         bangumi_list = await get_bangumi_list(ctx, client, season_id)
         Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))

--- a/src/yutto/extractor/bangumi.py
+++ b/src/yutto/extractor/bangumi.py
@@ -4,7 +4,6 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.bangumi import get_bangumi_list, get_season_id_by_episode_id
-from yutto.core.operation import report_resolve_failure
 from yutto.exceptions import (
     EpisodeNotFoundError,
     HttpStatusError,
@@ -14,13 +13,15 @@ from yutto.exceptions import (
 )
 from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import make_bangumi_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import EpisodeId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -49,8 +50,13 @@ class BangumiExtractor(SingleExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> ResolvableEpisode | None:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         season_id = await get_season_id_by_episode_id(ctx, client, self.episode_id)
         bangumi_list = await get_bangumi_list(ctx, client, season_id)
         Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))
@@ -62,17 +68,20 @@ class BangumiExtractor(SingleExtractor):
             else:
                 raise EpisodeNotFoundError("在列表中未找到该剧集")
 
-            return make_bangumi_episode(
-                ctx,
-                client,
-                bangumi_list_item,
-                options,
-                {
-                    "title": bangumi_list["title"],
-                },
-                "{name}",
+            return ResolveOutcome(
+                items=(
+                    make_bangumi_episode(
+                        ctx,
+                        client,
+                        bangumi_list_item,
+                        options,
+                        {
+                            "title": bangumi_list["title"],
+                        },
+                        "{name}",
+                    ),
+                )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
             Logger.error(e.message)
-            report_resolve_failure(e)
-            return None
+            return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -18,7 +18,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -77,9 +77,7 @@ class BangumiBatchExtractor(BatchExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         await self._parse_ids(ctx, client)
 
         bangumi_list = await get_bangumi_list(ctx, client, self.season_id)

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -10,6 +10,7 @@ from yutto.api.bangumi import (
 )
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_bangumi_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import EpisodeId, MediaId, SeasonId
 from yutto.utils.console.logger import Badge, Logger
@@ -17,7 +18,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -71,8 +73,13 @@ class BangumiBatchExtractor(BatchExtractor):
             self.season_id = await get_season_id_by_media_id(ctx, client, media_id)
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         await self._parse_ids(ctx, client)
 
         bangumi_list = await get_bangumi_list(ctx, client, self.season_id)
@@ -84,16 +91,18 @@ class BangumiBatchExtractor(BatchExtractor):
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(bangumi_list["pages"]))
         bangumi_list["pages"] = list(filter(lambda item: item["id"] in episodes, bangumi_list["pages"]))
-        return [
-            make_bangumi_episode(
-                ctx,
-                client,
-                bangumi_item,
-                options,
-                {
-                    "title": bangumi_list["title"],
-                },
-                "{title}/{name}",
+        return ResolveOutcome(
+            items=tuple(
+                make_bangumi_episode(
+                    ctx,
+                    client,
+                    bangumi_item,
+                    options,
+                    {
+                        "title": bangumi_list["title"],
+                    },
+                    "{title}/{name}",
+                )
+                for bangumi_item in bangumi_list["pages"]
             )
-            for bangumi_item in bangumi_list["pages"]
-        ]
+        )

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -18,7 +18,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import ExtractorResolveOutcome
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -77,6 +77,8 @@ class BangumiBatchExtractor(BatchExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         await self._parse_ids(ctx, client)
 

--- a/src/yutto/extractor/cheese.py
+++ b/src/yutto/extractor/cheese.py
@@ -4,7 +4,6 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.cheese import get_cheese_list, get_season_id_by_episode_id
-from yutto.core.operation import report_resolve_failure
 from yutto.exceptions import (
     EpisodeNotFoundError,
     HttpStatusError,
@@ -14,13 +13,15 @@ from yutto.exceptions import (
 )
 from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import make_cheese_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import EpisodeId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -50,8 +51,13 @@ class CheeseExtractor(SingleExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> ResolvableEpisode | None:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         season_id = await get_season_id_by_episode_id(ctx, client, self.episode_id)
         cheese_list = await get_cheese_list(ctx, client, season_id)
         Logger.custom(cheese_list["title"], Badge("课程", fore="black", back="cyan"))
@@ -63,18 +69,21 @@ class CheeseExtractor(SingleExtractor):
             else:
                 raise EpisodeNotFoundError("在列表中未找到该剧集")
 
-            return make_cheese_episode(
-                ctx,
-                client,
-                self.episode_id,
-                cheese_list_item,
-                options,
-                {
-                    "title": cheese_list["title"],
-                },
-                "{name}",
+            return ResolveOutcome(
+                items=(
+                    make_cheese_episode(
+                        ctx,
+                        client,
+                        self.episode_id,
+                        cheese_list_item,
+                        options,
+                        {
+                            "title": cheese_list["title"],
+                        },
+                        "{name}",
+                    ),
+                )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
             Logger.error(e.message)
-            report_resolve_failure(e)
-            return None
+            return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/cheese.py
+++ b/src/yutto/extractor/cheese.py
@@ -20,7 +20,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -55,9 +55,7 @@ class CheeseExtractor(SingleExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         season_id = await get_season_id_by_episode_id(ctx, client, self.episode_id)
         cheese_list = await get_cheese_list(ctx, client, season_id)
         Logger.custom(cheese_list["title"], Badge("课程", fore="black", back="cyan"))

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from yutto.api.cheese import get_cheese_list, get_season_id_by_episode_id
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_cheese_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import EpisodeId, SeasonId
 from yutto.utils.console.logger import Badge, Logger
@@ -13,7 +14,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -56,8 +58,13 @@ class CheeseBatchExtractor(BatchExtractor):
             self.season_id = SeasonId(self._match_result.group("season_id"))
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         await self._parse_ids(ctx, client)
 
         cheese_list = await get_cheese_list(ctx, client, self.season_id)
@@ -65,17 +72,19 @@ class CheeseBatchExtractor(BatchExtractor):
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(cheese_list["pages"]))
         cheese_list["pages"] = list(filter(lambda item: item["id"] in episodes, cheese_list["pages"]))
-        return [
-            make_cheese_episode(
-                ctx,
-                client,
-                cheese_item["episode_id"],
-                cheese_item,
-                options,
-                {
-                    "title": cheese_list["title"],
-                },
-                "{title}/{name}",
+        return ResolveOutcome(
+            items=tuple(
+                make_cheese_episode(
+                    ctx,
+                    client,
+                    cheese_item["episode_id"],
+                    cheese_item,
+                    options,
+                    {
+                        "title": cheese_list["title"],
+                    },
+                    "{title}/{name}",
+                )
+                for cheese_item in cheese_list["pages"]
             )
-            for cheese_item in cheese_list["pages"]
-        ]
+        )

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -14,7 +14,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -62,9 +62,7 @@ class CheeseBatchExtractor(BatchExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         await self._parse_ids(ctx, client)
 
         cheese_list = await get_cheese_list(ctx, client, self.season_id)

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -14,7 +14,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import ExtractorResolveOutcome
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -62,6 +62,8 @@ class CheeseBatchExtractor(BatchExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         await self._parse_ids(ctx, client)
 

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from yutto.api.collection import get_collection_details
 from yutto.api.space import get_user_name
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from yutto.utils.fetcher import FetcherContext
 
 
-class CollectionExtractor(StreamingBatchExtractor):
+class CollectionExtractor(BatchExtractor):
     """视频合集"""
 
     REGEX_COLLECTION_LISTS = re.compile(

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from yutto.api.collection import get_collection_details
 from yutto.api.space import get_user_name
-from yutto.extractor._abc import BatchExtractor
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -18,12 +18,13 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
-    from yutto.extractor._abc import EpisodeListedCallback
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
+    from yutto.types import ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
-class CollectionExtractor(BatchExtractor):
+class CollectionExtractor(StreamingBatchExtractor):
     """视频合集"""
 
     REGEX_COLLECTION_LISTS = re.compile(
@@ -54,7 +55,7 @@ class CollectionExtractor(BatchExtractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         username, collection_details = await asyncio.gather(
             get_user_name(ctx, client, self.mid),
             get_collection_details(ctx, client, self.series_id, self.mid),
@@ -72,9 +73,9 @@ class CollectionExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
-            if ugc_video_list is None:
-                return
+        async def build_episodes(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+            index = resolved.index
+            ugc_video_list = resolved.value
             if len(ugc_video_list["pages"]) != 1:
                 Logger.error(f"视频合集 {collection_title} 中的视频 {items[index]['avid']} 包含多个视频！")
             built: list[ResolvableEpisode] = []
@@ -111,5 +112,5 @@ class CollectionExtractor(BatchExtractor):
         )
         return ResolveOutcome(
             items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
-            failures=batch_outcome.failures,
+            failures=tuple(failure.error for failure in batch_outcome.failures),
         )

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING
 
 from yutto.api.collection import get_collection_details
 from yutto.api.space import get_user_name
-from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import MId, SeriesId
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -47,8 +48,13 @@ class CollectionExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         username, collection_details = await asyncio.gather(
             get_user_name(ctx, client, self.mid),
             get_collection_details(ctx, client, self.series_id, self.mid),
@@ -63,7 +69,7 @@ class CollectionExtractor(BatchExtractor):
         items = collection_details["pages"]
         avids = [item["avid"] for item in items]
 
-        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
         async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
@@ -89,16 +95,21 @@ class CollectionExtractor(BatchExtractor):
                     },
                     "{series_title}/{title}",
                 )
-                notify_episode_listed(episode)
-                await asyncio.sleep(0)
+                if on_item is not None:
+                    await on_item(episode)
+                else:
+                    await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 
-        await resolve_ugc_video_lists(
+        batch_outcome = await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,
         )
-        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]
+        return ResolveOutcome(
+            items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
+            failures=batch_outcome.failures,
+        )

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_favourite_info, get_favourite_items, get_user_name
-from yutto.extractor._abc import BatchExtractor
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -17,12 +17,13 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
-    from yutto.extractor._abc import EpisodeListedCallback
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
+    from yutto.types import ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
-class FavouritesExtractor(BatchExtractor):
+class FavouritesExtractor(StreamingBatchExtractor):
     """用户单一收藏夹"""
 
     REGEX_FAV = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)/favlist\?fid=(?P<fid>\d+)((&ftype=create)|$)")
@@ -45,7 +46,7 @@ class FavouritesExtractor(BatchExtractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         username, favourite_info = await asyncio.gather(
             get_user_name(ctx, client, self.mid),
             get_favourite_info(ctx, client, self.fid),
@@ -59,9 +60,9 @@ class FavouritesExtractor(BatchExtractor):
         # 顺序无关，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
-            if ugc_video_list is None:
-                return
+        async def build_episodes(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+            index = resolved.index
+            ugc_video_list = resolved.value
             favourite_video = favourite_videos[index]
             # 优先使用收藏夹 API 返回的人工标题；失效视频 title 为空时退回到 ugc 接口标题
             favourite_title = favourite_video["title"] or ugc_video_list["title"]
@@ -104,5 +105,5 @@ class FavouritesExtractor(BatchExtractor):
         )
         return ResolveOutcome(
             items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
-            failures=batch_outcome.failures,
+            failures=tuple(failure.error for failure in batch_outcome.failures),
         )

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -5,9 +5,9 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_favourite_info, get_favourite_items, get_user_name
-from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.extractor.utils.favourite import normalize_favourite_video_item
 from yutto.types import FId, MId
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -38,8 +39,13 @@ class FavouritesExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         username, favourite_info = await asyncio.gather(
             get_user_name(ctx, client, self.mid),
             get_favourite_info(ctx, client, self.fid),
@@ -49,8 +55,8 @@ class FavouritesExtractor(BatchExtractor):
         favourite_videos = await get_favourite_items(ctx, client, self.fid)
         avids = [favourite_video["avid"] for favourite_video in favourite_videos]
 
-        # 每个视频解析完成即构建其分集并通过 notify_episode_listed 推流（resolve
-        # 模式下前端逐条看到列表）；完成顺序与收藏夹顺序无关，最终按 index 重排。
+        # 每个视频解析完成即构建其分集并通过显式回调推流；完成顺序与收藏夹
+        # 顺序无关，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
         async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
@@ -82,16 +88,21 @@ class FavouritesExtractor(BatchExtractor):
                     auto_subpath_template,
                     display_group=display_group,
                 )
-                notify_episode_listed(episode)
-                await asyncio.sleep(0)
+                if on_item is not None:
+                    await on_item(episode)
+                else:
+                    await asyncio.sleep(0)
                 episodes.append(episode)
             episodes_by_index[index] = episodes
 
-        await resolve_ugc_video_lists(
+        batch_outcome = await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,
         )
-        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]
+        return ResolveOutcome(
+            items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
+            failures=batch_outcome.failures,
+        )

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_favourite_info, get_favourite_items, get_user_name
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from yutto.utils.fetcher import FetcherContext
 
 
-class FavouritesExtractor(StreamingBatchExtractor):
+class FavouritesExtractor(BatchExtractor):
     """用户单一收藏夹"""
 
     REGEX_FAV = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)/favlist\?fid=(?P<fid>\d+)((&ftype=create)|$)")

--- a/src/yutto/extractor/outcome.py
+++ b/src/yutto/extractor/outcome.py
@@ -1,26 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import Generic, TypeVar
 
-if TYPE_CHECKING:
-    from yutto.exceptions import YuttoBaseException
-    from yutto.types import ResolvableEpisode
-
-T = TypeVar("T")
+ItemT = TypeVar("ItemT")
+FailureT = TypeVar("FailureT")
 
 
 @dataclass(frozen=True, slots=True)
-class ResolveOutcome:
-    """Explicit result of one extractor listing operation."""
+class ResolveOutcome(Generic[ItemT, FailureT]):
+    """Ordered successes and expected failures from one resolve operation."""
 
-    items: tuple[ResolvableEpisode, ...] = field(default_factory=tuple)
-    failures: tuple[YuttoBaseException, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True, slots=True)
-class BatchResolveOutcome(Generic[T]):
-    """Ordered results and expected failures from a concurrent batch lookup."""
-
-    results: tuple[T | None, ...] = field(default_factory=tuple)
-    failures: tuple[YuttoBaseException, ...] = field(default_factory=tuple)
+    items: tuple[ItemT, ...] = field(default_factory=tuple)
+    failures: tuple[FailureT, ...] = field(default_factory=tuple)

--- a/src/yutto/extractor/outcome.py
+++ b/src/yutto/extractor/outcome.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from yutto.exceptions import YuttoBaseException
+    from yutto.types import ResolvableEpisode
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolveOutcome:
+    """Explicit result of one extractor listing operation."""
+
+    items: tuple[ResolvableEpisode, ...] = field(default_factory=tuple)
+    failures: tuple[YuttoBaseException, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class BatchResolveOutcome(Generic[T]):
+    """Ordered results and expected failures from a concurrent batch lookup."""
+
+    results: tuple[T | None, ...] = field(default_factory=tuple)
+    failures: tuple[YuttoBaseException, ...] = field(default_factory=tuple)

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_medialist_avids, get_medialist_title, get_user_name
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from yutto.utils.fetcher import FetcherContext
 
 
-class SeriesExtractor(StreamingBatchExtractor):
+class SeriesExtractor(BatchExtractor):
     """视频列表"""
 
     REGEX_SERIES_LISTS = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)/lists/(?P<series_id>\d+)\?type=series")

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_medialist_avids, get_medialist_title, get_user_name
-from yutto.extractor._abc import BatchExtractor
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -16,12 +16,13 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
-    from yutto.extractor._abc import EpisodeListedCallback
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
+    from yutto.types import ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
-class SeriesExtractor(BatchExtractor):
+class SeriesExtractor(StreamingBatchExtractor):
     """视频列表"""
 
     REGEX_SERIES_LISTS = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)/lists/(?P<series_id>\d+)\?type=series")
@@ -45,7 +46,7 @@ class SeriesExtractor(BatchExtractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         username, series_title = await asyncio.gather(
             get_user_name(ctx, client, self.mid), get_medialist_title(ctx, client, self.series_id)
         )
@@ -56,9 +57,9 @@ class SeriesExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
-            if ugc_video_list is None:
-                return
+        async def build_episodes(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+            index = resolved.index
+            ugc_video_list = resolved.value
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
@@ -91,5 +92,5 @@ class SeriesExtractor(BatchExtractor):
         )
         return ResolveOutcome(
             items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
-            failures=batch_outcome.failures,
+            failures=tuple(failure.error for failure in batch_outcome.failures),
         )

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -5,9 +5,9 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_medialist_avids, get_medialist_title, get_user_name
-from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import MId, SeriesId
 from yutto.utils.console.logger import Badge, Logger
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -38,8 +39,13 @@ class SeriesExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         username, series_title = await asyncio.gather(
             get_user_name(ctx, client, self.mid), get_medialist_title(ctx, client, self.series_id)
         )
@@ -47,7 +53,7 @@ class SeriesExtractor(BatchExtractor):
 
         avids = await get_medialist_avids(ctx, client, self.series_id, self.mid)
 
-        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
         async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
@@ -69,16 +75,21 @@ class SeriesExtractor(BatchExtractor):
                     },
                     "{series_title}/{title}/{name}",
                 )
-                notify_episode_listed(episode)
-                await asyncio.sleep(0)
+                if on_item is not None:
+                    await on_item(episode)
+                else:
+                    await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 
-        await resolve_ugc_video_lists(
+        batch_outcome = await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,
         )
-        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]
+        return ResolveOutcome(
+            items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
+            failures=batch_outcome.failures,
+        )

--- a/src/yutto/extractor/ugc_video.py
+++ b/src/yutto/extractor/ugc_video.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 from yutto.api.ugc_video import get_ugc_video_list
-from yutto.core.operation import report_resolve_failure
 from yutto.exceptions import (
     HttpStatusError,
     NoAccessPermissionError,
@@ -14,13 +13,15 @@ from yutto.exceptions import (
 )
 from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import AId, BvId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.types import AvId, ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -79,25 +80,33 @@ class UgcVideoExtractor(SingleExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> ResolvableEpisode | None:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)
             self.avid = ugc_video_list["avid"]  # 当视频撞车时，使用新的 avid 替代原有 avid，见 #96
             Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
-            return make_ugc_video_episode(
-                ctx,
-                client,
-                self.avid,
-                ugc_video_list["pages"][self.page - 1],
-                options,
-                {
-                    "title": ugc_video_list["title"],
-                    "pubdate": ugc_video_list["pubdate"],
-                },
-                "{title}",
+            return ResolveOutcome(
+                items=(
+                    make_ugc_video_episode(
+                        ctx,
+                        client,
+                        self.avid,
+                        ugc_video_list["pages"][self.page - 1],
+                        options,
+                        {
+                            "title": ugc_video_list["title"],
+                            "pubdate": ugc_video_list["pubdate"],
+                        },
+                        "{title}",
+                    ),
+                )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
             Logger.error(e.message)
-            report_resolve_failure(e)
-            return None
+            return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/ugc_video.py
+++ b/src/yutto/extractor/ugc_video.py
@@ -20,7 +20,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import AvId, ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -84,9 +84,7 @@ class UgcVideoExtractor(SingleExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)
             self.avid = ugc_video_list["avid"]  # 当视频撞车时，使用新的 avid 替代原有 avid，见 #96

--- a/src/yutto/extractor/ugc_video_batch.py
+++ b/src/yutto/extractor/ugc_video_batch.py
@@ -4,10 +4,10 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.ugc_video import get_ugc_video_list
-from yutto.core.operation import report_resolve_failure
 from yutto.exceptions import NoAccessPermissionError, NotFoundError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import AId, BvId
 from yutto.utils.console.logger import Badge, Logger
@@ -15,7 +15,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.types import AvId, ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
 
@@ -64,33 +65,39 @@ class UgcVideoBatchExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)
             Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
         except (NotFoundError, NoAccessPermissionError) as e:
             # 由于获取 info 时候也会因为视频不存在而报错，因此这里需要捕捉下
             Logger.error(e.message)
-            report_resolve_failure(e)
-            return []
+            return ResolveOutcome(failures=(e,))
 
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(ugc_video_list["pages"]))
         ugc_video_list["pages"] = list(filter(lambda item: item["id"] in episodes, ugc_video_list["pages"]))
 
-        return [
-            make_ugc_video_episode(
-                ctx,
-                client,
-                ugc_video_item["avid"],
-                ugc_video_item,
-                options,
-                {
-                    "title": ugc_video_list["title"],
-                    "pubdate": ugc_video_list["pubdate"],
-                },
-                "{title}/{name}",
+        return ResolveOutcome(
+            items=tuple(
+                make_ugc_video_episode(
+                    ctx,
+                    client,
+                    ugc_video_item["avid"],
+                    ugc_video_item,
+                    options,
+                    {
+                        "title": ugc_video_list["title"],
+                        "pubdate": ugc_video_list["pubdate"],
+                    },
+                    "{title}/{name}",
+                )
+                for ugc_video_item in ugc_video_list["pages"]
             )
-            for ugc_video_item in ugc_video_list["pages"]
-        ]
+        )

--- a/src/yutto/extractor/ugc_video_batch.py
+++ b/src/yutto/extractor/ugc_video_batch.py
@@ -15,7 +15,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import ExtractorResolveOutcome
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.types import AvId, ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -69,6 +69,8 @@ class UgcVideoBatchExtractor(BatchExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)

--- a/src/yutto/extractor/ugc_video_batch.py
+++ b/src/yutto/extractor/ugc_video_batch.py
@@ -15,7 +15,7 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     import httpx
 
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import AvId, ExtractorOptions
     from yutto.utils.fetcher import FetcherContext
 
@@ -69,9 +69,7 @@ class UgcVideoBatchExtractor(BatchExtractor):
         ctx: FetcherContext,
         client: httpx.AsyncClient,
         options: ExtractorOptions,
-        *,
-        on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)
             Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -5,9 +5,9 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_all_favourites, get_favourite_items, get_user_name
-from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.extractor.utils.favourite import normalize_favourite_video_item
 from yutto.types import MId
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
     from yutto.api.space import FavouriteVideoData
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.exceptions import YuttoBaseException
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -37,12 +39,18 @@ class UserAllFavouritesExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         username = await get_user_name(ctx, client, self.mid)
         Logger.custom(username, Badge("用户收藏夹", fore="black", back="cyan"))
 
-        all_episodes: list[ResolvableEpisode | None] = []
+        all_episodes: list[ResolvableEpisode] = []
+        failures: list[YuttoBaseException] = []
 
         for fav in await get_all_favourites(ctx, client, self.mid):
             series_title = fav["title"]
@@ -50,7 +58,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
             favourite_videos = await get_favourite_items(ctx, client, fid)
             avids = [favourite_video["avid"] for favourite_video in favourite_videos]
 
-            # 逐视频解析完成即构建分集并推流（notify_episode_listed），收藏夹内按 index 重排。
+            # 逐视频解析完成即构建分集并通过显式回调推流，收藏夹内按 index 重排。
             # 回调在本轮循环内就被消费；循环变量经默认参数绑定（B023）。
             episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
@@ -91,18 +99,21 @@ class UserAllFavouritesExtractor(BatchExtractor):
                         auto_subpath_template,
                         display_group=display_group,
                     )
-                    notify_episode_listed(episode)
-                    await asyncio.sleep(0)
+                    if on_item is not None:
+                        await on_item(episode)
+                    else:
+                        await asyncio.sleep(0)
                     built.append(episode)
                 _episodes_by_index[index] = built
 
-            await resolve_ugc_video_lists(
+            batch_outcome = await resolve_ugc_video_lists(
                 ctx,
                 client,
                 avids,
                 publication_time_filter=options["publication_time_filter"],
                 on_resolved=build_episodes,
             )
+            failures.extend(batch_outcome.failures)
             all_episodes.extend(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, []))
 
-        return all_episodes
+        return ResolveOutcome(items=tuple(all_episodes), failures=tuple(failures))

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_all_favourites, get_favourite_items, get_user_name
-from yutto.extractor._abc import BatchExtractor
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -19,12 +19,13 @@ if TYPE_CHECKING:
     from yutto.api.space import FavouriteVideoData
     from yutto.api.ugc_video import UgcVideoList
     from yutto.exceptions import YuttoBaseException
-    from yutto.extractor._abc import EpisodeListedCallback
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
+    from yutto.types import ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
-class UserAllFavouritesExtractor(BatchExtractor):
+class UserAllFavouritesExtractor(StreamingBatchExtractor):
     """用户所有收藏夹"""
 
     REGEX_FAV_ALL = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)/favlist$")
@@ -45,7 +46,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         username = await get_user_name(ctx, client, self.mid)
         Logger.custom(username, Badge("用户收藏夹", fore="black", back="cyan"))
 
@@ -63,16 +64,14 @@ class UserAllFavouritesExtractor(BatchExtractor):
             episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
             async def build_episodes(
-                index: int,
-                _avid: AvId,
-                ugc_video_list: UgcVideoList | None,
+                resolved: IndexedResolveItem[UgcVideoList],
                 *,
                 _favourite_videos: list[FavouriteVideoData] = favourite_videos,
                 _series_title: str = series_title,
                 _episodes_by_index: dict[int, list[ResolvableEpisode]] = episodes_by_index,
             ) -> None:
-                if ugc_video_list is None:
-                    return
+                index = resolved.index
+                ugc_video_list = resolved.value
                 favourite_video = _favourite_videos[index]
                 # 优先使用收藏夹 API 返回的人工标题；失效视频 title 为空时退回到 ugc 接口标题
                 favourite_title = favourite_video["title"] or ugc_video_list["title"]
@@ -113,7 +112,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
                 publication_time_filter=options["publication_time_filter"],
                 on_resolved=build_episodes,
             )
-            failures.extend(batch_outcome.failures)
+            failures.extend(failure.error for failure in batch_outcome.failures)
             all_episodes.extend(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, []))
 
         return ResolveOutcome(items=tuple(all_episodes), failures=tuple(failures))

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_all_favourites, get_favourite_items, get_user_name
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from yutto.utils.fetcher import FetcherContext
 
 
-class UserAllFavouritesExtractor(StreamingBatchExtractor):
+class UserAllFavouritesExtractor(BatchExtractor):
     """用户所有收藏夹"""
 
     REGEX_FAV_ALL = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)/favlist$")

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_user_name, get_user_space_all_videos_avids
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from yutto.utils.fetcher import FetcherContext
 
 
-class UserAllUgcVideosExtractor(StreamingBatchExtractor):
+class UserAllUgcVideosExtractor(BatchExtractor):
     """UP 主个人空间全部投稿视频"""
 
     REGEX_SPACE = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)(/video)?")

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_user_name, get_user_space_all_videos_avids
-from yutto.extractor._abc import BatchExtractor
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -16,12 +16,13 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
-    from yutto.extractor._abc import EpisodeListedCallback
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
+    from yutto.types import ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
-class UserAllUgcVideosExtractor(BatchExtractor):
+class UserAllUgcVideosExtractor(StreamingBatchExtractor):
     """UP 主个人空间全部投稿视频"""
 
     REGEX_SPACE = re.compile(r"https?://space\.bilibili\.com/(?P<mid>\d+)(/video)?")
@@ -42,7 +43,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         username = await get_user_name(ctx, client, self.mid)
         Logger.custom(username, Badge("UP 主投稿视频", fore="black", back="cyan"))
 
@@ -58,9 +59,9 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
-            if ugc_video_list is None:
-                return
+        async def build_episodes(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+            index = resolved.index
+            ugc_video_list = resolved.value
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
@@ -92,5 +93,5 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         )
         return ResolveOutcome(
             items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
-            failures=batch_outcome.failures,
+            failures=tuple(failure.error for failure in batch_outcome.failures),
         )

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -5,9 +5,9 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_user_name, get_user_space_all_videos_avids
-from yutto.core.operation import notify_episode_listed
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import MId
 from yutto.utils.console.logger import Badge, Logger
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -35,8 +36,13 @@ class UserAllUgcVideosExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         username = await get_user_name(ctx, client, self.mid)
         Logger.custom(username, Badge("UP 主投稿视频", fore="black", back="cyan"))
 
@@ -49,7 +55,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
             stop_before_timestamp=publication_time_filter.start_timestamp,
         )
 
-        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
         async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
@@ -70,16 +76,21 @@ class UserAllUgcVideosExtractor(BatchExtractor):
                     },
                     "{username}的全部投稿视频/{title}/{name}",
                 )
-                notify_episode_listed(episode)
-                await asyncio.sleep(0)
+                if on_item is not None:
+                    await on_item(episode)
+                else:
+                    await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 
-        await resolve_ugc_video_lists(
+        batch_outcome = await resolve_ugc_video_lists(
             ctx,
             client,
             avids,
             publication_time_filter=publication_time_filter,
             on_resolved=build_episodes,
         )
-        return [episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])]
+        return ResolveOutcome(
+            items=tuple(episode for index in range(len(avids)) for episode in episodes_by_index.get(index, [])),
+            failures=batch_outcome.failures,
+        )

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -5,10 +5,10 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_watch_later_avids
-from yutto.core.operation import notify_episode_listed, report_resolve_failure
 from yutto.exceptions import NotLoginError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.utils.console.logger import Badge, Logger
 
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
@@ -33,18 +34,22 @@ class UserWatchLaterExtractor(BatchExtractor):
             return False
 
     async def extract(
-        self, ctx: FetcherContext, client: httpx.AsyncClient, options: ExtractorOptions
-    ) -> list[ResolvableEpisode | None]:
+        self,
+        ctx: FetcherContext,
+        client: httpx.AsyncClient,
+        options: ExtractorOptions,
+        *,
+        on_item: EpisodeListedCallback | None = None,
+    ) -> ResolveOutcome:
         Logger.custom("当前用户", Badge("稍后再看", fore="black", back="cyan"))
 
         try:
             avid_list = await get_watch_later_avids(ctx, client)
         except NotLoginError as e:
             Logger.error(e.message)
-            report_resolve_failure(e)
-            return []
+            return ResolveOutcome(failures=(e,))
 
-        # 逐视频解析完成即构建分集并推流（notify_episode_listed），最终按 index 重排。
+        # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
         async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
@@ -66,16 +71,21 @@ class UserWatchLaterExtractor(BatchExtractor):
                     },
                     "稍后再看/{title}/{name}",
                 )
-                notify_episode_listed(episode)
-                await asyncio.sleep(0)
+                if on_item is not None:
+                    await on_item(episode)
+                else:
+                    await asyncio.sleep(0)
                 built.append(episode)
             episodes_by_index[index] = built
 
-        await resolve_ugc_video_lists(
+        batch_outcome = await resolve_ugc_video_lists(
             ctx,
             client,
             avid_list,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,
         )
-        return [episode for index in range(len(avid_list)) for episode in episodes_by_index.get(index, [])]
+        return ResolveOutcome(
+            items=tuple(episode for index in range(len(avid_list)) for episode in episodes_by_index.get(index, [])),
+            failures=batch_outcome.failures,
+        )

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from yutto.api.space import get_watch_later_avids
 from yutto.exceptions import NotLoginError
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from yutto.utils.fetcher import FetcherContext
 
 
-class UserWatchLaterExtractor(StreamingBatchExtractor):
+class UserWatchLaterExtractor(BatchExtractor):
     """用户稍后再看"""
 
     REGEX_WATCH_LATER_INDEX = re.compile(r"https?://www\.bilibili\.com/watchlater/?.*?$")

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from yutto.api.space import get_watch_later_avids
 from yutto.exceptions import NotLoginError
-from yutto.extractor._abc import BatchExtractor
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -16,12 +16,13 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
-    from yutto.extractor._abc import EpisodeListedCallback
-    from yutto.types import AvId, ExtractorOptions, ResolvableEpisode
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
+    from yutto.types import ExtractorOptions, ResolvableEpisode
     from yutto.utils.fetcher import FetcherContext
 
 
-class UserWatchLaterExtractor(BatchExtractor):
+class UserWatchLaterExtractor(StreamingBatchExtractor):
     """用户稍后再看"""
 
     REGEX_WATCH_LATER_INDEX = re.compile(r"https?://www\.bilibili\.com/watchlater/?.*?$")
@@ -40,7 +41,7 @@ class UserWatchLaterExtractor(BatchExtractor):
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         Logger.custom("当前用户", Badge("稍后再看", fore="black", back="cyan"))
 
         try:
@@ -52,9 +53,9 @@ class UserWatchLaterExtractor(BatchExtractor):
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
 
-        async def build_episodes(index: int, _avid: AvId, ugc_video_list: UgcVideoList | None) -> None:
-            if ugc_video_list is None:
-                return
+        async def build_episodes(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+            index = resolved.index
+            ugc_video_list = resolved.value
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
@@ -87,5 +88,5 @@ class UserWatchLaterExtractor(BatchExtractor):
         )
         return ResolveOutcome(
             items=tuple(episode for index in range(len(avid_list)) for episode in episodes_by_index.get(index, [])),
-            failures=batch_outcome.failures,
+            failures=tuple(failure.error for failure in batch_outcome.failures),
         )

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -4,8 +4,8 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from yutto.api.ugc_video import get_ugc_video_list
-from yutto.core.operation import report_resolve_failure
 from yutto.exceptions import MaxRetryError, NoAccessPermissionError, NotFoundError
+from yutto.extractor.outcome import BatchResolveOutcome
 from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.exceptions import YuttoBaseException
     from yutto.types import AvId
     from yutto.utils.fetcher import FetcherContext
     from yutto.utils.filter import PublicationTimeFilter
@@ -27,7 +28,7 @@ async def resolve_ugc_video_lists(
     *,
     publication_time_filter: PublicationTimeFilter,
     on_resolved: Callable[[int, AvId, UgcVideoList | None], Awaitable[None]] | None = None,
-) -> list[UgcVideoList | None]:
+) -> BatchResolveOutcome[UgcVideoList]:
     """并发解析一批视频的分 P 列表，结果顺序与 avids 一致
 
     并发度由 ctx 中已有的 fetch semaphore 控制（Fetcher 的每个请求都会经过 ctx.fetch_guard()），
@@ -44,31 +45,31 @@ async def resolve_ugc_video_lists(
     函数返回或抛错后不会再有回调或事件发生；单个异常直接抛原始异常，保持稳定错误码。
     """
 
-    async def resolve_one(avid: AvId) -> UgcVideoList | None:
+    async def resolve_one(avid: AvId) -> tuple[UgcVideoList | None, YuttoBaseException | None]:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, avid)
             if not publication_time_filter.matches(ugc_video_list["pubdate"]):
                 Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
-                return None
+                return None, None
             # 在使用 SESSDATA 时，如果不去事先 touch 一下视频链接的话，是无法获取 episode_data 的
             # 至于为什么前面那俩（投稿视频页和番剧页）不需要额外 touch，因为在 get_redirected_url 阶段连接过了呀
             unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
-            return ugc_video_list
+            return ugc_video_list, None
         except (NotFoundError, NoAccessPermissionError) as e:
             Logger.error(e.message)
-            report_resolve_failure(e)
-            return None
+            return None, e
         except MaxRetryError as e:
             Logger.error(f"获取视频 {avid} 信息失败：{e.message}")
-            report_resolve_failure(e)
-            return None
+            return None, e
 
     results: list[UgcVideoList | None] = [None] * len(avids)
+    failures: list[YuttoBaseException | None] = [None] * len(avids)
     completed: asyncio.Queue[tuple[int, AvId, UgcVideoList | None]] = asyncio.Queue()
 
     async def resolve_into(index: int, avid: AvId) -> None:
-        result = await resolve_one(avid)
+        result, failure = await resolve_one(avid)
         results[index] = result
+        failures[index] = failure
         completed.put_nowait((index, avid, result))
 
     async def publish_completed(deliver: Callable[[int, AvId, UgcVideoList | None], Awaitable[None]]) -> None:
@@ -89,4 +90,7 @@ async def resolve_ugc_video_lists(
         if len(error_group.exceptions) == 1:
             raise error_group.exceptions[0] from None
         raise
-    return results
+    return BatchResolveOutcome(
+        results=tuple(results),
+        failures=tuple(failure for failure in failures if failure is not None),
+    )

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
 
-from yutto.api.ugc_video import get_ugc_video_list
+from yutto.api.ugc_video import UgcVideoList, get_ugc_video_list
 from yutto.exceptions import MaxRetryError, NoAccessPermissionError, NotFoundError
-from yutto.extractor.outcome import BatchResolveOutcome
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
@@ -14,11 +15,32 @@ if TYPE_CHECKING:
 
     import httpx
 
-    from yutto.api.ugc_video import UgcVideoList
     from yutto.exceptions import YuttoBaseException
     from yutto.types import AvId
     from yutto.utils.fetcher import FetcherContext
     from yutto.utils.filter import PublicationTimeFilter
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class IndexedResolveItem(Generic[T]):
+    index: int
+    source: AvId
+    value: T
+
+
+@dataclass(frozen=True, slots=True)
+class IndexedResolveFailure:
+    index: int
+    source: AvId
+    error: YuttoBaseException
+
+
+@dataclass(frozen=True, slots=True)
+class _FilteredResolveItem:
+    index: int
+    source: AvId
 
 
 async def resolve_ugc_video_lists(
@@ -27,16 +49,16 @@ async def resolve_ugc_video_lists(
     avids: list[AvId],
     *,
     publication_time_filter: PublicationTimeFilter,
-    on_resolved: Callable[[int, AvId, UgcVideoList | None], Awaitable[None]] | None = None,
-) -> BatchResolveOutcome[UgcVideoList]:
+    on_resolved: Callable[[IndexedResolveItem[UgcVideoList]], Awaitable[None]] | None = None,
+) -> ResolveOutcome[IndexedResolveItem[UgcVideoList], IndexedResolveFailure]:
     """并发解析一批视频的分 P 列表，结果顺序与 avids 一致
 
     并发度由 ctx 中已有的 fetch semaphore 控制（Fetcher 的每个请求都会经过 ctx.fetch_guard()），
-    这里无需额外限流；被时间过滤或解析失败（NotFoundError / NoAccessPermissionError /
-    MaxRetryError）的视频以 None 占位，不会中断整批解析。
+    这里无需额外限流；时间过滤项不进入 outcome，预期失败则显式保留输入位置和来源，
+    不会中断整批解析。
 
     on_resolved 由单一 publisher 串行 await：解析仍然并发，但已完成的结果按完成顺序
-    逐个交付（参数为 (index, avid, result)，index 是该 avid 在入参列表中的位置）。
+    逐个交付；每个成功结果携带 avid 及其在入参列表中的位置。
     多个同时就绪的视频不会并发发布、多分 P 视频的事件不会彼此穿插；回调约定在每推送
     一个分集后让出一次控制权（内置提取器均如此），因此事件生产对消费者（如 server
     每连接的 sender）始终可调度，不受同时完成的视频数或单视频分 P 数影响。
@@ -45,38 +67,40 @@ async def resolve_ugc_video_lists(
     函数返回或抛错后不会再有回调或事件发生；单个异常直接抛原始异常，保持稳定错误码。
     """
 
-    async def resolve_one(avid: AvId) -> tuple[UgcVideoList | None, YuttoBaseException | None]:
+    async def resolve_one(
+        index: int, avid: AvId
+    ) -> IndexedResolveItem[UgcVideoList] | IndexedResolveFailure | _FilteredResolveItem:
         try:
             ugc_video_list = await get_ugc_video_list(ctx, client, avid)
             if not publication_time_filter.matches(ugc_video_list["pubdate"]):
                 Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
-                return None, None
+                return _FilteredResolveItem(index=index, source=avid)
             # 在使用 SESSDATA 时，如果不去事先 touch 一下视频链接的话，是无法获取 episode_data 的
             # 至于为什么前面那俩（投稿视频页和番剧页）不需要额外 touch，因为在 get_redirected_url 阶段连接过了呀
             unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
-            return ugc_video_list, None
+            return IndexedResolveItem(index=index, source=avid, value=ugc_video_list)
         except (NotFoundError, NoAccessPermissionError) as e:
             Logger.error(e.message)
-            return None, e
+            return IndexedResolveFailure(index=index, source=avid, error=e)
         except MaxRetryError as e:
             Logger.error(f"获取视频 {avid} 信息失败：{e.message}")
-            return None, e
+            return IndexedResolveFailure(index=index, source=avid, error=e)
 
-    results: list[UgcVideoList | None] = [None] * len(avids)
-    failures: list[YuttoBaseException | None] = [None] * len(avids)
-    completed: asyncio.Queue[tuple[int, AvId, UgcVideoList | None]] = asyncio.Queue()
+    Completion = IndexedResolveItem[UgcVideoList] | IndexedResolveFailure | _FilteredResolveItem
+    completed_by_index: dict[int, Completion] = {}
+    completed: asyncio.Queue[Completion] = asyncio.Queue()
 
     async def resolve_into(index: int, avid: AvId) -> None:
-        result, failure = await resolve_one(avid)
-        results[index] = result
-        failures[index] = failure
-        completed.put_nowait((index, avid, result))
+        result = await resolve_one(index, avid)
+        completed_by_index[index] = result
+        completed.put_nowait(result)
 
-    async def publish_completed(deliver: Callable[[int, AvId, UgcVideoList | None], Awaitable[None]]) -> None:
+    async def publish_completed(deliver: Callable[[IndexedResolveItem[UgcVideoList]], Awaitable[None]]) -> None:
         # 单一 producer：完成一个交付一个，publisher 的每次 await 都给消费者排空队列的机会
         for _ in range(len(avids)):
-            index, avid, result = await completed.get()
-            await deliver(index, avid, result)
+            result = await completed.get()
+            if isinstance(result, IndexedResolveItem):
+                await deliver(result)
 
     try:
         async with asyncio.TaskGroup() as task_group:
@@ -90,7 +114,8 @@ async def resolve_ugc_video_lists(
         if len(error_group.exceptions) == 1:
             raise error_group.exceptions[0] from None
         raise
-    return BatchResolveOutcome(
-        results=tuple(results),
-        failures=tuple(failure for failure in failures if failure is not None),
+    ordered = tuple(completed_by_index[index] for index in range(len(avids)))
+    return ResolveOutcome(
+        items=tuple(result for result in ordered if isinstance(result, IndexedResolveItem)),
+        failures=tuple(result for result in ordered if isinstance(result, IndexedResolveFailure)),
     )

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -88,15 +88,17 @@ async def resolve_ugc_video_lists(
 
     Completion = IndexedResolveItem[UgcVideoList] | IndexedResolveFailure | _FilteredResolveItem
     completed_by_index: dict[int, Completion] = {}
-    completed: asyncio.Queue[Completion] = asyncio.Queue()
+    completed: asyncio.Queue[Completion] | None = asyncio.Queue() if on_resolved is not None else None
 
     async def resolve_into(index: int, avid: AvId) -> None:
         result = await resolve_one(index, avid)
         completed_by_index[index] = result
-        completed.put_nowait(result)
+        if completed is not None:
+            completed.put_nowait(result)
 
     async def publish_completed(deliver: Callable[[IndexedResolveItem[UgcVideoList]], Awaitable[None]]) -> None:
         # 单一 producer：完成一个交付一个，publisher 的每次 await 都给消费者排空队列的机会
+        assert completed is not None
         for _ in range(len(avids)):
             result = await completed.get()
             if isinstance(result, IndexedResolveItem):

--- a/tests/test_processor/test_batch_resolve.py
+++ b/tests/test_processor/test_batch_resolve.py
@@ -62,13 +62,14 @@ async def test_resolve_ugc_video_lists_preserves_order(monkeypatch: pytest.Monke
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
 
-    assert [result["title"] if result is not None else None for result in outcome.results] == [
+    assert [item.value["title"] for item in outcome.items] == [
         "video-1",
         "video-2",
-        None,
         "video-4",
         "video-5",
     ]
+    assert [item.index for item in outcome.items] == [0, 1, 3, 4]
+    assert outcome.failures == ()
 
 
 @pytest.mark.processor
@@ -99,11 +100,11 @@ async def test_resolve_ugc_video_lists_isolates_failures(monkeypatch: pytest.Mon
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
 
-    assert outcome.results[0] is not None
-    assert outcome.results[1] is None
-    assert outcome.results[2] is None
-    assert outcome.results[3] is not None
-    assert [type(error).__name__ for error in outcome.failures] == ["NotFoundError", "MaxRetryError"]
+    assert [item.index for item in outcome.items] == [0, 3]
+    assert [str(item.source) for item in outcome.items] == ["1", "4"]
+    assert [failure.index for failure in outcome.failures] == [1, 2]
+    assert [str(failure.source) for failure in outcome.failures] == ["2", "3"]
+    assert [type(failure.error).__name__ for failure in outcome.failures] == ["NotFoundError", "MaxRetryError"]
 
 
 @pytest.mark.processor
@@ -145,6 +146,6 @@ async def test_resolve_ugc_video_lists_bounded_by_fetch_semaphore(monkeypatch: p
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
 
-    assert all(result is not None for result in outcome.results)
+    assert len(outcome.items) == len(avids)
     assert outcome.failures == ()
     assert max_running == fetch_workers

--- a/tests/test_processor/test_batch_resolve.py
+++ b/tests/test_processor/test_batch_resolve.py
@@ -55,14 +55,14 @@ async def test_resolve_ugc_video_lists_preserves_order(monkeypatch: pytest.Monke
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", touch_url_ok)
 
-    results = await resolve_ugc_video_lists(
+    outcome = await resolve_ugc_video_lists(
         FetcherContext(),
         make_fake_client(),
         avids,
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
 
-    assert [result["title"] if result is not None else None for result in results] == [
+    assert [result["title"] if result is not None else None for result in outcome.results] == [
         "video-1",
         "video-2",
         None,
@@ -92,17 +92,18 @@ async def test_resolve_ugc_video_lists_isolates_failures(monkeypatch: pytest.Mon
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
-    results = await resolve_ugc_video_lists(
+    outcome = await resolve_ugc_video_lists(
         FetcherContext(),
         make_fake_client(),
         avids,
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
 
-    assert results[0] is not None
-    assert results[1] is None
-    assert results[2] is None
-    assert results[3] is not None
+    assert outcome.results[0] is not None
+    assert outcome.results[1] is None
+    assert outcome.results[2] is None
+    assert outcome.results[3] is not None
+    assert [type(error).__name__ for error in outcome.failures] == ["NotFoundError", "MaxRetryError"]
 
 
 @pytest.mark.processor
@@ -137,12 +138,13 @@ async def test_resolve_ugc_video_lists_bounded_by_fetch_semaphore(monkeypatch: p
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
     avids: list[AvId] = [AId(str(i)) for i in range(10)]
-    results = await resolve_ugc_video_lists(
+    outcome = await resolve_ugc_video_lists(
         ctx,
         make_fake_client(),
         avids,
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
 
-    assert all(result is not None for result in results)
+    assert all(result is not None for result in outcome.results)
+    assert outcome.failures == ()
     assert max_running == fetch_workers

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -18,6 +18,7 @@ from yutto.download_manager import (
     show_batch_episode_title,
 )
 from yutto.exceptions import NotLoginError, WrongArgumentError
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import AId, CId, ResolvableEpisode
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.fetcher import Fetcher, FetcherContext
@@ -144,13 +145,15 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ):
+            *,
+            on_item: object | None = None,
+        ) -> ResolveOutcome:
             captured_extractor_options.update(options)
 
             async def resolve_episode() -> EpisodeData | None:
                 return episode
 
-            return [ResolvableEpisode(info=episode["info"], resolve_data=resolve_episode)]
+            return ResolveOutcome(items=(ResolvableEpisode(info=episode["info"], resolve_data=resolve_episode),))
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
         validation_requirements.append(requirements)
@@ -263,18 +266,20 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
 
         return resolve_data
 
-    episodes: list[ResolvableEpisode | None] = [
+    episodes = (
         ResolvableEpisode(info=first_episode["info"], resolve_data=make_resolver("first", first_episode)),
         ResolvableEpisode(info=second_episode["info"], resolve_data=make_resolver("second", second_episode)),
-    ]
+    )
     validation_results = iter([True, False])
 
     async def fake_resolve_request(
         client: httpx.AsyncClient,
         ctx: FetcherContext,
         request: DownloadRequest,
-    ) -> list[ResolvableEpisode | None]:
-        return episodes
+        *,
+        on_item: object | None = None,
+    ) -> ResolveOutcome:
+        return ResolveOutcome(items=episodes)
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
         return next(validation_results)

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -29,6 +29,7 @@ from yutto.utils.time import TIME_FULL_FMT
 if TYPE_CHECKING:
     import httpx
 
+    from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import DownloaderOptions, EpisodeData, ExtractorOptions
 
 pytestmark = pytest.mark.processor
@@ -145,9 +146,7 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-            *,
-            on_item: object | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             captured_extractor_options.update(options)
 
             async def resolve_episode() -> EpisodeData | None:
@@ -276,9 +275,7 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
         client: httpx.AsyncClient,
         ctx: FetcherContext,
         request: DownloadRequest,
-        *,
-        on_item: object | None = None,
-    ) -> ResolveOutcome:
+    ) -> ExtractorResolveOutcome:
         return ResolveOutcome(items=episodes)
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -14,6 +14,7 @@ from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem, ResolveFailure, ResolveResult
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, MaxRetryError, NotFoundError, NotLoginError, ResolveFailedError
+from yutto.extractor._abc import StreamingBatchExtractor
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId, CId, ResolvableEpisode
@@ -24,8 +25,10 @@ from yutto.utils.functional import as_sync
 if TYPE_CHECKING:
     import httpx
 
+    from yutto.api.ugc_video import UgcVideoList
     from yutto.core.events import DownloadEvent
-    from yutto.extractor._abc import EpisodeListedCallback
+    from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
+    from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import EpisodeData, EpisodeInfo, ExtractorOptions
 
 pytestmark = pytest.mark.processor
@@ -67,8 +70,8 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
     resolvable = ResolvableEpisode(info=info, resolve_data=resolve_episode)
 
     class FakeExtractor:
-        def resolve_shortcut(self, url: str) -> tuple[bool, str]:
-            return True, f"https://example.com/{url}"
+        def resolve_shortcut(self, id: str) -> tuple[bool, str]:
+            return True, f"https://example.com/{id}"
 
         def match(self, url: str) -> bool:
             return url == "https://example.com/BV1baseline"
@@ -78,9 +81,7 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-            *,
-            on_item: EpisodeListedCallback | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             return ResolveOutcome(items=(resolvable,))
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
@@ -150,21 +151,21 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
     final_copy = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
     late = ResolvableEpisode(info=make_info("P2", display_group="标题"), resolve_data=noop)
 
-    class FakeExtractor:
-        def resolve_shortcut(self, url: str) -> tuple[bool, str]:
-            return True, f"https://example.com/{url}"
+    class FakeExtractor(StreamingBatchExtractor):
+        def resolve_shortcut(self, id: str) -> tuple[bool, str]:
+            return True, f"https://example.com/{id}"
 
         def match(self, url: str) -> bool:
             return url == "https://example.com/BV1stream"
 
-        async def __call__(
+        async def extract(
             self,
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
             *,
             on_item: EpisodeListedCallback | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             # 流式提取器：解析过程中先推送 P1；P2 留给 resolve_items 收尾补发
             assert on_item is not None
             await on_item(streamed)
@@ -232,16 +233,14 @@ class _ShortcutExtractorBase:
 
 
 @as_sync
-async def test_execute_resolve_treats_filtered_only_nones_as_empty_success(monkeypatch: pytest.MonkeyPatch):
+async def test_execute_resolve_treats_filtered_source_as_empty_success(monkeypatch: pytest.MonkeyPatch):
     class FilteredExtractor(_ShortcutExtractorBase):
         async def __call__(
             self,
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-            *,
-            on_item: EpisodeListedCallback | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             # 纯过滤（如发布时间过滤 / 选集过滤）没有条目，也没有失败
             return ResolveOutcome()
 
@@ -305,9 +304,7 @@ async def test_execute_resolve_reports_partial_failures(monkeypatch: pytest.Monk
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-            *,
-            on_item: EpisodeListedCallback | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             return ResolveOutcome(
                 items=(resolvable,),
                 failures=(MaxRetryError("获取视频 av2 信息失败：超出最大重试次数！"),),
@@ -339,9 +336,7 @@ async def test_execute_resolve_aggregates_multiple_failures(monkeypatch: pytest.
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-            *,
-            on_item: EpisodeListedCallback | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             return ResolveOutcome(
                 failures=(
                     NotFoundError("啊叻？视频 av1 不见了诶"),
@@ -382,9 +377,9 @@ async def test_resolve_ugc_video_lists_reports_expected_failures(monkeypatch: py
         publication_time_filter=PublicationTimeFilter.from_strings(None, None),
     )
 
-    # 失败以 None 占位、顺序保持，同时结构化上报 —— 收藏夹等批量 extractor 丢弃 None 前信息不再丢失
-    assert outcome.results == (None, fake_list)
-    assert [type(error).__name__ for error in outcome.failures] == ["MaxRetryError"]
+    assert [(item.index, str(item.source), item.value) for item in outcome.items] == [(1, "2", fake_list)]
+    assert [(failure.index, str(failure.source)) for failure in outcome.failures] == [(0, "1")]
+    assert [type(failure.error).__name__ for failure in outcome.failures] == ["MaxRetryError"]
 
 
 @as_sync
@@ -402,8 +397,8 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
 
     calls: list[tuple[int, str, bool]] = []
 
-    async def on_resolved(index: int, avid: object, result: object) -> None:
-        calls.append((index, str(avid), result is not None))
+    async def on_resolved(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+        calls.append((resolved.index, str(resolved.source), True))
         # 契约：回调是异步的，逐分集的让出由回调自身负责（内置提取器均如此）
         await asyncio.sleep(0)
 
@@ -416,8 +411,8 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
         on_resolved=on_resolved,
     )
 
-    # 每个视频恰好触发一次 await 回调，携带 (入参序 index, avid, 解析结果)
-    assert len(outcome.results) == 2
+    # 每个成功视频恰好触发一次 await 回调，并显式携带输入位置与来源
+    assert len(outcome.items) == 2
     assert sorted(calls) == [(0, "1", True), (1, "2", True)]
 
 
@@ -440,8 +435,8 @@ async def test_resolve_ugc_video_lists_cancels_siblings_on_fatal_error(monkeypat
 
     calls: list[int] = []
 
-    async def on_resolved(index: int, avid: object, result: object) -> None:
-        calls.append(index)
+    async def on_resolved(resolved: IndexedResolveItem[UgcVideoList]) -> None:
+        calls.append(resolved.index)
 
     client = cast("httpx.AsyncClient", object())
     # 单个未预期异常直接抛原始异常（而非 ExceptionGroup），wire 错误类型保持稳定
@@ -477,7 +472,7 @@ async def test_resolve_ugc_video_lists_cancels_workers_when_callback_fails(monke
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
-    async def on_resolved(index: int, avid: object, result: object) -> None:
+    async def on_resolved(resolved: IndexedResolveItem[UgcVideoList]) -> None:
         raise RuntimeError("callback boom")
 
     client = cast("httpx.AsyncClient", object())
@@ -504,9 +499,7 @@ async def test_execute_resolve_keeps_genuinely_empty_source_as_success(monkeypat
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-            *,
-            on_item: EpisodeListedCallback | None = None,
-        ) -> ResolveOutcome:
+        ) -> ExtractorResolveOutcome:
             return ResolveOutcome()
 
     _patch_resolve_environment(monkeypatch, EmptySourceExtractor)

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -9,16 +9,12 @@ from returns.result import Success
 
 import yutto.download_manager as download_manager_module
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.operation import (
-    bind_download_event_sink,
-    collect_resolve_failures,
-    notify_episode_listed,
-    report_resolve_failure,
-)
+from yutto.core.operation import bind_download_event_sink
 from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem, ResolveFailure, ResolveResult
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, MaxRetryError, NotFoundError, NotLoginError, ResolveFailedError
+from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId, CId, ResolvableEpisode
 from yutto.utils.fetcher import Fetcher, FetcherContext
@@ -29,6 +25,7 @@ if TYPE_CHECKING:
     import httpx
 
     from yutto.core.events import DownloadEvent
+    from yutto.extractor._abc import EpisodeListedCallback
     from yutto.types import EpisodeData, EpisodeInfo, ExtractorOptions
 
 pytestmark = pytest.mark.processor
@@ -81,8 +78,10 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ) -> list[ResolvableEpisode | None]:
-            return [None, resolvable]
+            *,
+            on_item: EpisodeListedCallback | None = None,
+        ) -> ResolveOutcome:
+            return ResolveOutcome(items=(resolvable,))
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
         return True
@@ -115,7 +114,8 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
         description="视频简介",
         tags=("标签A", "标签B"),
     )
-    assert items == [expected_item]
+    assert items.items == (expected_item,)
+    assert items.failures == ()
     # data resolver 从未调用，因此没有未 await 的 coroutine 需要清理
     assert executed == []
     assert sink.events == [
@@ -137,8 +137,8 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
 
 
 @as_sync
-async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypatch: pytest.MonkeyPatch):
-    """流式提取器经 notify_episode_listed 提前推送的条目不会被收尾补发重复。"""
+async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypatch: pytest.MonkeyPatch):
+    """流式回调与最终结果中的等值条目不依赖对象身份去重。"""
 
     resolved: list[str] = []
 
@@ -147,6 +147,7 @@ async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypa
         return None
 
     streamed = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+    final_copy = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
     late = ResolvableEpisode(info=make_info("P2", display_group="标题"), resolve_data=noop)
 
     class FakeExtractor:
@@ -161,10 +162,14 @@ async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypa
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ) -> list[ResolvableEpisode | None]:
+            *,
+            on_item: EpisodeListedCallback | None = None,
+        ) -> ResolveOutcome:
             # 流式提取器：解析过程中先推送 P1；P2 留给 resolve_items 收尾补发
-            notify_episode_listed(streamed)
-            return [streamed, late]
+            assert on_item is not None
+            await on_item(streamed)
+            await on_item(streamed)
+            return ResolveOutcome(items=(final_copy, late))
 
     async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
         return True
@@ -188,7 +193,7 @@ async def test_resolve_items_streams_hooked_episodes_without_duplicates(monkeypa
     # 每条恰好一次：流式推送的 P1 在前（提取中），P2 收尾补发
     assert [event.name for event in listed] == ["P1", "P2"]
     # 返回列表保持提取器给出的顺序
-    assert [item.name for item in items] == ["P1", "P2"]
+    assert [item.name for item in items.items] == ["P1", "P2"]
     # resolve-only 路径不会调用 data resolver，也不会提前创建 coroutine
     assert resolved == []
 
@@ -234,9 +239,11 @@ async def test_execute_resolve_treats_filtered_only_nones_as_empty_success(monke
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ) -> list[ResolvableEpisode | None]:
-            # 纯过滤（如发布时间过滤 / 选集过滤）产生的 None：没有失败上报
-            return [None, None]
+            *,
+            on_item: EpisodeListedCallback | None = None,
+        ) -> ResolveOutcome:
+            # 纯过滤（如发布时间过滤 / 选集过滤）没有条目，也没有失败
+            return ResolveOutcome()
 
     _patch_resolve_environment(monkeypatch, FilteredExtractor)
     manager = DownloadManager()
@@ -298,9 +305,13 @@ async def test_execute_resolve_reports_partial_failures(monkeypatch: pytest.Monk
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ) -> list[ResolvableEpisode | None]:
-            report_resolve_failure(MaxRetryError("获取视频 av2 信息失败：超出最大重试次数！"))
-            return [resolvable, None]
+            *,
+            on_item: EpisodeListedCallback | None = None,
+        ) -> ResolveOutcome:
+            return ResolveOutcome(
+                items=(resolvable,),
+                failures=(MaxRetryError("获取视频 av2 信息失败：超出最大重试次数！"),),
+            )
 
     _patch_resolve_environment(monkeypatch, PartialExtractor)
     manager = DownloadManager()
@@ -328,10 +339,15 @@ async def test_execute_resolve_aggregates_multiple_failures(monkeypatch: pytest.
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ) -> list[ResolvableEpisode | None]:
-            report_resolve_failure(NotFoundError("啊叻？视频 av1 不见了诶"))
-            report_resolve_failure(MaxRetryError("获取视频 av2 信息失败：超出最大重试次数！"))
-            return [None, None]
+            *,
+            on_item: EpisodeListedCallback | None = None,
+        ) -> ResolveOutcome:
+            return ResolveOutcome(
+                failures=(
+                    NotFoundError("啊叻？视频 av1 不见了诶"),
+                    MaxRetryError("获取视频 av2 信息失败：超出最大重试次数！"),
+                )
+            )
 
     _patch_resolve_environment(monkeypatch, AllFailedExtractor)
     manager = DownloadManager()
@@ -359,17 +375,16 @@ async def test_resolve_ugc_video_lists_reports_expected_failures(monkeypatch: py
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
     client = cast("httpx.AsyncClient", object())
-    with collect_resolve_failures() as failures:
-        results = await resolve_ugc_video_lists(
-            FetcherContext(),
-            client,
-            [AId("1"), AId("2")],
-            publication_time_filter=PublicationTimeFilter.from_strings(None, None),
-        )
+    outcome = await resolve_ugc_video_lists(
+        FetcherContext(),
+        client,
+        [AId("1"), AId("2")],
+        publication_time_filter=PublicationTimeFilter.from_strings(None, None),
+    )
 
     # 失败以 None 占位、顺序保持，同时结构化上报 —— 收藏夹等批量 extractor 丢弃 None 前信息不再丢失
-    assert results == [None, fake_list]
-    assert [type(error).__name__ for error in failures] == ["MaxRetryError"]
+    assert outcome.results == (None, fake_list)
+    assert [type(error).__name__ for error in outcome.failures] == ["MaxRetryError"]
 
 
 @as_sync
@@ -393,7 +408,7 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
         await asyncio.sleep(0)
 
     client = cast("httpx.AsyncClient", object())
-    results = await resolve_ugc_video_lists(
+    outcome = await resolve_ugc_video_lists(
         FetcherContext(),
         client,
         [AId("1"), AId("2")],
@@ -402,7 +417,7 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
     )
 
     # 每个视频恰好触发一次 await 回调，携带 (入参序 index, avid, 解析结果)
-    assert len(results) == 2
+    assert len(outcome.results) == 2
     assert sorted(calls) == [(0, "1", True), (1, "2", True)]
 
 
@@ -489,8 +504,10 @@ async def test_execute_resolve_keeps_genuinely_empty_source_as_success(monkeypat
             ctx: FetcherContext,
             client: httpx.AsyncClient,
             options: ExtractorOptions,
-        ) -> list[ResolvableEpisode | None]:
-            return []
+            *,
+            on_item: EpisodeListedCallback | None = None,
+        ) -> ResolveOutcome:
+            return ResolveOutcome()
 
     _patch_resolve_environment(monkeypatch, EmptySourceExtractor)
     manager = DownloadManager()

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -14,7 +14,7 @@ from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem, ResolveFailure, ResolveResult
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, MaxRetryError, NotFoundError, NotLoginError, ResolveFailedError
-from yutto.extractor._abc import StreamingBatchExtractor
+from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId, CId, ResolvableEpisode
@@ -151,7 +151,7 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
     final_copy = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
     late = ResolvableEpisode(info=make_info("P2", display_group="标题"), resolve_data=noop)
 
-    class FakeExtractor(StreamingBatchExtractor):
+    class FakeExtractor(BatchExtractor):
         def resolve_shortcut(self, id: str) -> tuple[bool, str]:
             return True, f"https://example.com/{id}"
 

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -199,6 +199,55 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
     assert resolved == []
 
 
+@as_sync
+async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.MonkeyPatch):
+    """字段完全相同的独立结果条目仍各自对应一条 item_listed 事件。"""
+
+    async def noop() -> EpisodeData | None:
+        return None
+
+    first = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+    second = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+
+    class FakeExtractor:
+        def resolve_shortcut(self, id: str) -> tuple[bool, str]:
+            return True, f"https://example.com/{id}"
+
+        def match(self, url: str) -> bool:
+            return url == "https://example.com/BV1equal"
+
+        async def __call__(
+            self,
+            ctx: FetcherContext,
+            client: httpx.AsyncClient,
+            options: ExtractorOptions,
+        ) -> ExtractorResolveOutcome:
+            return ResolveOutcome(items=(first, second))
+
+    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+        return True
+
+    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+        return Success(url)
+
+    monkeypatch.setattr(download_manager_module, "UgcVideoExtractor", FakeExtractor)
+    monkeypatch.setattr(download_manager_module, "validate_user_info", fake_validate_user_info)
+    monkeypatch.setattr(Fetcher, "get_redirected_url", fake_get_redirected_url)
+
+    manager = DownloadManager()
+    sink = RecordingEventSink()
+    client = cast("httpx.AsyncClient", object())
+    request = DownloadRequest.model_validate({"source": {"url": "BV1equal"}})
+
+    with bind_download_event_sink(sink):
+        outcome = await manager.resolve_items(client, FetcherContext(), request)
+
+    listed = [event for event in sink.events if isinstance(event, DownloadItemListed)]
+    assert len(listed) == len(outcome.items) == 2
+    assert listed[0] == listed[1]
+    assert outcome.items[0] == outcome.items[1]
+
+
 class _FakeClientContext:
     async def __aenter__(self) -> httpx.AsyncClient:
         return cast("httpx.AsyncClient", object())

--- a/tests/test_server/test_websocket.py
+++ b/tests/test_server/test_websocket.py
@@ -32,6 +32,8 @@ pytestmark = pytest.mark.processor
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from yutto.api.ugc_video import UgcVideoList
+    from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.runtime import EventReplay, TaskEvent
 
 
@@ -129,10 +131,10 @@ class BatchStreamingResolveApi(FakeResolveTaskApi):
     async def _run(self, request: DownloadRequest, context: TaskContext) -> ResolveResult:
         await self.release.wait()
 
-        async def on_resolved(index: int, avid: object, result: object) -> None:
+        async def on_resolved(resolved: IndexedResolveItem[UgcVideoList]) -> None:
             # 模拟内置提取器的回调：逐分集 emit 并让出控制权
             for page in range(self.pages_per_video):
-                context.emit("item_listed", {"avid": str(avid), "page": page})
+                context.emit("item_listed", {"avid": str(resolved.source), "page": page})
                 await asyncio.sleep(0)
 
         await resolve_ugc_video_lists(


### PR DESCRIPTION
## 动机

Resolve 的真实输出目前分散在 extractor 返回值与 ambient `ContextVar` 中：预期失败被吞成 `None` 后旁路上报，流式条目通过全局 hook 推送，`DownloadManager` 再用对象身份去重。这让函数签名无法表达失败语义，也让事件生命周期依赖隐式调用上下文。

本 PR 实现 `refactor-plan.md` 中的 PR 2：显式 Resolve Outcome，同时保持现有 `ResolveResult` 与 JSON-RPC v1 wire schema。

## 解决方案

- 引入统一的泛型 `ResolveOutcome[ItemT, FailureT]`，由 extractor 直接返回有序成功项与预期失败；不再维护不对称的 batch outcome。
- batch helper 使用显式的 `IndexedResolveItem` / `IndexedResolveFailure` 保留输入位置与来源；过滤项不再与失败共同编码为 `None`。
- 删除 resolve failure collector、failure reporter 和 episode listed ambient hook。
- 所有 `BatchExtractor` 统一接受可选 `on_item`；single extractor 保持无流式参数，六个长列表 extractor 实际使用该回调进行增量列举。
- 流式事件继续按解析完成顺序产生，最终结果按输入顺序返回；稳定条目键配合 occurrence 队列保证 `item_listed` exactly once，等值但独立的条目不会被合并。
- 保留单条失败、部分失败、全部失败和过滤为空的既有任务与 wire 语义，并补充回归测试。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

## 验证

- `just fmt`
- `just lint`
- Python 3.11 完整非联网集合：226 passed, 1 skipped
- Python 3.14 完整非联网集合：227 passed, 1 skipped
- 最新 resolve/server 定向测试：66 passed
- `just test` 中仅 `tests/test_processor/test_downloader.py` 的两个既有用例失败；两次运行均在访问 GitHub 样例文件时于 `Fetcher.get_size` 超时，与本次 resolve 改动无关。

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol xhigh)</sup>
</div>