### PR TITLE
fix(api): tolerate missing is_preview in playurl responses

### DIFF
--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -108,8 +108,8 @@ async def get_bangumi_playurl(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
         )
     video_info = resp_json["result"]["video_info"]
-    if video_info["is_preview"] == 1:
-        # Maybe always 0 in v2 API
+    # v2 playurl may omit is_preview for some OGV titles (see #585)
+    if video_info.get("is_preview") == 1:
         Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
     if video_info.get("dash") is None:
         raise UnSupportedTypeError(f"该视频（{format_ids(avid, cid)}）尚不支持 DASH 格式")

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -94,7 +94,8 @@ async def get_cheese_playurl(
         raise NoAccessPermissionError(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
         )
-    if resp_json["data"]["is_preview"] == 1:
+    # playurl payload may omit is_preview for some titles
+    if resp_json["data"].get("is_preview") == 1:
         Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
     if resp_json["data"].get("dash") is None:
         raise UnSupportedTypeError(f"该视频（{format_ids(avid, cid)}）尚不支持 DASH 格式")


### PR DESCRIPTION
## 动机

fixes #585

付费电影（如 `ep777110` / `ss46063` 寻梦环游记）在配置大会员后仍下载失败。
原先会以 `KeyError: is_preview` 崩溃；仅把 `is_preview` 改成 `.get()` **并不能真正下载这些内容**。

## 根因（已用公开 API 验证）

对 DRM 电影调用 `pgc/player/web/v2/playurl` 时，常见响应形态是：

```json
{
  "result": {
    "play_check": {
      "limit_play_reason": "DRM_UNSUPPORTED",
      "play_detail": "PLAY_NONE"
    },
    "video_info": { "is_drm": true },
    "view_info": {
      "dialog": {
        "title": { "text": "当前设备加密等级较低，应版权方要求无法播放，请更换其他浏览器尝试" }
      }
    }
  }
}
```

要点：

1. **没有 `is_preview` 字段** → 旧代码 `video_info[\"is_preview\"]` 直接 KeyError
2. **`video_info` 只有 `is_drm`，没有 `dash`** → 即使修好 KeyError，下一步也会变成「不支持 DASH」
3. 浏览器能播是因为 **Widevine 等 DRM 解密**；yutto 作为本地下载器 **无法也不应绕过 DRM**

普通番剧（非 DRM）的 playurl 仍返回 dash，行为不变。

## 解决方案

- 继续用 `.get(\"is_preview\")`，避免无关字段缺失导致崩溃
- 当 `dash` 缺失时，解析 `is_drm` / `play_check` / `view_info.dialog`
- 若判定为 DRM/版权限制，抛出明确的 `NoAccessPermissionError`，说明原因与限制
- 补充 unit test 覆盖 DRM 响应解析

## 类型

- [x] :bug: fix: 修复 bug

## 测试

- [x] unit：`_bangumi_playurl_failure_reason` DRM 样例
- [x] 对 `BV1u94y1Y7MS`/`cid=30088891420` 公开 API 探测确认响应结构
- [ ] 有大会员 cookie 时，非 DRM 番剧仍可正常下载（回归）

## 说明

感谢 @SigureMo 的 review：之前只改 KeyError 确实不够。本次修正为 **正确定位并说明 DRM 限制**，而不是假装能下载付费加密电影。