### PR TITLE
♻️ refactor: unify request execution context

### DIFF
--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -8,19 +8,21 @@ import shlex
 import sys
 from typing import TYPE_CHECKING
 
+from yutto.api.user_info import validate_user_info
 from yutto.cli.cli import cli, handle_default_subcommand
 from yutto.cli.event_renderer import CliApplicationEventRenderer
 from yutto.cli.request_adapter import download_request_from_namespace
 from yutto.core.application import YuttoApplication
+from yutto.core.execution import ExecutionScopeFactory, RequestExecutionScopeFactory
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, YuttoBaseException
 from yutto.input_parser import file_scheme_parser
 from yutto.login import run_auth_logout, run_auth_status, run_login
-from yutto.utils.console.logger import Logger
-from yutto.utils.fetcher import FetcherContext
+from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.ffmpeg import FFmpegNotFoundError
 from yutto.utils.functional import as_sync
 from yutto.validator import (
+    hydrate_auth,
     initial_validation,
     validate_basic_arguments,
 )
@@ -28,7 +30,9 @@ from yutto.validator import (
 if TYPE_CHECKING:
     import argparse
 
+    from yutto.auth import AuthInfo
     from yutto.core.request import DownloadRequest
+    from yutto.utils.fetcher import ExecutionScope
 
 
 def main():
@@ -37,11 +41,20 @@ def main():
     match args.command:
         case "download":
             try:
-                ctx = FetcherContext()
-                initial_validation(ctx, args)
+                initial_validation(args)
                 args_list = flatten_args(args, parser)
+                auth_list = [hydrate_auth(item) for item in args_list]
                 requests = [download_request_from_namespace(item) for item in args_list]
-                run_download(ctx, requests)
+                credentials_by_request = {id(request): auth for request, auth in zip(requests, auth_list, strict=True)}
+
+                def resolve_credentials(request: DownloadRequest) -> AuthInfo | None:
+                    return credentials_by_request[id(request)]
+
+                scope_factory = RequestExecutionScopeFactory(
+                    resolve_credentials,
+                    on_open=announce_cli_auth,
+                )
+                run_download(scope_factory, requests)
             except YuttoBaseException as e:
                 Logger.error(e.message)
                 sys.exit(e.code.value)
@@ -75,13 +88,28 @@ def main():
 
 
 @as_sync
-async def run_download(ctx: FetcherContext, requests: list[DownloadRequest]):
+async def run_download(
+    scope_factory: ExecutionScopeFactory,
+    requests: list[DownloadRequest],
+):
     application = YuttoApplication(
-        ctx,
+        scope_factory,
         workflow=DownloadManager(),
         event_sink=CliApplicationEventRenderer(),
     )
     await application.download_all(requests)
+
+
+async def announce_cli_auth(scope: ExecutionScope, _request: DownloadRequest) -> None:
+    if scope.cookies.get("SESSDATA") is None:
+        Logger.info(
+            "未提供登录认证信息，无法下载高清视频、字幕等资源哦～请通过 `--auth` 参数提供认证信息，或者先使用 `yutto auth login` 登录存储认证信息后再下载～"
+        )
+        return
+    if await validate_user_info(scope, {"vip_status": True, "is_login": True}):
+        Logger.custom("成功以大会员身份登录～", badge=Badge("大会员", fore="white", back="magenta", style=["bold"]))
+    else:
+        Logger.warning("以非大会员身份登录，注意无法下载会员专享剧集喔～")
 
 
 def flatten_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> list[argparse.Namespace]:

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
     import argparse
 
     from yutto.auth import AuthInfo
+    from yutto.core.execution import ExecutionScope
     from yutto.core.request import DownloadRequest
-    from yutto.utils.fetcher import ExecutionScope
 
 
 def main():
@@ -101,7 +101,7 @@ async def run_download(
 
 
 async def announce_cli_auth(scope: ExecutionScope, _request: DownloadRequest) -> None:
-    if scope.cookies.get("SESSDATA") is None:
+    if scope.client.cookies.get("SESSDATA") is None:
         Logger.info(
             "未提供登录认证信息，无法下载高清视频、字幕等资源哦～请通过 `--auth` 参数提供认证信息，或者先使用 `yutto auth login` 登录存储认证信息后再下载～"
         )

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -23,14 +23,12 @@ from yutto.utils.metadata import MetaData
 from yutto.utils.time import get_time_stamp_by_now
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import (
         AvId,
         MediaId,
         MultiLangSubtitle,
     )
-    from yutto.utils.fetcher import FetcherContext
 
 
 class BangumiListItem(TypedDict):
@@ -49,21 +47,21 @@ class BangumiList(TypedDict):
     pages: list[BangumiListItem]
 
 
-async def get_season_id_by_media_id(ctx: FetcherContext, client: AsyncClient, media_id: MediaId) -> SeasonId:
+async def get_season_id_by_media_id(scope: ExecutionScope, media_id: MediaId) -> SeasonId:
     media_api = f"https://api.bilibili.com/pgc/review/user?media_id={media_id}"
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, media_api))
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, media_api))
     return SeasonId(str(res_json["result"]["media"]["season_id"]))
 
 
-async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, episode_id: EpisodeId) -> SeasonId:
+async def get_season_id_by_episode_id(scope: ExecutionScope, episode_id: EpisodeId) -> SeasonId:
     episode_api = f"https://api.bilibili.com/pgc/view/web/season?ep_id={episode_id}"
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, episode_api))
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, episode_api))
     return SeasonId(str(res_json["result"]["season_id"]))
 
 
-async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> BangumiList:
+async def get_bangumi_list(scope: ExecutionScope, season_id: SeasonId) -> BangumiList:
     list_api = "http://api.bilibili.com/pgc/view/web/season?season_id={season_id}"
-    list_result = await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id))
+    list_result = await Fetcher.fetch_json(scope, list_api.format(season_id=season_id))
     if isinstance(list_result, Failure):
         raise NoAccessPermissionError(f"无法解析该番剧列表（season_id: {season_id}）") from list_result.failure()
     resp_json = list_result.unwrap()
@@ -95,11 +93,11 @@ async def get_bangumi_list(ctx: FetcherContext, client: AsyncClient, season_id: 
 
 
 async def get_bangumi_playurl(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, cid: CId
+    scope: ExecutionScope, avid: AvId, cid: CId
 ) -> tuple[list[VideoUrlMeta], list[AudioUrlMeta]]:
     play_api = "https://api.bilibili.com/pgc/player/web/v2/playurl?avid={aid}&bvid={bvid}&cid={cid}&qn=127&fnver=0&fnval=4048&fourk=1&support_multi_audio=true&from_client=BROWSER"
 
-    play_result = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
+    play_result = await Fetcher.fetch_json(scope, play_api.format(**avid.to_dict(), cid=cid))
     if isinstance(play_result, Failure):
         raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from play_result.failure()
     resp_json = play_result.unwrap()
@@ -152,12 +150,10 @@ async def get_bangumi_playurl(
     return (videos, audios)
 
 
-async def get_bangumi_subtitles(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, cid: CId
-) -> list[MultiLangSubtitle]:
+async def get_bangumi_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/wbi/v2?aid={aid}&bvid={bvid}&cid={cid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    subtitles_json_info = (await Fetcher.fetch_json(ctx, client, subtitle_url)).value_or(None)
+    subtitles_json_info = (await Fetcher.fetch_json(scope, subtitle_url)).value_or(None)
     if subtitles_json_info is None:
         return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
@@ -173,7 +169,7 @@ async def get_bangumi_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        subtitle_text = (await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)).value_or(None)
+        subtitle_text = (await Fetcher.fetch_json(scope, "https:" + subtitle_url)).value_or(None)
         if subtitle_text is None:
             continue
         results.append(

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -22,13 +22,11 @@ from yutto.utils.metadata import MetaData
 from yutto.utils.time import get_time_stamp_by_now
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import (
         AvId,
         MultiLangSubtitle,
     )
-    from yutto.utils.fetcher import FetcherContext
 
 
 class CheeseListItem(TypedDict):
@@ -45,15 +43,15 @@ class CheeseList(TypedDict):
     pages: list[CheeseListItem]
 
 
-async def get_season_id_by_episode_id(ctx: FetcherContext, client: AsyncClient, episode_id: EpisodeId) -> SeasonId:
+async def get_season_id_by_episode_id(scope: ExecutionScope, episode_id: EpisodeId) -> SeasonId:
     home_url = f"https://api.bilibili.com/pugv/view/web/season?ep_id={episode_id}"
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, home_url))
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, home_url))
     return SeasonId(str(res_json["data"]["season_id"]))
 
 
-async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: SeasonId) -> CheeseList:
+async def get_cheese_list(scope: ExecutionScope, season_id: SeasonId) -> CheeseList:
     list_api = "https://api.bilibili.com/pugv/view/web/season?season_id={season_id}"
-    list_result = await Fetcher.fetch_json(ctx, client, list_api.format(season_id=season_id))
+    list_result = await Fetcher.fetch_json(scope, list_api.format(season_id=season_id))
     if isinstance(list_result, Failure):
         raise NoAccessPermissionError(f"无法解析该课程列表（season_id: {season_id}）") from list_result.failure()
     resp_json = list_result.unwrap()
@@ -78,15 +76,13 @@ async def get_cheese_list(ctx: FetcherContext, client: AsyncClient, season_id: S
 
 
 async def get_cheese_playurl(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, episode_id: EpisodeId, cid: CId
+    scope: ExecutionScope, avid: AvId, episode_id: EpisodeId, cid: CId
 ) -> tuple[list[VideoUrlMeta], list[AudioUrlMeta]]:
     play_api = (
         "https://api.bilibili.com/pugv/player/web/playurl?avid={aid}&cid={"
         "cid}&qn=80&fnver=0&fnval=16&fourk=1&ep_id={episode_id}&from_client=BROWSER&drm_tech_type=2"
     )
-    play_result = await Fetcher.fetch_json(
-        ctx, client, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id)
-    )
+    play_result = await Fetcher.fetch_json(scope, play_api.format(**avid.to_dict(), cid=cid, episode_id=episode_id))
     if isinstance(play_result, Failure):
         raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from play_result.failure()
     resp_json = play_result.unwrap()
@@ -124,12 +120,10 @@ async def get_cheese_playurl(
     )
 
 
-async def get_cheese_subtitles(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, cid: CId
-) -> list[MultiLangSubtitle]:
+async def get_cheese_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/v2?cid={cid}&aid={aid}&bvid={bvid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    subtitles_json_info = (await Fetcher.fetch_json(ctx, client, subtitle_url)).value_or(None)
+    subtitles_json_info = (await Fetcher.fetch_json(scope, subtitle_url)).value_or(None)
     if subtitles_json_info is None:
         return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
@@ -145,7 +139,7 @@ async def get_cheese_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        subtitle_text = (await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)).value_or(None)
+        subtitle_text = (await Fetcher.fetch_json(scope, "https:" + subtitle_url)).value_or(None)
         if subtitle_text is None:
             continue
         results.append(

--- a/src/yutto/api/collection.py
+++ b/src/yutto/api/collection.py
@@ -8,10 +8,8 @@ from yutto.types import BvId
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import AvId, MId, SeriesId
-    from yutto.utils.fetcher import FetcherContext
 
 
 class CollectionDetailsItem(TypedDict):
@@ -25,12 +23,10 @@ class CollectionDetails(TypedDict):
     pages: list[CollectionDetailsItem]
 
 
-async def get_collection_details(
-    ctx: FetcherContext, client: AsyncClient, series_id: SeriesId, mid: MId
-) -> CollectionDetails:
+async def get_collection_details(scope: ExecutionScope, series_id: SeriesId, mid: MId) -> CollectionDetails:
     title, avids = await asyncio.gather(
-        _get_collection_title(ctx, client, series_id),
-        _get_collection_avids(ctx, client, series_id, mid),
+        _get_collection_title(scope, series_id),
+        _get_collection_avids(scope, series_id, mid),
     )
     return CollectionDetails(
         title=title,
@@ -45,7 +41,7 @@ async def get_collection_details(
     )
 
 
-async def _get_collection_avids(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId, mid: MId) -> list[AvId]:
+async def _get_collection_avids(scope: ExecutionScope, series_id: SeriesId, mid: MId) -> list[AvId]:
     api = "https://api.bilibili.com/x/polymer/web-space/seasons_archives_list?mid={mid}&season_id={series_id}&sort_reverse=false&page_num={pn}&page_size={ps}"
     ps = 30
     pn = 1
@@ -54,14 +50,14 @@ async def _get_collection_avids(ctx: FetcherContext, client: AsyncClient, series
 
     while pn <= total:
         space_videos_url = api.format(series_id=series_id, ps=ps, pn=pn, mid=mid)
-        json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, space_videos_url))
+        json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, space_videos_url))
         total = math.ceil(json_data["data"]["page"]["total"] / ps)
         pn += 1
         all_avid += [BvId(archives["bvid"]) for archives in json_data["data"]["archives"]]
     return all_avid
 
 
-async def _get_collection_title(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId) -> str:
+async def _get_collection_title(scope: ExecutionScope, series_id: SeriesId) -> str:
     api = "https://api.bilibili.com/x/v1/medialist/info?type=8&biz_id={series_id}"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)))
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(series_id=series_id)))
     return json_data["data"]["title"]

--- a/src/yutto/api/danmaku.py
+++ b/src/yutto/api/danmaku.py
@@ -9,55 +9,46 @@ from yutto.api.user_info import get_user_info
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import AvId, CId
     from yutto.utils.danmaku import DanmakuData, DanmakuSaveType
-    from yutto.utils.fetcher import FetcherContext
 
 
-async def get_xml_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, cid: CId) -> str:
+async def get_xml_danmaku(scope: ExecutionScope, cid: CId) -> str:
     danmaku_api = "http://comment.bilibili.com/{cid}.xml"
-    results = unwrap_fetch_result(await Fetcher.fetch_text(ctx, client, danmaku_api.format(cid=cid), encoding="utf-8"))
+    results = unwrap_fetch_result(await Fetcher.fetch_text(scope, danmaku_api.format(cid=cid), encoding="utf-8"))
     assert results is not None
     return results
 
 
-async def get_protobuf_danmaku_segment(
-    ctx: FetcherContext, client: httpx.AsyncClient, cid: CId, segment_id: int = 1
-) -> bytes:
+async def get_protobuf_danmaku_segment(scope: ExecutionScope, cid: CId, segment_id: int = 1) -> bytes:
     danmaku_api = "http://api.bilibili.com/x/v2/dm/web/seg.so?type=1&oid={cid}&segment_index={segment_id}"
-    results = unwrap_fetch_result(
-        await Fetcher.fetch_bin(ctx, client, danmaku_api.format(cid=cid, segment_id=segment_id))
-    )
+    results = unwrap_fetch_result(await Fetcher.fetch_bin(scope, danmaku_api.format(cid=cid, segment_id=segment_id)))
     assert results is not None
     return results
 
 
-async def get_protobuf_danmaku(ctx: FetcherContext, client: httpx.AsyncClient, avid: AvId, cid: CId) -> list[bytes]:
+async def get_protobuf_danmaku(scope: ExecutionScope, avid: AvId, cid: CId) -> list[bytes]:
     danmaku_meta_api = "https://api.bilibili.com/x/v2/dm/web/view?type=1&oid={cid}&pid={aid}"
     aid = avid.as_aid()
-    meta_results = unwrap_fetch_result(
-        await Fetcher.fetch_bin(ctx, client, danmaku_meta_api.format(cid=cid, aid=aid.value))
-    )
+    meta_results = unwrap_fetch_result(await Fetcher.fetch_bin(scope, danmaku_meta_api.format(cid=cid, aid=aid.value)))
     assert meta_results is not None
     size = get_danmaku_meta_size(meta_results)
 
     results = await asyncio.gather(
-        *[get_protobuf_danmaku_segment(ctx, client, cid, segment_id) for segment_id in range(1, size + 1)]
+        *[get_protobuf_danmaku_segment(scope, cid, segment_id) for segment_id in range(1, size + 1)]
     )
     return results
 
 
 async def get_danmaku(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     cid: CId,
     avid: AvId,
     save_type: DanmakuSaveType,
 ) -> DanmakuData:
     # 在已经登录的情况下，使用 protobuf，因为未登录时 protobuf 弹幕会少非常多
-    source_type = "xml" if save_type == "xml" or not (await get_user_info(ctx, client))["is_login"] else "protobuf"
+    source_type = "xml" if save_type == "xml" or not (await get_user_info(scope))["is_login"] else "protobuf"
     danmaku_data: DanmakuData = {
         "source_type": source_type,
         "save_type": save_type,
@@ -65,7 +56,7 @@ async def get_danmaku(
     }
 
     if source_type == "xml":
-        danmaku_data["data"].append(await get_xml_danmaku(ctx, client, cid))
+        danmaku_data["data"].append(await get_xml_danmaku(scope, cid))
     else:
-        danmaku_data["data"].extend(await get_protobuf_danmaku(ctx, client, avid, cid))
+        danmaku_data["data"].extend(await get_protobuf_danmaku(scope, avid, cid))
     return danmaku_data

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -14,16 +14,13 @@ from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from httpx import AsyncClient
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import AvId, MId, SeriesId
-    from yutto.utils.fetcher import FetcherContext
 
 
 # 个人空间·全部
 async def get_user_space_all_videos_avids(
-    ctx: FetcherContext,
-    client: AsyncClient,
+    scope: ExecutionScope,
     mid: MId,
     *,
     pubdate_filter: Callable[[int], bool] | None = None,
@@ -36,7 +33,7 @@ async def get_user_space_all_videos_avids(
     pn = 1
     total = 1
     all_avid: list[AvId] = []
-    wbi_img = await get_wbi_img(ctx, client)
+    wbi_img = await get_wbi_img(scope)
     while pn <= total:
         params = {
             "mid": mid,
@@ -46,7 +43,7 @@ async def get_user_space_all_videos_avids(
             "order": "pubdate",
         }
         params = encode_wbi(params, wbi_img)
-        match await Fetcher.fetch_json(ctx, client, space_videos_api, params=params):
+        match await Fetcher.fetch_json(scope, space_videos_api, params=params):
             case Success(json_data):
                 match _parse_user_space_videos_page(json_data, ps):
                     case Success((total, video_infos)):
@@ -96,13 +93,13 @@ def _should_stop_user_space_pagination(video_infos: list[dict[str, Any]], stop_b
 
 
 # 个人空间·用户名
-async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> str:
-    wbi_img = await get_wbi_img(ctx, client)
+async def get_user_name(scope: ExecutionScope, mid: MId) -> str:
+    wbi_img = await get_wbi_img(scope)
     params = {"mid": mid}
     params = encode_wbi(params, wbi_img)
     space_info_api = "https://api.bilibili.com/x/space/wbi/acc/info"
-    unwrap_fetch_result(await Fetcher.touch_url(ctx, client, "https://www.bilibili.com"))
-    match await Fetcher.fetch_json(ctx, client, space_info_api, params=params):
+    unwrap_fetch_result(await Fetcher.touch_url(scope, "https://www.bilibili.com"))
+    match await Fetcher.fetch_json(scope, space_info_api, params=params):
         case Success({"code": 0, "data": {"name": username}}):
             return str(username)
         case Success({"code": -404}):
@@ -119,30 +116,29 @@ async def get_user_name(ctx: FetcherContext, client: AsyncClient, mid: MId) -> s
 
 
 # 个人空间·收藏夹·信息
-async def get_favourite_info(ctx: FetcherContext, client: AsyncClient, fid: FId) -> FavouriteMetaData:
+async def get_favourite_info(scope: ExecutionScope, fid: FId) -> FavouriteMetaData:
     api = "https://api.bilibili.com/x/v3/fav/folder/info?media_id={fid}"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(fid=fid)))
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(fid=fid)))
     data = json_data["data"]
     return FavouriteMetaData(title=data["title"], fid=FId(str(data["id"])))
 
 
 # 个人空间·收藏夹·avid
-async def get_favourite_avids(ctx: FetcherContext, client: AsyncClient, fid: FId) -> list[AvId]:
+async def get_favourite_avids(scope: ExecutionScope, fid: FId) -> list[AvId]:
     api = "https://api.bilibili.com/x/v3/fav/resource/ids?media_id={fid}"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(fid=fid)))
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(fid=fid)))
     return [BvId(video_info["bvid"]) for video_info in json_data["data"]]
 
 
 # 个人空间·收藏夹·条目（含标题和分 p 数量）
-async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId) -> list[FavouriteVideoData]:
+async def get_favourite_items(scope: ExecutionScope, fid: FId) -> list[FavouriteVideoData]:
     """获取收藏夹中所有视频的元数据，包含 B 站侧标题和分 p 数量。
 
     相比 get_favourite_avids，此接口通过分页列表 API 拉取完整标题，
     可用于区分单分 p / 多分 p 视频，以及使用人工标题替换机器生成的文件名。
 
     Args:
-        ctx: 请求上下文，含 Cookie 和代理配置。
-        client: httpx 异步客户端。
+        scope: 当前请求的执行上下文。
         fid: 收藏夹 ID。
 
     Returns:
@@ -154,7 +150,7 @@ async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId
     favourite_items: list[FavouriteVideoData] = []
 
     while True:
-        json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(fid=fid, pn=pn, ps=ps)))
+        json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(fid=fid, pn=pn, ps=ps)))
         data = cast("dict[str, Any]", json_data["data"])
         medias = cast("list[dict[str, Any]]", data["medias"] or [])
         # 仅保留正常视频（type=2），过滤已失效条目（bvid 为空）
@@ -182,16 +178,16 @@ async def get_favourite_items(ctx: FetcherContext, client: AsyncClient, fid: FId
 
 
 # 个人空间·收藏夹·全部
-async def get_all_favourites(ctx: FetcherContext, client: AsyncClient, mid: MId) -> list[FavouriteMetaData]:
+async def get_all_favourites(scope: ExecutionScope, mid: MId) -> list[FavouriteMetaData]:
     api = "https://api.bilibili.com/x/v3/fav/folder/created/list-all?up_mid={mid}"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(mid=mid)))
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(mid=mid)))
     if not json_data["data"]:
         return []
     return [FavouriteMetaData(title=data["title"], fid=FId(str(data["id"]))) for data in json_data["data"]["list"]]
 
 
 # 个人空间·视频列表·avid
-async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId, mid: MId) -> list[AvId]:
+async def get_medialist_avids(scope: ExecutionScope, series_id: SeriesId, mid: MId) -> list[AvId]:
     api = "https://api.bilibili.com/x/series/archives?mid={mid}&series_id={series_id}&only_normal=true&pn={pn}&ps={ps}"
     ps = 30
     pn = 1
@@ -200,7 +196,7 @@ async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_i
 
     while pn <= total:
         url = api.format(series_id=series_id, mid=mid, ps=ps, pn=pn)
-        json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, url))
+        json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, url))
         total = math.ceil(json_data["data"]["page"]["total"] / ps)
         pn += 1
         all_avid += [BvId(video_info["bvid"]) for video_info in json_data["data"]["archives"]]
@@ -208,16 +204,16 @@ async def get_medialist_avids(ctx: FetcherContext, client: AsyncClient, series_i
 
 
 # 个人空间·视频列表·标题
-async def get_medialist_title(ctx: FetcherContext, client: AsyncClient, series_id: SeriesId) -> str:
+async def get_medialist_title(scope: ExecutionScope, series_id: SeriesId) -> str:
     api = "https://api.bilibili.com/x/v1/medialist/info?type=5&biz_id={series_id}"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api.format(series_id=series_id)))
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(series_id=series_id)))
     return json_data["data"]["title"]
 
 
 # 个人空间·稍后再看
-async def get_watch_later_avids(ctx: FetcherContext, client: AsyncClient) -> list[AvId]:
+async def get_watch_later_avids(scope: ExecutionScope) -> list[AvId]:
     api = "https://api.bilibili.com/x/v2/history/toview/web"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, api))
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api))
     if json_data["code"] in [-101, -400]:
         raise NotLoginError("账号未登录，无法获取稍后再看列表哦~ Ծ‸Ծ")
     # TODO: 处理其他code不为0的异常

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -29,10 +29,8 @@ from yutto.utils.metadata import Actor, ChapterInfoData, MetaData
 from yutto.utils.time import get_time_stamp_by_now
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import AvId
-    from yutto.utils.fetcher import FetcherContext
 
 
 class _UgcVideoPageInfo(TypedDict):
@@ -72,10 +70,10 @@ class UgcVideoList(TypedDict):
     pages: list[UgcVideoListItem]
 
 
-async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> list[str]:
+async def get_ugc_video_tag(scope: ExecutionScope, avid: AvId) -> list[str]:
     tags: list[str] = []
     tag_api = "http://api.bilibili.com/x/tag/archive/tags?aid={aid}&bvid={bvid}"
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, tag_api.format(**avid.to_dict())))
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, tag_api.format(**avid.to_dict())))
     if res_json["code"] != 0:
         raise NotFoundError(f"无法获取视频 {avid} 标签")
     for tag in res_json["data"]:
@@ -83,10 +81,10 @@ async def get_ugc_video_tag(ctx: FetcherContext, client: AsyncClient, avid: AvId
     return tags
 
 
-async def get_ugc_video_info(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> _UgcVideoInfo:
+async def get_ugc_video_info(scope: ExecutionScope, avid: AvId) -> _UgcVideoInfo:
     regex_ep = re.compile(r"https?://www\.bilibili\.com/bangumi/play/ep(?P<episode_id>\d+)")
     info_api = "http://api.bilibili.com/x/web-interface/view?aid={aid}&bvid={bvid}"
-    info_result = await Fetcher.fetch_json(ctx, client, info_api.format(**avid.to_dict()))
+    info_result = await Fetcher.fetch_json(scope, info_api.format(**avid.to_dict()))
     if isinstance(info_result, Failure):
         raise NotFoundError(f"无法获取该视频 {avid} 信息") from info_result.failure()
     res_json = info_result.unwrap()
@@ -103,14 +101,14 @@ async def get_ugc_video_info(ctx: FetcherContext, client: AsyncClient, avid: AvI
     if res_json_data.get("forward"):
         forward_avid = AId(str(res_json_data["forward"]))
         Logger.info(f"视频 {avid} 撞车了哦！正在跳转到原视频 {forward_avid}～")
-        return await get_ugc_video_info(ctx, client, forward_avid)
+        return await get_ugc_video_info(scope, forward_avid)
     episode_id = EpisodeId("")
     if res_json_data.get("redirect_url") and (ep_match := regex_ep.match(res_json_data["redirect_url"])):
         episode_id = EpisodeId(ep_match.group("episode_id"))
 
     actors = _parse_actor_info(res_json_data)
     genres = _parse_genre_info(res_json_data)
-    tags: list[str] = await get_ugc_video_tag(ctx, client, avid)
+    tags: list[str] = await get_ugc_video_tag(scope, avid)
     return _UgcVideoInfo(
         avid=BvId(res_json_data["bvid"]),
         aid=AId(str(res_json_data["aid"])),
@@ -135,8 +133,8 @@ async def get_ugc_video_info(ctx: FetcherContext, client: AsyncClient, avid: AvI
     )
 
 
-async def get_ugc_video_list(ctx: FetcherContext, client: AsyncClient, avid: AvId) -> UgcVideoList:
-    video_info = await get_ugc_video_info(ctx, client, avid)
+async def get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
+    video_info = await get_ugc_video_info(scope, avid)
     if avid not in [video_info["aid"], video_info["bvid"]]:
         avid = video_info["avid"]
     video_title = video_info["title"]
@@ -147,7 +145,7 @@ async def get_ugc_video_list(ctx: FetcherContext, client: AsyncClient, avid: AvI
         "pages": [],
     }
     list_api = "https://api.bilibili.com/x/player/pagelist?aid={aid}&bvid={bvid}&jsonp=jsonp"
-    res_json = (await Fetcher.fetch_json(ctx, client, list_api.format(**avid.to_dict()))).value_or(None)
+    res_json = (await Fetcher.fetch_json(scope, list_api.format(**avid.to_dict()))).value_or(None)
     if res_json is None or res_json.get("data") is None:
         Logger.warning(f"啊叻？视频 {avid} 不见了诶")
         return result
@@ -209,14 +207,14 @@ def show_ai_translation_language(resp_json: dict[str, Any], ai_translation_langu
 
 
 async def get_ugc_video_playurl(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, cid: CId, ai_translation_language: str | None = None
+    scope: ExecutionScope, avid: AvId, cid: CId, ai_translation_language: str | None = None
 ) -> tuple[list[VideoUrlMeta], list[AudioUrlMeta]]:
     # 4048 = 16(useDash) | 64(useHDR) | 128(use4K) | 256(useDolby) | 512(useXXX) | 1024(use8K) | 2048(useAV1)
     play_api = "https://api.bilibili.com/x/player/playurl?avid={aid}&bvid={bvid}&cid={cid}&qn=127&type=&otype=json&fnver=0&fnval=4048&fourk=1"
     if ai_translation_language:
         play_api += f"&cur_language={ai_translation_language}"
 
-    play_result = await Fetcher.fetch_json(ctx, client, play_api.format(**avid.to_dict(), cid=cid))
+    play_result = await Fetcher.fetch_json(scope, play_api.format(**avid.to_dict(), cid=cid))
     if isinstance(play_result, Failure):
         raise NoAccessPermissionError(f"无法获取该视频链接（{format_ids(avid, cid)}）") from play_result.failure()
     resp_json = play_result.unwrap()
@@ -287,12 +285,10 @@ async def get_ugc_video_playurl(
     return (videos, audios)
 
 
-async def get_ugc_video_subtitles(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, cid: CId
-) -> list[MultiLangSubtitle]:
+async def get_ugc_video_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> list[MultiLangSubtitle]:
     subtitle_api = "https://api.bilibili.com/x/player/wbi/v2?aid={aid}&bvid={bvid}&cid={cid}"
     subtitle_url = subtitle_api.format(**avid.to_dict(), cid=cid)
-    res_json = (await Fetcher.fetch_json(ctx, client, subtitle_url)).value_or(None)
+    res_json = (await Fetcher.fetch_json(scope, subtitle_url)).value_or(None)
     if res_json is None:
         return []
     if not data_has_chained_keys(res_json, ["data", "subtitle", "subtitles"]):
@@ -306,7 +302,7 @@ async def get_ugc_video_subtitles(
             Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
             continue
 
-        subtitle_text = (await Fetcher.fetch_json(ctx, client, "https:" + subtitle_url)).value_or(None)
+        subtitle_text = (await Fetcher.fetch_json(scope, "https:" + subtitle_url)).value_or(None)
         if subtitle_text is None:
             continue
         results.append(
@@ -318,12 +314,10 @@ async def get_ugc_video_subtitles(
     return results
 
 
-async def get_ugc_video_chapters(
-    ctx: FetcherContext, client: AsyncClient, avid: AvId, cid: CId
-) -> list[ChapterInfoData]:
+async def get_ugc_video_chapters(scope: ExecutionScope, avid: AvId, cid: CId) -> list[ChapterInfoData]:
     chapter_api = "https://api.bilibili.com/x/player/v2?aid={aid}&bvid={bvid}&cid={cid}"
     chapter_url = chapter_api.format(**avid.to_dict(), cid=cid)
-    chapter_json_info = (await Fetcher.fetch_json(ctx, client, chapter_url)).value_or(None)
+    chapter_json_info = (await Fetcher.fetch_json(scope, chapter_url)).value_or(None)
     if chapter_json_info is None:
         return []
     if not data_has_chained_keys(chapter_json_info, ["data", "view_points"]):

--- a/src/yutto/api/user_info.py
+++ b/src/yutto/api/user_info.py
@@ -10,12 +10,12 @@ import urllib.parse
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from yutto.types import UserInfo
-from yutto.utils.fetcher import Fetcher, create_client, unwrap_fetch_result
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
 
-    from yutto.utils.fetcher import FetcherContext
+    from yutto.utils.fetcher import ExecutionScope, FetcherContext
 
 
 class WbiImg(TypedDict):
@@ -23,7 +23,6 @@ class WbiImg(TypedDict):
     sub_key: str
 
 
-wbi_img_cache: WbiImg | None = None  # Simulate the LocalStorage of the browser
 dm_img_str_cache: str = base64.b64encode("".join(random.choices(string.printable, k=random.randint(16, 64))).encode())[:-2].decode()  # fmt: skip
 dm_cover_img_str_cache: str = base64.b64encode("".join(random.choices(string.printable, k=random.randint(32, 128))).encode())[:-2].decode()  # fmt: skip
 USER_INFO_API = "https://api.bilibili.com/x/web-interface/nav"
@@ -56,35 +55,30 @@ def user_info_matches(user_info: UserInfo, check_option: UserInfo) -> bool:
     return True
 
 
-async def validate_user_info(ctx: FetcherContext, check_option: UserInfo) -> bool:
+async def validate_user_info(ctx: ExecutionScope, check_option: UserInfo) -> bool:
     """UserInfo 结构和用户输入是匹配的，如果要校验则置 True 即可，估计不会有要校验为 False 的情况吧~~"""
     if not check_option["is_login"] and not check_option["vip_status"]:
         return True
 
-    # 命中缓存时无需建立网络客户端
     if ctx.user_info_cache is not None:
         return user_info_matches(ctx.user_info_cache, check_option)
 
-    async with create_client(
-        cookies=ctx.cookies,
-        trust_env=ctx.trust_env,
-        proxy=ctx.proxy,
-    ) as client:
-        user_info = await get_user_info(ctx, client)
-        return user_info_matches(user_info, check_option)
+    user_info = await get_user_info(ctx, ctx.client)
+    return user_info_matches(user_info, check_option)
 
 
 async def get_wbi_img(ctx: FetcherContext, client: AsyncClient) -> WbiImg:
-    global wbi_img_cache
-
-    if wbi_img_cache is not None:
-        return wbi_img_cache
+    if ctx.wbi_img_cache is not None:
+        return cast("WbiImg", ctx.wbi_img_cache)
     res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, USER_INFO_API))
     wbi_img: WbiImg = {
         "img_key": _get_key_from_url(res_json["data"]["wbi_img"]["img_url"]),
         "sub_key": _get_key_from_url(res_json["data"]["wbi_img"]["sub_url"]),
     }
-    wbi_img_cache = wbi_img
+    ctx.wbi_img_cache = {
+        "img_key": wbi_img["img_key"],
+        "sub_key": wbi_img["sub_key"],
+    }
     return wbi_img
 
 

--- a/src/yutto/api/user_info.py
+++ b/src/yutto/api/user_info.py
@@ -13,9 +13,7 @@ from yutto.types import UserInfo
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
-
-    from yutto.utils.fetcher import ExecutionScope, FetcherContext
+    from yutto.core.execution import ExecutionScope
 
 
 class WbiImg(TypedDict):
@@ -39,12 +37,12 @@ def parse_user_info(res_json: dict[str, Any]) -> UserInfo:
     )
 
 
-async def get_user_info(ctx: FetcherContext, client: AsyncClient) -> UserInfo:
-    if ctx.user_info_cache is not None:
-        return ctx.user_info_cache
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, USER_INFO_API))
-    ctx.user_info_cache = parse_user_info(res_json)
-    return ctx.user_info_cache
+async def get_user_info(scope: ExecutionScope) -> UserInfo:
+    if scope.user_info_cache is not None:
+        return scope.user_info_cache
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, USER_INFO_API))
+    scope.user_info_cache = parse_user_info(res_json)
+    return scope.user_info_cache
 
 
 def user_info_matches(user_info: UserInfo, check_option: UserInfo) -> bool:
@@ -55,27 +53,27 @@ def user_info_matches(user_info: UserInfo, check_option: UserInfo) -> bool:
     return True
 
 
-async def validate_user_info(ctx: ExecutionScope, check_option: UserInfo) -> bool:
+async def validate_user_info(scope: ExecutionScope, check_option: UserInfo) -> bool:
     """UserInfo 结构和用户输入是匹配的，如果要校验则置 True 即可，估计不会有要校验为 False 的情况吧~~"""
     if not check_option["is_login"] and not check_option["vip_status"]:
         return True
 
-    if ctx.user_info_cache is not None:
-        return user_info_matches(ctx.user_info_cache, check_option)
+    if scope.user_info_cache is not None:
+        return user_info_matches(scope.user_info_cache, check_option)
 
-    user_info = await get_user_info(ctx, ctx.client)
+    user_info = await get_user_info(scope)
     return user_info_matches(user_info, check_option)
 
 
-async def get_wbi_img(ctx: FetcherContext, client: AsyncClient) -> WbiImg:
-    if ctx.wbi_img_cache is not None:
-        return cast("WbiImg", ctx.wbi_img_cache)
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(ctx, client, USER_INFO_API))
+async def get_wbi_img(scope: ExecutionScope) -> WbiImg:
+    if scope.wbi_img_cache is not None:
+        return cast("WbiImg", scope.wbi_img_cache)
+    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, USER_INFO_API))
     wbi_img: WbiImg = {
         "img_key": _get_key_from_url(res_json["data"]["wbi_img"]["img_url"]),
         "sub_key": _get_key_from_url(res_json["data"]["wbi_img"]["sub_url"]),
     }
-    ctx.wbi_img_cache = {
+    scope.wbi_img_cache = {
         "img_key": wbi_img["img_key"],
         "sub_key": wbi_img["sub_key"],
     }

--- a/src/yutto/core/application.py
+++ b/src/yutto/core/application.py
@@ -9,17 +9,25 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from yutto.core.events import DownloadEventSink
+    from yutto.core.execution import ExecutionScopeFactory
     from yutto.core.request import DownloadRequest
     from yutto.core.result import DownloadResult, ResolveResult
-    from yutto.utils.fetcher import FetcherContext
 
 
 class DownloadWorkflow(Protocol):
-    async def execute(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> DownloadResult: ...
+    async def execute(
+        self,
+        scope_factory: ExecutionScopeFactory,
+        requests: Sequence[DownloadRequest],
+    ) -> DownloadResult: ...
 
 
 class ResolveWorkflow(Protocol):
-    async def execute_resolve(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> ResolveResult: ...
+    async def execute_resolve(
+        self,
+        scope_factory: ExecutionScopeFactory,
+        requests: Sequence[DownloadRequest],
+    ) -> ResolveResult: ...
 
 
 class YuttoApplication:
@@ -27,13 +35,13 @@ class YuttoApplication:
 
     def __init__(
         self,
-        ctx: FetcherContext,
+        scope_factory: ExecutionScopeFactory,
         *,
         workflow: DownloadWorkflow,
         event_sink: DownloadEventSink | None = None,
         resolve_workflow: ResolveWorkflow | None = None,
     ):
-        self.ctx = ctx
+        self.scope_factory = scope_factory
         self.workflow = workflow
         self.resolve_workflow = resolve_workflow
         self.event_sink = event_sink if event_sink is not None else NullDownloadEventSink()
@@ -51,7 +59,7 @@ class YuttoApplication:
                             total=total,
                         )
                     )
-            return await self.workflow.execute(self.ctx, requests)
+            return await self.workflow.execute(self.scope_factory, requests)
 
     async def download(self, request: DownloadRequest) -> DownloadResult:
         return await self.download_all([request])
@@ -60,7 +68,7 @@ class YuttoApplication:
         if self.resolve_workflow is None:
             raise RuntimeError("this application was built without a resolve workflow")
         with bind_download_event_sink(self.event_sink):
-            return await self.resolve_workflow.execute_resolve(self.ctx, requests)
+            return await self.resolve_workflow.execute_resolve(self.scope_factory, requests)
 
     async def resolve(self, request: DownloadRequest) -> ResolveResult:
         return await self.resolve_all([request])

--- a/src/yutto/core/execution.py
+++ b/src/yutto/core/execution.py
@@ -1,16 +1,60 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Protocol
 
-from yutto.utils.fetcher import ExecutionScope, cookies_from_auth, create_client, resolve_proxy
+from yutto.utils.fetcher import (
+    DEFAULT_FETCH_WORKERS,
+    cookies_from_auth,
+    create_client,
+    resolve_proxy,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
     from contextlib import AbstractAsyncContextManager
+
+    from httpx import AsyncClient
 
     from yutto.auth import AuthInfo
     from yutto.core.request import DownloadRequest
+    from yutto.types import UserInfo
+
+
+class ExecutionScope:
+    """Runtime resources owned by one request execution."""
+
+    client: AsyncClient
+    fetch_limiter: asyncio.Semaphore
+    download_limiter: asyncio.Semaphore
+    user_info_cache: UserInfo | None
+    wbi_img_cache: Mapping[str, str] | None
+    touched_urls: set[str]
+
+    def __init__(
+        self,
+        client: AsyncClient,
+        *,
+        fetch_workers: int = DEFAULT_FETCH_WORKERS,
+        download_workers: int = DEFAULT_FETCH_WORKERS,
+    ):
+        self.client = client
+        self.fetch_limiter = asyncio.Semaphore(fetch_workers)
+        self.download_limiter = asyncio.Semaphore(download_workers)
+        self.user_info_cache = None
+        self.wbi_img_cache = None
+        self.touched_urls = set()
+
+    @asynccontextmanager
+    async def fetch_guard(self):
+        async with self.fetch_limiter:
+            yield
+
+    @asynccontextmanager
+    async def download_guard(self):
+        async with self.download_limiter:
+            yield
 
 
 class ExecutionScopeFactory(Protocol):
@@ -44,9 +88,6 @@ class RequestExecutionScopeFactory:
         ) as client:
             scope = ExecutionScope(
                 client,
-                proxy=proxy,
-                trust_env=trust_env,
-                cookies=cookies,
                 fetch_workers=request.network.fetch_workers,
                 download_workers=request.network.download_workers,
             )

--- a/src/yutto/core/execution.py
+++ b/src/yutto/core/execution.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Protocol
+
+from yutto.utils.fetcher import ExecutionScope, cookies_from_auth, create_client, resolve_proxy
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
+    from contextlib import AbstractAsyncContextManager
+
+    from yutto.auth import AuthInfo
+    from yutto.core.request import DownloadRequest
+
+
+class ExecutionScopeFactory(Protocol):
+    """Open all runtime resources required by one request."""
+
+    def open(self, request: DownloadRequest) -> AbstractAsyncContextManager[ExecutionScope]: ...
+
+
+class RequestExecutionScopeFactory:
+    """Build request-scoped clients, concurrency guards, credentials, and caches."""
+
+    def __init__(
+        self,
+        credential_resolver: Callable[[DownloadRequest], AuthInfo | None] | None = None,
+        *,
+        on_open: Callable[[ExecutionScope, DownloadRequest], Awaitable[None]] | None = None,
+    ):
+        self._credential_resolver = credential_resolver or (lambda request: None)
+        self._on_open = on_open
+
+    @asynccontextmanager
+    async def open(self, request: DownloadRequest) -> AsyncIterator[ExecutionScope]:
+        proxy, trust_env = resolve_proxy(request.network.proxy)
+        auth = self._credential_resolver(request)
+        cookies = cookies_from_auth(auth)
+
+        async with create_client(
+            cookies=cookies,
+            trust_env=trust_env,
+            proxy=proxy,
+        ) as client:
+            scope = ExecutionScope(
+                client,
+                proxy=proxy,
+                trust_env=trust_env,
+                cookies=cookies,
+                fetch_workers=request.network.fetch_workers,
+                download_workers=request.network.download_workers,
+            )
+            if self._on_open is not None:
+                await self._on_open(scope, request)
+            yield scope

--- a/src/yutto/core/execution.py
+++ b/src/yutto/core/execution.py
@@ -39,6 +39,10 @@ class ExecutionScope:
         fetch_workers: int = DEFAULT_FETCH_WORKERS,
         download_workers: int = DEFAULT_FETCH_WORKERS,
     ):
+        if fetch_workers < 1:
+            raise ValueError("fetch_workers must be at least 1")
+        if download_workers < 1:
+            raise ValueError("download_workers must be at least 1")
         self.client = client
         self.fetch_limiter = asyncio.Semaphore(fetch_workers)
         self.download_limiter = asyncio.Semaphore(download_workers)

--- a/src/yutto/core/task_service.py
+++ b/src/yutto/core/task_service.py
@@ -20,8 +20,8 @@ from yutto.runtime import TaskRuntime
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from yutto.core.execution import ExecutionScopeFactory
     from yutto.runtime import EventReplay, TaskCapacityPool, TaskContext, TaskEvent, TaskSnapshot
-    from yutto.utils.fetcher import FetcherContext
 
 
 class DownloadApplication(Protocol):
@@ -37,8 +37,8 @@ class DownloadTaskService:
 
     def __init__(
         self,
-        context_factory: Callable[[DownloadRequest], FetcherContext],
-        application_factory: Callable[[FetcherContext, DownloadEventSink], DownloadApplication],
+        scope_factory: ExecutionScopeFactory,
+        application_factory: Callable[[ExecutionScopeFactory, DownloadEventSink], DownloadApplication],
         *,
         replay_limit: int = 100,
         task_limit: int = 256,
@@ -46,7 +46,7 @@ class DownloadTaskService:
         seq_allocator: Callable[[], int] | None = None,
         capacity_pool: TaskCapacityPool | None = None,
     ):
-        self._context_factory = context_factory
+        self._scope_factory = scope_factory
         self._application_factory = application_factory
         self.runtime = TaskRuntime[DownloadRequest, DownloadResult](
             self._run,
@@ -90,8 +90,7 @@ class DownloadTaskService:
         return self.runtime.add_event_listener(listener)
 
     async def _run(self, request: DownloadRequest, task_context: TaskContext) -> DownloadResult:
-        ctx = self._context_factory(request)
-        application = self._application_factory(ctx, _RuntimeDownloadEventSink(task_context))
+        application = self._application_factory(self._scope_factory, _RuntimeDownloadEventSink(task_context))
         return await application.download(request)
 
 
@@ -104,8 +103,8 @@ class ResolveTaskService:
 
     def __init__(
         self,
-        context_factory: Callable[[DownloadRequest], FetcherContext],
-        application_factory: Callable[[FetcherContext, DownloadEventSink], ResolveApplication],
+        scope_factory: ExecutionScopeFactory,
+        application_factory: Callable[[ExecutionScopeFactory, DownloadEventSink], ResolveApplication],
         *,
         replay_limit: int = 100,
         task_limit: int = 256,
@@ -113,7 +112,7 @@ class ResolveTaskService:
         seq_allocator: Callable[[], int] | None = None,
         capacity_pool: TaskCapacityPool | None = None,
     ):
-        self._context_factory = context_factory
+        self._scope_factory = scope_factory
         self._application_factory = application_factory
         self.runtime = TaskRuntime[DownloadRequest, ResolveResult](
             self._run,
@@ -157,8 +156,7 @@ class ResolveTaskService:
         return self.runtime.add_event_listener(listener)
 
     async def _run(self, request: DownloadRequest, task_context: TaskContext) -> ResolveResult:
-        ctx = self._context_factory(request)
-        application = self._application_factory(ctx, _RuntimeDownloadEventSink(task_context))
+        application = self._application_factory(self._scope_factory, _RuntimeDownloadEventSink(task_context))
         return await application.resolve(request)
 
 

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -35,7 +35,7 @@ from yutto.types import EpisodeData, ExtractorOptions
 from yutto.utils.asynclib import sleep_with_status_bar_refresh
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import DanmakuOptions
-from yutto.utils.fetcher import Fetcher, create_client, unwrap_fetch_result
+from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.time import TIME_FULL_FMT
 from yutto.validator import validate_batch_selection
@@ -43,14 +43,13 @@ from yutto.validator import validate_batch_selection
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from httpx import AsyncClient
-
+    from yutto.core.execution import ExecutionScopeFactory
     from yutto.core.request import DanmakuRequestOptions, DownloadRequest
     from yutto.exceptions import YuttoBaseException
     from yutto.extractor._abc import EpisodeListedCallback
     from yutto.extractor.outcome import ResolveOutcome
-    from yutto.types import EpisodeData, EpisodeInfo, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
+    from yutto.types import EpisodeInfo, ResolvableEpisode
+    from yutto.utils.fetcher import ExecutionScope
 
 
 def show_batch_episode_title(
@@ -144,36 +143,34 @@ class _ResolvedItemsOutcome:
 
 
 class DownloadManager:
-    """Execute download requests sequentially in one shared network session."""
+    """Execute requests sequentially with one explicit scope per request."""
 
     def __init__(self):
         self.unique_path = create_unique_path_resolver()
 
-    async def execute(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> DownloadResult:
-        """Run requests in order while sharing the client and path allocator."""
+    async def execute(
+        self,
+        scope_factory: ExecutionScopeFactory,
+        requests: Sequence[DownloadRequest],
+    ) -> DownloadResult:
+        """Run requests in order while keeping network state request-scoped."""
         items: list[ItemResult] = []
-        ctx.set_fetch_semaphore(fetch_workers=ctx.fetch_workers)
-        async with create_client(
-            cookies=ctx.cookies,
-            trust_env=ctx.trust_env,
-            proxy=ctx.proxy,
-        ) as client:
-            for request in requests:
-                items.extend(await self.process_request(client, ctx, request))
+        for request in requests:
+            async with scope_factory.open(request) as scope:
+                items.extend(await self.process_request(scope, request))
         return DownloadResult(items=tuple(items))
 
-    async def execute_resolve(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> ResolveResult:
+    async def execute_resolve(
+        self,
+        scope_factory: ExecutionScopeFactory,
+        requests: Sequence[DownloadRequest],
+    ) -> ResolveResult:
         """Enumerate episodes for requests in order without downloading anything."""
         items: list[ResolvedItem] = []
         failures: list[YuttoBaseException] = []
-        ctx.set_fetch_semaphore(fetch_workers=ctx.fetch_workers)
-        async with create_client(
-            cookies=ctx.cookies,
-            trust_env=ctx.trust_env,
-            proxy=ctx.proxy,
-        ) as client:
-            for request in requests:
-                outcome = await self.resolve_items(client, ctx, request)
+        for request in requests:
+            async with scope_factory.open(request) as scope:
+                outcome = await self.resolve_items(scope, request)
                 items.extend(outcome.items)
                 failures.extend(outcome.failures)
         if failures and not items:
@@ -191,8 +188,7 @@ class DownloadManager:
 
     async def resolve_items(
         self,
-        client: AsyncClient,
-        ctx: FetcherContext,
+        scope: ExecutionScope,
         request: DownloadRequest,
     ) -> _ResolvedItemsOutcome:
         """List the stable episode snapshots of one request; the volatile data is never fetched.
@@ -217,7 +213,7 @@ class DownloadManager:
             _emit_item_listed(episode)
             await asyncio.sleep(0)
 
-        outcome = await self.resolve_request(client, ctx, request, on_item=stream_episode)
+        outcome = await self.resolve_request(scope, request, on_item=stream_episode)
         items: list[ResolvedItem] = []
         for episode in outcome.items:
             key = _resolved_item_key(episode)
@@ -235,11 +231,10 @@ class DownloadManager:
 
     async def process_request(
         self,
-        client: AsyncClient,
-        ctx: FetcherContext,
+        scope: ExecutionScope,
         request: DownloadRequest,
     ) -> tuple[ItemResult, ...]:
-        outcome = await self.resolve_request(client, ctx, request)
+        outcome = await self.resolve_request(scope, request)
         download_list = outcome.items
 
         item_results: list[ItemResult] = []
@@ -249,9 +244,9 @@ class DownloadManager:
         # 下载～
         for i, episode in enumerate(download_list):
             # 中途校验基于请求级缓存的用户信息（见 get_user_info），不会重复请求；
-            # 凭据若在过程中失效，需等缓存所在的 FetcherContext 重建后才能被发现
+            # 凭据若在过程中失效，需等当前 ExecutionScope 关闭后才能被发现
             if not await validate_user_info(
-                ctx,
+                scope,
                 {"is_login": request.access.login_strict, "vip_status": request.access.vip_strict},
             ):
                 raise NotLoginError("启用了严格校验大会员或登录模式，请检查认证信息（--auth）或大会员状态！")
@@ -285,8 +280,8 @@ class DownloadManager:
                 )
 
             previous_result = await process_download(
-                ctx,
-                client,
+                scope,
+                scope.client,
                 episode_data,
                 {
                     "output_dir": request.output.directory,
@@ -305,7 +300,6 @@ class DownloadManager:
                     "output_format_audio_only": request.output.audio_only_format,
                     "overwrite": request.output.overwrite,
                     "block_size": request.network.block_size_bytes,
-                    "num_workers": request.network.download_workers,
                     "save_cover": request.resources.save_cover,
                     "metadata_format": {
                         "premiered": request.output.metadata_format_premiered,
@@ -322,8 +316,7 @@ class DownloadManager:
 
     async def resolve_request(
         self,
-        client: AsyncClient,
-        ctx: FetcherContext,
+        scope: ExecutionScope,
         request: DownloadRequest,
         *,
         on_item: EpisodeListedCallback | None = None,
@@ -367,13 +360,13 @@ class DownloadManager:
 
         # 在开始前校验，减少对第一个视频的请求
         if not await validate_user_info(
-            ctx,
+            scope,
             {"is_login": request.access.login_strict, "vip_status": request.access.vip_strict},
         ):
             raise NotLoginError("启用了严格校验大会员或登录模式，请检查认证信息（--auth）或大会员状态！")
         # 重定向到可识别的 url
         try:
-            url = unwrap_fetch_result(await Fetcher.get_redirected_url(ctx, client, url))
+            url = unwrap_fetch_result(await Fetcher.get_redirected_url(scope, scope.client, url))
         except httpx.InvalidURL:
             raise WrongUrlError(f"无效的 url({url})～请检查一下链接是否正确～") from None
         except httpx.UnsupportedProtocol:
@@ -403,9 +396,9 @@ class DownloadManager:
                     publication_time_filter=publication_time_filter,
                 )
                 if isinstance(extractor, BatchExtractor):
-                    download_list = await extractor(ctx, client, extractor_options, on_item=on_item)
+                    download_list = await extractor(scope, scope.client, extractor_options, on_item=on_item)
                 else:
-                    download_list = await extractor(ctx, client, extractor_options)
+                    download_list = await extractor(scope, scope.client, extractor_options)
                 break
         else:
             if request.scope.batch:

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -43,13 +43,12 @@ from yutto.validator import validate_batch_selection
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from yutto.core.execution import ExecutionScopeFactory
+    from yutto.core.execution import ExecutionScope, ExecutionScopeFactory
     from yutto.core.request import DanmakuRequestOptions, DownloadRequest
     from yutto.exceptions import YuttoBaseException
     from yutto.extractor._abc import EpisodeListedCallback
     from yutto.extractor.outcome import ResolveOutcome
     from yutto.types import EpisodeInfo, ResolvableEpisode
-    from yutto.utils.fetcher import ExecutionScope
 
 
 def show_batch_episode_title(
@@ -281,7 +280,6 @@ class DownloadManager:
 
             previous_result = await process_download(
                 scope,
-                scope.client,
                 episode_data,
                 {
                     "output_dir": request.output.directory,
@@ -366,7 +364,7 @@ class DownloadManager:
             raise NotLoginError("启用了严格校验大会员或登录模式，请检查认证信息（--auth）或大会员状态！")
         # 重定向到可识别的 url
         try:
-            url = unwrap_fetch_result(await Fetcher.get_redirected_url(scope, scope.client, url))
+            url = unwrap_fetch_result(await Fetcher.get_redirected_url(scope, url))
         except httpx.InvalidURL:
             raise WrongUrlError(f"无效的 url({url})～请检查一下链接是否正确～") from None
         except httpx.UnsupportedProtocol:
@@ -396,9 +394,9 @@ class DownloadManager:
                     publication_time_filter=publication_time_filter,
                 )
                 if isinstance(extractor, BatchExtractor):
-                    download_list = await extractor(scope, scope.client, extractor_options, on_item=on_item)
+                    download_list = await extractor(scope, extractor_options, on_item=on_item)
                 else:
-                    download_list = await extractor(scope, scope.client, extractor_options)
+                    download_list = await extractor(scope, extractor_options)
                 break
         else:
             if request.scope.batch:

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -165,7 +165,6 @@ async def download_video_and_audio(
     coroutine_factories_list: list[list[Callable[[], Coroutine[Any, Any, None]]]] = []
     lifecycle_started = False
     mirrors_filter = create_mirrors_filter(options["banned_mirrors_pattern"])
-    ctx.set_download_semaphore(options["num_workers"])
 
     async def get_size(url: str) -> int | None:
         return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -33,10 +33,8 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Protocol
 
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.types import AudioUrlMeta, DownloaderOptions, EpisodeData, VideoUrlMeta
-    from yutto.utils.fetcher import FetcherContext
     from yutto.utils.metadata import ChapterInfoData
 
     class _DownloadBuffer(Protocol):
@@ -150,8 +148,7 @@ async def _run_download_lifecycle(
 
 
 async def download_video_and_audio(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     video: VideoUrlMeta | None,
     video_path: Path,
     audio: AudioUrlMeta | None,
@@ -167,7 +164,7 @@ async def download_video_and_audio(
     mirrors_filter = create_mirrors_filter(options["banned_mirrors_pattern"])
 
     async def get_size(url: str) -> int | None:
-        return unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
+        return unwrap_fetch_result(await Fetcher.get_size(scope, url))
 
     defer_download_file = make_coroutine_factory(Fetcher.download_file_with_offset)
     defer_progress = make_coroutine_factory(show_progress)
@@ -182,8 +179,7 @@ async def download_video_and_audio(
             sizes[0] = vsize
             video_coroutine_factories: list[Callable[[], Coroutine[Any, Any, None]]] = [
                 defer_download_file(
-                    ctx,
-                    client,
+                    scope,
                     video["url"],
                     mirrors_filter(video["mirrors"]),
                     vbuf,
@@ -203,8 +199,7 @@ async def download_video_and_audio(
             sizes[1] = asize
             audio_coroutine_factories: list[Callable[[], Coroutine[Any, Any, None]]] = [
                 defer_download_file(
-                    ctx,
-                    client,
+                    scope,
                     audio["url"],
                     mirrors_filter(audio["mirrors"]),
                     abuf,
@@ -381,8 +376,7 @@ def resolve_path(base_output_dir: Path, base_tmp_dir: Path, path: Path) -> tuple
 
 
 async def process_download(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     episode_data: EpisodeData,
     options: DownloaderOptions,
 ) -> ItemResult:
@@ -557,7 +551,7 @@ async def process_download(
 
     # 下载视频 / 音频
     emit_download_event(DownloadStageChanged(name=DownloadStage.DOWNLOADING, item=filename))
-    await download_video_and_audio(ctx, client, video, video_path, audio, audio_path, options)
+    await download_video_and_audio(scope, video, video_path, audio, audio_path, options)
 
     # 合并视频 / 音频
     emit_download_event(DownloadStageChanged(name=DownloadStage.POSTPROCESSING, item=filename))

--- a/src/yutto/extractor/_abc.py
+++ b/src/yutto/extractor/_abc.py
@@ -9,12 +9,10 @@ from yutto.types import ResolvableEpisode
 if TYPE_CHECKING:
     from typing import TypeAlias
 
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.exceptions import YuttoBaseException
     from yutto.extractor.outcome import ResolveOutcome
     from yutto.types import ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
     ExtractorResolveOutcome: TypeAlias = ResolveOutcome[ResolvableEpisode, YuttoBaseException]
 
@@ -34,8 +32,7 @@ class Extractor(metaclass=ABCMeta):
     @abstractmethod
     async def __call__(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
     ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         raise NotImplementedError
@@ -44,17 +41,15 @@ class Extractor(metaclass=ABCMeta):
 class SingleExtractor(Extractor):
     async def __call__(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
     ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
-        return await self.extract(ctx, client, options)
+        return await self.extract(scope, options)
 
     @abstractmethod
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
     ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
         raise NotImplementedError
@@ -63,19 +58,17 @@ class SingleExtractor(Extractor):
 class BatchExtractor(Extractor):
     async def __call__(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ResolveOutcome[ResolvableEpisode, YuttoBaseException]:
-        return await self.extract(ctx, client, options, on_item=on_item)
+        return await self.extract(scope, options, on_item=on_item)
 
     @abstractmethod
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,

--- a/src/yutto/extractor/bangumi.py
+++ b/src/yutto/extractor/bangumi.py
@@ -18,11 +18,9 @@ from yutto.types import EpisodeId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 class BangumiExtractor(SingleExtractor):
@@ -51,12 +49,11 @@ class BangumiExtractor(SingleExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
     ) -> ExtractorResolveOutcome:
-        season_id = await get_season_id_by_episode_id(ctx, client, self.episode_id)
-        bangumi_list = await get_bangumi_list(ctx, client, season_id)
+        season_id = await get_season_id_by_episode_id(scope, self.episode_id)
+        bangumi_list = await get_bangumi_list(scope, season_id)
         Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))
         try:
             for bangumi_item in bangumi_list["pages"]:
@@ -69,8 +66,7 @@ class BangumiExtractor(SingleExtractor):
             return ResolveOutcome(
                 items=(
                     make_bangumi_episode(
-                        ctx,
-                        client,
+                        scope,
                         bangumi_list_item,
                         options,
                         {

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -16,11 +16,9 @@ from yutto.types import EpisodeId, MediaId, SeasonId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 class BangumiBatchExtractor(BatchExtractor):
@@ -62,27 +60,26 @@ class BangumiBatchExtractor(BatchExtractor):
         else:
             return False
 
-    async def _parse_ids(self, ctx: FetcherContext, client: httpx.AsyncClient):
+    async def _parse_ids(self, scope: ExecutionScope):
         if "episode_id" in self._match_result.groupdict().keys():
             episode_id = EpisodeId(self._match_result.group("episode_id"))
-            self.season_id = await get_season_id_by_episode_id(ctx, client, episode_id)
+            self.season_id = await get_season_id_by_episode_id(scope, episode_id)
         elif "season_id" in self._match_result.groupdict().keys():
             self.season_id = SeasonId(self._match_result.group("season_id"))
         else:
             media_id = MediaId(self._match_result.group("media_id"))
-            self.season_id = await get_season_id_by_media_id(ctx, client, media_id)
+            self.season_id = await get_season_id_by_media_id(scope, media_id)
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
-        await self._parse_ids(ctx, client)
+        await self._parse_ids(scope)
 
-        bangumi_list = await get_bangumi_list(ctx, client, self.season_id)
+        bangumi_list = await get_bangumi_list(scope, self.season_id)
         Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))
         # 如果没有 with_section 则不需要专区内容
         bangumi_list["pages"] = list(
@@ -94,8 +91,7 @@ class BangumiBatchExtractor(BatchExtractor):
         return ResolveOutcome(
             items=tuple(
                 make_bangumi_episode(
-                    ctx,
-                    client,
+                    scope,
                     bangumi_item,
                     options,
                     {

--- a/src/yutto/extractor/cheese.py
+++ b/src/yutto/extractor/cheese.py
@@ -18,11 +18,9 @@ from yutto.types import EpisodeId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 class CheeseExtractor(SingleExtractor):
@@ -52,12 +50,11 @@ class CheeseExtractor(SingleExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
     ) -> ExtractorResolveOutcome:
-        season_id = await get_season_id_by_episode_id(ctx, client, self.episode_id)
-        cheese_list = await get_cheese_list(ctx, client, season_id)
+        season_id = await get_season_id_by_episode_id(scope, self.episode_id)
+        cheese_list = await get_cheese_list(scope, season_id)
         Logger.custom(cheese_list["title"], Badge("课程", fore="black", back="cyan"))
         try:
             for cheese_item in cheese_list["pages"]:
@@ -70,8 +67,7 @@ class CheeseExtractor(SingleExtractor):
             return ResolveOutcome(
                 items=(
                     make_cheese_episode(
-                        ctx,
-                        client,
+                        scope,
                         self.episode_id,
                         cheese_list_item,
                         options,

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -12,11 +12,9 @@ from yutto.types import EpisodeId, SeasonId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.types import ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 class CheeseBatchExtractor(BatchExtractor):
@@ -50,24 +48,23 @@ class CheeseBatchExtractor(BatchExtractor):
         else:
             return False
 
-    async def _parse_ids(self, ctx: FetcherContext, client: httpx.AsyncClient):
+    async def _parse_ids(self, scope: ExecutionScope):
         if "episode_id" in self._match_result.groupdict().keys():
             episode_id = EpisodeId(self._match_result.group("episode_id"))
-            self.season_id = await get_season_id_by_episode_id(ctx, client, episode_id)
+            self.season_id = await get_season_id_by_episode_id(scope, episode_id)
         else:
             self.season_id = SeasonId(self._match_result.group("season_id"))
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
-        await self._parse_ids(ctx, client)
+        await self._parse_ids(scope)
 
-        cheese_list = await get_cheese_list(ctx, client, self.season_id)
+        cheese_list = await get_cheese_list(scope, self.season_id)
         Logger.custom(cheese_list["title"], Badge("课程", fore="black", back="cyan"))
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(cheese_list["pages"]))
@@ -75,8 +72,7 @@ class CheeseBatchExtractor(BatchExtractor):
         return ResolveOutcome(
             items=tuple(
                 make_cheese_episode(
-                    ctx,
-                    client,
+                    scope,
                     cheese_item["episode_id"],
                     cheese_item,
                     options,

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -15,13 +15,11 @@ from yutto.types import MId, SeriesId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import ExtractorOptions, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
 
 
 class CollectionExtractor(BatchExtractor):
@@ -50,15 +48,14 @@ class CollectionExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         username, collection_details = await asyncio.gather(
-            get_user_name(ctx, client, self.mid),
-            get_collection_details(ctx, client, self.series_id, self.mid),
+            get_user_name(scope, self.mid),
+            get_collection_details(scope, self.series_id, self.mid),
         )
         collection_title = collection_details["title"]
         Logger.custom(collection_title, Badge("视频合集", fore="black", back="cyan"))
@@ -81,8 +78,7 @@ class CollectionExtractor(BatchExtractor):
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
-                    ctx,
-                    client,
+                    scope,
                     ugc_video_item["avid"],
                     ugc_video_item,
                     options,
@@ -104,8 +100,7 @@ class CollectionExtractor(BatchExtractor):
             episodes_by_index[index] = built
 
         batch_outcome = await resolve_ugc_video_lists(
-            ctx,
-            client,
+            scope,
             avids,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -32,8 +32,6 @@ from yutto.utils.fetcher import Fetcher
 from yutto.utils.metadata import MetaData, attach_chapter_info
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.bangumi import (
         BangumiListItem,
     )
@@ -41,11 +39,11 @@ if TYPE_CHECKING:
     from yutto.api.ugc_video import (
         UgcVideoListItem,
     )
+    from yutto.core.execution import ExecutionScope
     from yutto.path_templates import (
         PathTemplateVariableDict,
     )
     from yutto.types import AvId, EpisodeId, ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 def _get_display_fields_from_metadata(metadata: MetaData | None) -> tuple[str, str, list[str]]:
@@ -96,8 +94,7 @@ def build_bangumi_info(
 
 
 async def extract_bangumi_data(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     info: EpisodeInfo,
     bangumi_info: BangumiListItem,
     options: ExtractorOptions,
@@ -108,21 +105,19 @@ async def extract_bangumi_data(
         if bangumi_info["is_preview"]:
             Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
         videos, audios = (
-            await get_bangumi_playurl(ctx, client, avid, cid)
+            await get_bangumi_playurl(scope, avid, cid)
             if options["require_video"] or options["require_audio"]
             else ([], [])
         )
-        subtitles = await get_bangumi_subtitles(ctx, client, avid, cid) if options["require_subtitle"] else []
+        subtitles = await get_bangumi_subtitles(scope, avid, cid) if options["require_subtitle"] else []
         danmaku = (
-            await get_danmaku(ctx, client, cid, avid, options["danmaku_format"])
+            await get_danmaku(scope, cid, avid, options["danmaku_format"])
             if options["require_danmaku"]
             else EmptyDanmakuData
         )
         metadata = bangumi_info["metadata"] if options["require_metadata"] else None
         cover_data = (
-            (await Fetcher.fetch_bin(ctx, client, info["cover_url"])).value_or(None)
-            if options["require_cover"]
-            else None
+            (await Fetcher.fetch_bin(scope, info["cover_url"])).value_or(None) if options["require_cover"] else None
         )
         return EpisodeData(
             info=info,
@@ -140,8 +135,7 @@ async def extract_bangumi_data(
 
 
 def make_bangumi_episode(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     bangumi_info: BangumiListItem,
     options: ExtractorOptions,
     subpath_variables: PathTemplateVariableDict,
@@ -150,7 +144,7 @@ def make_bangumi_episode(
     info = build_bangumi_info(bangumi_info, options, subpath_variables, auto_subpath_template)
     return ResolvableEpisode(
         info=info,
-        resolve_data=make_coroutine_factory(extract_bangumi_data)(ctx, client, info, bangumi_info, options),
+        resolve_data=make_coroutine_factory(extract_bangumi_data)(scope, info, bangumi_info, options),
     )
 
 
@@ -193,8 +187,7 @@ def build_cheese_info(
 
 
 async def extract_cheese_data(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     episode_id: EpisodeId,
     info: EpisodeInfo,
     cheese_info: CheeseListItem,
@@ -204,21 +197,19 @@ async def extract_cheese_data(
         avid = info["avid"]
         cid = info["cid"]
         videos, audios = (
-            await get_cheese_playurl(ctx, client, avid, episode_id, cid)
+            await get_cheese_playurl(scope, avid, episode_id, cid)
             if options["require_video"] or options["require_audio"]
             else ([], [])
         )
-        subtitles = await get_cheese_subtitles(ctx, client, avid, cid) if options["require_subtitle"] else []
+        subtitles = await get_cheese_subtitles(scope, avid, cid) if options["require_subtitle"] else []
         danmaku = (
-            await get_danmaku(ctx, client, cid, avid, options["danmaku_format"])
+            await get_danmaku(scope, cid, avid, options["danmaku_format"])
             if options["require_danmaku"]
             else EmptyDanmakuData
         )
         metadata = cheese_info["metadata"] if options["require_metadata"] else None
         cover_data = (
-            (await Fetcher.fetch_bin(ctx, client, info["cover_url"])).value_or(None)
-            if options["require_cover"]
-            else None
+            (await Fetcher.fetch_bin(scope, info["cover_url"])).value_or(None) if options["require_cover"] else None
         )
         return EpisodeData(
             info=info,
@@ -236,8 +227,7 @@ async def extract_cheese_data(
 
 
 def make_cheese_episode(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     episode_id: EpisodeId,
     cheese_info: CheeseListItem,
     options: ExtractorOptions,
@@ -247,7 +237,7 @@ def make_cheese_episode(
     info = build_cheese_info(cheese_info, options, subpath_variables, auto_subpath_template)
     return ResolvableEpisode(
         info=info,
-        resolve_data=make_coroutine_factory(extract_cheese_data)(ctx, client, episode_id, info, cheese_info, options),
+        resolve_data=make_coroutine_factory(extract_cheese_data)(scope, episode_id, info, cheese_info, options),
     )
 
 
@@ -299,8 +289,7 @@ def build_ugc_video_info(
 
 
 async def extract_ugc_video_data(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     info: EpisodeInfo,
     ugc_video_info: UgcVideoListItem,
     options: ExtractorOptions,
@@ -309,16 +298,14 @@ async def extract_ugc_video_data(
         avid = info["avid"]
         cid = info["cid"]
         videos, audios = (
-            await get_ugc_video_playurl(ctx, client, avid, cid, options["ai_translation_language"])
+            await get_ugc_video_playurl(scope, avid, cid, options["ai_translation_language"])
             if options["require_video"] or options["require_audio"]
             else ([], [])
         )
-        subtitles = await get_ugc_video_subtitles(ctx, client, avid, cid) if options["require_subtitle"] else []
-        chapter_info_data = (
-            await get_ugc_video_chapters(ctx, client, avid, cid) if options["require_chapter_info"] else []
-        )
+        subtitles = await get_ugc_video_subtitles(scope, avid, cid) if options["require_subtitle"] else []
+        chapter_info_data = await get_ugc_video_chapters(scope, avid, cid) if options["require_chapter_info"] else []
         danmaku = (
-            await get_danmaku(ctx, client, cid, avid, options["danmaku_format"])
+            await get_danmaku(scope, cid, avid, options["danmaku_format"])
             if options["require_danmaku"]
             else EmptyDanmakuData
         )
@@ -326,9 +313,7 @@ async def extract_ugc_video_data(
         if metadata and chapter_info_data:
             attach_chapter_info(metadata, chapter_info_data)
         cover_data = (
-            (await Fetcher.fetch_bin(ctx, client, info["cover_url"])).value_or(None)
-            if options["require_cover"]
-            else None
+            (await Fetcher.fetch_bin(scope, info["cover_url"])).value_or(None) if options["require_cover"] else None
         )
         return EpisodeData(
             info=info,
@@ -346,8 +331,7 @@ async def extract_ugc_video_data(
 
 
 def make_ugc_video_episode(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     avid: AvId,
     ugc_video_info: UgcVideoListItem,
     options: ExtractorOptions,
@@ -358,5 +342,5 @@ def make_ugc_video_episode(
     info = build_ugc_video_info(avid, ugc_video_info, options, subpath_variables, auto_subpath_template, display_group)
     return ResolvableEpisode(
         info=info,
-        resolve_data=make_coroutine_factory(extract_ugc_video_data)(ctx, client, info, ugc_video_info, options),
+        resolve_data=make_coroutine_factory(extract_ugc_video_data)(scope, info, ugc_video_info, options),
     )

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -14,13 +14,11 @@ from yutto.types import FId, MId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import ExtractorOptions, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
 
 
 class FavouritesExtractor(BatchExtractor):
@@ -41,19 +39,18 @@ class FavouritesExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         username, favourite_info = await asyncio.gather(
-            get_user_name(ctx, client, self.mid),
-            get_favourite_info(ctx, client, self.fid),
+            get_user_name(scope, self.mid),
+            get_favourite_info(scope, self.fid),
         )
         Logger.custom(favourite_info["title"], Badge("收藏夹", fore="black", back="cyan"))
 
-        favourite_videos = await get_favourite_items(ctx, client, self.fid)
+        favourite_videos = await get_favourite_items(scope, self.fid)
         avids = [favourite_video["avid"] for favourite_video in favourite_videos]
 
         # 每个视频解析完成即构建其分集并通过显式回调推流；完成顺序与收藏夹
@@ -75,8 +72,7 @@ class FavouritesExtractor(BatchExtractor):
                     is_single_page_video=is_single_page_video,
                 )
                 episode = make_ugc_video_episode(
-                    ctx,
-                    client,
+                    scope,
                     resolved_video_item["avid"],
                     resolved_video_item,
                     options,
@@ -97,8 +93,7 @@ class FavouritesExtractor(BatchExtractor):
             episodes_by_index[index] = episodes
 
         batch_outcome = await resolve_ugc_video_lists(
-            ctx,
-            client,
+            scope,
             avids,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -13,13 +13,11 @@ from yutto.types import MId, SeriesId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import ExtractorOptions, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
 
 
 class SeriesExtractor(BatchExtractor):
@@ -41,18 +39,17 @@ class SeriesExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         username, series_title = await asyncio.gather(
-            get_user_name(ctx, client, self.mid), get_medialist_title(ctx, client, self.series_id)
+            get_user_name(scope, self.mid), get_medialist_title(scope, self.series_id)
         )
         Logger.custom(series_title, Badge("视频列表", fore="black", back="cyan"))
 
-        avids = await get_medialist_avids(ctx, client, self.series_id, self.mid)
+        avids = await get_medialist_avids(scope, self.series_id, self.mid)
 
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。
         episodes_by_index: dict[int, list[ResolvableEpisode]] = {}
@@ -63,8 +60,7 @@ class SeriesExtractor(BatchExtractor):
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
-                    ctx,
-                    client,
+                    scope,
                     ugc_video_item["avid"],
                     ugc_video_item,
                     options,
@@ -84,8 +80,7 @@ class SeriesExtractor(BatchExtractor):
             episodes_by_index[index] = built
 
         batch_outcome = await resolve_ugc_video_lists(
-            ctx,
-            client,
+            scope,
             avids,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,

--- a/src/yutto/extractor/ugc_video.py
+++ b/src/yutto/extractor/ugc_video.py
@@ -18,11 +18,9 @@ from yutto.types import AId, BvId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import AvId, ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 class UgcVideoExtractor(SingleExtractor):
@@ -81,19 +79,17 @@ class UgcVideoExtractor(SingleExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
     ) -> ExtractorResolveOutcome:
         try:
-            ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)
+            ugc_video_list = await get_ugc_video_list(scope, self.avid)
             self.avid = ugc_video_list["avid"]  # 当视频撞车时，使用新的 avid 替代原有 avid，见 #96
             Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
             return ResolveOutcome(
                 items=(
                     make_ugc_video_episode(
-                        ctx,
-                        client,
+                        scope,
                         self.avid,
                         ugc_video_list["pages"][self.page - 1],
                         options,

--- a/src/yutto/extractor/ugc_video_batch.py
+++ b/src/yutto/extractor/ugc_video_batch.py
@@ -13,11 +13,9 @@ from yutto.types import AId, BvId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.types import AvId, ExtractorOptions
-    from yutto.utils.fetcher import FetcherContext
 
 
 class UgcVideoBatchExtractor(BatchExtractor):
@@ -66,14 +64,13 @@ class UgcVideoBatchExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         try:
-            ugc_video_list = await get_ugc_video_list(ctx, client, self.avid)
+            ugc_video_list = await get_ugc_video_list(scope, self.avid)
             Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
         except (NotFoundError, NoAccessPermissionError) as e:
             # 由于获取 info 时候也会因为视频不存在而报错，因此这里需要捕捉下
@@ -87,8 +84,7 @@ class UgcVideoBatchExtractor(BatchExtractor):
         return ResolveOutcome(
             items=tuple(
                 make_ugc_video_episode(
-                    ctx,
-                    client,
+                    scope,
                     ugc_video_item["avid"],
                     ugc_video_item,
                     options,

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -14,15 +14,13 @@ from yutto.types import MId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.space import FavouriteVideoData
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.core.execution import ExecutionScope
     from yutto.exceptions import YuttoBaseException
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import ExtractorOptions, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
 
 
 class UserAllFavouritesExtractor(BatchExtractor):
@@ -41,22 +39,21 @@ class UserAllFavouritesExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
-        username = await get_user_name(ctx, client, self.mid)
+        username = await get_user_name(scope, self.mid)
         Logger.custom(username, Badge("用户收藏夹", fore="black", back="cyan"))
 
         all_episodes: list[ResolvableEpisode] = []
         failures: list[YuttoBaseException] = []
 
-        for fav in await get_all_favourites(ctx, client, self.mid):
+        for fav in await get_all_favourites(scope, self.mid):
             series_title = fav["title"]
             fid = fav["fid"]
-            favourite_videos = await get_favourite_items(ctx, client, fid)
+            favourite_videos = await get_favourite_items(scope, fid)
             avids = [favourite_video["avid"] for favourite_video in favourite_videos]
 
             # 逐视频解析完成即构建分集并通过显式回调推流，收藏夹内按 index 重排。
@@ -84,8 +81,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
                         is_single_page_video=is_single_page_video,
                     )
                     episode = make_ugc_video_episode(
-                        ctx,
-                        client,
+                        scope,
                         resolved_video_item["avid"],
                         resolved_video_item,
                         options,
@@ -106,8 +102,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
                 _episodes_by_index[index] = built
 
             batch_outcome = await resolve_ugc_video_lists(
-                ctx,
-                client,
+                scope,
                 avids,
                 publication_time_filter=options["publication_time_filter"],
                 on_resolved=build_episodes,

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -13,13 +13,11 @@ from yutto.types import MId
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import ExtractorOptions, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
 
 
 class UserAllUgcVideosExtractor(BatchExtractor):
@@ -38,19 +36,17 @@ class UserAllUgcVideosExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
-        username = await get_user_name(ctx, client, self.mid)
+        username = await get_user_name(scope, self.mid)
         Logger.custom(username, Badge("UP 主投稿视频", fore="black", back="cyan"))
 
         publication_time_filter = options["publication_time_filter"]
         avids = await get_user_space_all_videos_avids(
-            ctx,
-            client,
+            scope,
             self.mid,
             pubdate_filter=publication_time_filter.matches,
             stop_before_timestamp=publication_time_filter.start_timestamp,
@@ -65,8 +61,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
-                    ctx,
-                    client,
+                    scope,
                     ugc_video_item["avid"],
                     ugc_video_item,
                     options,
@@ -85,8 +80,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
             episodes_by_index[index] = built
 
         batch_outcome = await resolve_ugc_video_lists(
-            ctx,
-            client,
+            scope,
             avids,
             publication_time_filter=publication_time_filter,
             on_resolved=build_episodes,

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -13,13 +13,11 @@ from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.ugc_video import UgcVideoList
+    from yutto.core.execution import ExecutionScope
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
     from yutto.extractor.utils.batch import IndexedResolveItem
     from yutto.types import ExtractorOptions, ResolvableEpisode
-    from yutto.utils.fetcher import FetcherContext
 
 
 class UserWatchLaterExtractor(BatchExtractor):
@@ -36,8 +34,7 @@ class UserWatchLaterExtractor(BatchExtractor):
 
     async def extract(
         self,
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         options: ExtractorOptions,
         *,
         on_item: EpisodeListedCallback | None = None,
@@ -45,7 +42,7 @@ class UserWatchLaterExtractor(BatchExtractor):
         Logger.custom("当前用户", Badge("稍后再看", fore="black", back="cyan"))
 
         try:
-            avid_list = await get_watch_later_avids(ctx, client)
+            avid_list = await get_watch_later_avids(scope)
         except NotLoginError as e:
             Logger.error(e.message)
             return ResolveOutcome(failures=(e,))
@@ -59,8 +56,7 @@ class UserWatchLaterExtractor(BatchExtractor):
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
-                    ctx,
-                    client,
+                    scope,
                     ugc_video_item["avid"],
                     ugc_video_item,
                     options,
@@ -80,8 +76,7 @@ class UserWatchLaterExtractor(BatchExtractor):
             episodes_by_index[index] = built
 
         batch_outcome = await resolve_ugc_video_lists(
-            ctx,
-            client,
+            scope,
             avid_list,
             publication_time_filter=options["publication_time_filter"],
             on_resolved=build_episodes,

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -13,11 +13,9 @@ from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    import httpx
-
+    from yutto.core.execution import ExecutionScope
     from yutto.exceptions import YuttoBaseException
     from yutto.types import AvId
-    from yutto.utils.fetcher import FetcherContext
     from yutto.utils.filter import PublicationTimeFilter
 
 T = TypeVar("T")
@@ -44,8 +42,7 @@ class _FilteredResolveItem:
 
 
 async def resolve_ugc_video_lists(
-    ctx: FetcherContext,
-    client: httpx.AsyncClient,
+    scope: ExecutionScope,
     avids: list[AvId],
     *,
     publication_time_filter: PublicationTimeFilter,
@@ -53,7 +50,7 @@ async def resolve_ugc_video_lists(
 ) -> ResolveOutcome[IndexedResolveItem[UgcVideoList], IndexedResolveFailure]:
     """并发解析一批视频的分 P 列表，结果顺序与 avids 一致
 
-    并发度由 ctx 中已有的 fetch semaphore 控制（Fetcher 的每个请求都会经过 ctx.fetch_guard()），
+    并发度由 scope 中已有的 fetch semaphore 控制（Fetcher 的每个请求都会经过 scope.fetch_guard()），
     这里无需额外限流；时间过滤项不进入 outcome，预期失败则显式保留输入位置和来源，
     不会中断整批解析。
 
@@ -71,13 +68,13 @@ async def resolve_ugc_video_lists(
         index: int, avid: AvId
     ) -> IndexedResolveItem[UgcVideoList] | IndexedResolveFailure | _FilteredResolveItem:
         try:
-            ugc_video_list = await get_ugc_video_list(ctx, client, avid)
+            ugc_video_list = await get_ugc_video_list(scope, avid)
             if not publication_time_filter.matches(ugc_video_list["pubdate"]):
                 Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
                 return _FilteredResolveItem(index=index, source=avid)
             # 在使用 SESSDATA 时，如果不去事先 touch 一下视频链接的话，是无法获取 episode_data 的
             # 至于为什么前面那俩（投稿视频页和番剧页）不需要额外 touch，因为在 get_redirected_url 阶段连接过了呀
-            unwrap_fetch_result(await Fetcher.touch_url(ctx, client, avid.to_url()))
+            unwrap_fetch_result(await Fetcher.touch_url(scope, avid.to_url()))
             return IndexedResolveItem(index=index, source=avid, value=ugc_video_list)
         except (NotFoundError, NoAccessPermissionError) as e:
             Logger.error(e.message)

--- a/src/yutto/login.py
+++ b/src/yutto/login.py
@@ -12,7 +12,7 @@ from yutto.api.user_info import USER_INFO_API, parse_user_info, user_info_matche
 from yutto.auth import AuthInfo, remove_auth, resolve_auth, resolve_auth_file, save_auth, validate_profile
 from yutto.exceptions import ErrorCode
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import FetcherContext, create_sync_client
+from yutto.utils.fetcher import cookies_from_auth, create_sync_client, resolve_proxy
 
 if TYPE_CHECKING:
     from yutto.types import UserInfo
@@ -28,15 +28,14 @@ QR_STATUS_CONFIRMED = 0
 
 
 def run_login(args: Any):
-    ctx = FetcherContext()
     try:
-        ctx.set_proxy(args.proxy)
+        proxy, trust_env = resolve_proxy(args.proxy)
         validate_profile(args.auth_profile)
     except ValueError as e:
         Logger.error(str(e))
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 
-    with create_sync_client(proxy=ctx.proxy, trust_env=ctx.trust_env, timeout=10, verify=True) as client:
+    with create_sync_client(proxy=proxy, trust_env=trust_env, timeout=10, verify=True) as client:
         qr_login_url, qr_key = generate_qr_login(client)
         show_qr_code(qr_login_url, args.mode)
         Logger.info("请使用哔哩哔哩 App 扫码并确认登录")
@@ -49,7 +48,7 @@ def run_login(args: Any):
     auth_file = resolve_auth_file(args)
     save_auth(auth_file, args.auth_profile, sessdata, bili_jct)
     auth = AuthInfo(SESSDATA=sessdata, bili_jct=bili_jct)
-    if validate_saved_auth(auth, proxy=ctx.proxy, trust_env=ctx.trust_env):
+    if validate_saved_auth(auth, proxy=proxy, trust_env=trust_env):
         Logger.info(
             f"登录成功，已写入认证文件：{auth_file}（profile: {args.auth_profile}，url: {sanitize_url_for_log(result_url)}）"
         )
@@ -60,9 +59,8 @@ def run_login(args: Any):
 
 
 def run_auth_status(args: Any):
-    ctx = FetcherContext()
     try:
-        ctx.set_proxy(args.proxy)
+        proxy, trust_env = resolve_proxy(args.proxy)
         auth = resolve_auth(args)
     except ValueError as e:
         Logger.error(str(e))
@@ -73,7 +71,7 @@ def run_auth_status(args: Any):
         sys.exit(ErrorCode.NOT_LOGIN_ERROR.value)
 
     try:
-        user_info = fetch_authenticated_user_info(auth, proxy=ctx.proxy, trust_env=ctx.trust_env)
+        user_info = fetch_authenticated_user_info(auth, proxy=proxy, trust_env=trust_env)
     except Exception as e:
         Logger.error(f"登录状态检查失败：{e}")
         sys.exit(ErrorCode.HTTP_STATUS_ERROR.value)
@@ -249,9 +247,8 @@ def get_cookie_value(cookies: httpx.Cookies, name: str) -> str | None:
 
 
 def fetch_authenticated_user_info(auth: AuthInfo, *, proxy: str | None, trust_env: bool) -> UserInfo:
-    ctx = FetcherContext(proxy=proxy, trust_env=trust_env)
-    ctx.set_auth_info(auth)
-    with create_sync_client(cookies=ctx.cookies, proxy=ctx.proxy, trust_env=ctx.trust_env, verify=True) as client:
+    cookies = cookies_from_auth(auth)
+    with create_sync_client(cookies=cookies, proxy=proxy, trust_env=trust_env, verify=True) as client:
         return parse_user_info(request_json(client, USER_INFO_API, params={}))
 
 

--- a/src/yutto/server/command.py
+++ b/src/yutto/server/command.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from yutto.core.events import DownloadEventSink
-    from yutto.utils.fetcher import FetcherContext
+    from yutto.core.execution import ExecutionScopeFactory
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,20 +107,21 @@ def build_server(args: argparse.Namespace, token: str, *, ffmpeg: FFmpeg | None 
     parse_request = download_request_parser_from_settings(args.server_settings)
     default_request = parse_request({"source": {"url": "yutto-server-default-validation"}})
     policy.prepare_request(default_request)
-    policy.build_context(default_request)
+    policy.resolve_credentials(default_request)
+    scope_factory = policy.build_scope_factory()
     # download 与 resolve 两个 runtime 共享同一事件序号空间与全局任务容量，
     # 维持 v1 契约：`seq` 全局递增可去重、`--task-limit` 是两类任务的总量
     event_seq_allocator = monotonic_seq_allocator()
     task_capacity = TaskCapacityPool(args.task_limit)
     task_service = DownloadTaskService(
-        policy.build_context,
+        scope_factory,
         _build_download_application,
         task_limit=args.task_limit,
         seq_allocator=event_seq_allocator,
         capacity_pool=task_capacity,
     )
     resolve_service = ResolveTaskService(
-        policy.build_context,
+        scope_factory,
         _build_download_application,
         task_limit=args.task_limit,
         seq_allocator=event_seq_allocator,
@@ -140,9 +141,17 @@ def build_server(args: argparse.Namespace, token: str, *, ffmpeg: FFmpeg | None 
     )
 
 
-def _build_download_application(ctx: FetcherContext, event_sink: DownloadEventSink) -> YuttoApplication:
+def _build_download_application(
+    scope_factory: ExecutionScopeFactory,
+    event_sink: DownloadEventSink,
+) -> YuttoApplication:
     manager = DownloadManager()
-    return YuttoApplication(ctx, workflow=manager, event_sink=event_sink, resolve_workflow=manager)
+    return YuttoApplication(
+        scope_factory,
+        workflow=manager,
+        event_sink=event_sink,
+        resolve_workflow=manager,
+    )
 
 
 @as_sync

--- a/src/yutto/server/service.py
+++ b/src/yutto/server/service.py
@@ -12,9 +12,11 @@ from typing import TYPE_CHECKING, TypeAlias, TypeVar
 from pydantic import BaseModel
 
 from yutto.auth import load_auth
-from yutto.utils.fetcher import FetcherContext
+from yutto.core.execution import RequestExecutionScopeFactory
+from yutto.utils.fetcher import resolve_proxy
 
 if TYPE_CHECKING:
+    from yutto.auth import AuthInfo
     from yutto.core.request import DownloadRequest
     from yutto.runtime import EventReplay, TaskEvent, TaskSnapshot
 
@@ -82,6 +84,7 @@ class ServerPolicy:
     def prepare_request(self, request: DownloadRequest) -> DownloadRequest:
         """Return an immutable copy with server-owned absolute output paths."""
         self._validate_workers(request)
+        self._validate_proxy(request)
         self._validate_block_size(request)
         self._validate_save_codecs(request)
         self._validate_subpath_template(request.output.subpath_template)
@@ -108,20 +111,16 @@ class ServerPolicy:
         )
         return request.model_copy(update={"output": output})
 
-    def build_context(self, request: DownloadRequest) -> FetcherContext:
-        """Build a fetch context without attaching credentials to the request."""
-        self._validate_workers(request)
-        context = FetcherContext()
+    def build_scope_factory(self) -> RequestExecutionScopeFactory:
+        """Build the shared request-to-scope boundary used by server tasks."""
+        return RequestExecutionScopeFactory(self.resolve_credentials)
+
+    def resolve_credentials(self, request: DownloadRequest) -> AuthInfo | None:
+        """Resolve one auth profile without attaching credentials to the request."""
         try:
-            context.set_proxy(request.network.proxy)
-            auth = load_auth(self.options.auth_file, request.access.auth_profile)
+            return load_auth(self.options.auth_file, request.access.auth_profile)
         except ValueError as error:
             raise ServerPolicyError(str(error)) from error
-
-        context.set_fetch_workers(request.network.fetch_workers)
-        if auth is not None:
-            context.set_auth_info(auth)
-        return context
 
     def _validate_workers(self, request: DownloadRequest) -> None:
         self._validate_worker_count(
@@ -134,6 +133,13 @@ class ServerPolicy:
             request.network.download_workers,
             self.options.max_download_workers,
         )
+
+    @staticmethod
+    def _validate_proxy(request: DownloadRequest) -> None:
+        try:
+            resolve_proxy(request.network.proxy)
+        except ValueError as error:
+            raise ServerPolicyError(str(error)) from error
 
     def _validate_block_size(self, request: DownloadRequest) -> None:
         value = request.network.block_size_bytes

--- a/src/yutto/server/service.py
+++ b/src/yutto/server/service.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, TypeAlias, TypeVar
 
 from pydantic import BaseModel
 
-from yutto.auth import load_auth
+from yutto.auth import load_auth, validate_profile
 from yutto.core.execution import RequestExecutionScopeFactory
 from yutto.utils.fetcher import resolve_proxy
 
@@ -85,6 +85,7 @@ class ServerPolicy:
         """Return an immutable copy with server-owned absolute output paths."""
         self._validate_workers(request)
         self._validate_proxy(request)
+        self._validate_auth_profile(request)
         self._validate_block_size(request)
         self._validate_save_codecs(request)
         self._validate_subpath_template(request.output.subpath_template)
@@ -138,6 +139,13 @@ class ServerPolicy:
     def _validate_proxy(request: DownloadRequest) -> None:
         try:
             resolve_proxy(request.network.proxy)
+        except ValueError as error:
+            raise ServerPolicyError(str(error)) from error
+
+    @staticmethod
+    def _validate_auth_profile(request: DownloadRequest) -> None:
+        try:
+            validate_profile(request.access.auth_profile)
         except ValueError as error:
             raise ServerPolicyError(str(error)) from error
 

--- a/src/yutto/types.py
+++ b/src/yutto/types.py
@@ -284,7 +284,6 @@ class DownloaderOptions(TypedDict):
     output_format_audio_only: str
     overwrite: bool
     block_size: int
-    num_workers: int
     metadata_format: dict[str, str]
     banned_mirrors_pattern: str | None
     danmaku_options: DanmakuOptions

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -94,6 +94,18 @@ def resolve_proxy(proxy: str) -> tuple[str | None, bool]:
     return proxy, False
 
 
+def cookies_from_auth(auth_info: AuthInfo | None) -> httpx.Cookies:
+    cookies = httpx.Cookies()
+    if auth_info is None:
+        return cookies
+    # 先解码后编码是防止获取到的 SESSDATA 是已经解码后的（包含「,」）
+    # 而番剧无法使用解码后的 SESSDATA
+    cookies.set("SESSDATA", quote(unquote(auth_info["SESSDATA"])))
+    if auth_info["bili_jct"]:
+        cookies.set("bili_jct", auth_info["bili_jct"])
+    return cookies
+
+
 class FetcherContext:
     proxy: str | None
     trust_env: bool
@@ -103,6 +115,7 @@ class FetcherContext:
     fetch_semaphore: asyncio.Semaphore | None
     download_semaphore: asyncio.Semaphore | None
     user_info_cache: UserInfo | None
+    wbi_img_cache: Mapping[str, str] | None
     touched_urls: WeakKeyDictionary[AsyncClient, set[str]]
 
     def __init__(
@@ -110,17 +123,18 @@ class FetcherContext:
         *,
         proxy: str | None = DEFAULT_PROXY,
         trust_env: bool = DEFAULT_TRUST_ENV,
-        headers: dict[str, str] = DEFAULT_HEADERS,
-        cookies: httpx.Cookies = DEFAULT_COOKIES,
+        headers: dict[str, str] | None = None,
+        cookies: httpx.Cookies | None = None,
     ):
         self.proxy = proxy
         self.trust_env = trust_env
-        self.headers = headers
-        self.cookies = cookies
+        self.headers = dict(DEFAULT_HEADERS if headers is None else headers)
+        self.cookies = httpx.Cookies(DEFAULT_COOKIES if cookies is None else cookies)
         self.fetch_workers = DEFAULT_FETCH_WORKERS
         self.fetch_semaphore = None
         self.download_semaphore = None
         self.user_info_cache = None
+        self.wbi_img_cache = None
         self.touched_urls = WeakKeyDictionary()
 
     def set_fetch_workers(self, fetch_workers: int):
@@ -135,12 +149,8 @@ class FetcherContext:
 
     def set_auth_info(self, auth_info: AuthInfo):
         self.user_info_cache = None
-        self.cookies = httpx.Cookies()
-        # 先解码后编码是防止获取到的 SESSDATA 是已经解码后的（包含「,」）
-        # 而番剧无法使用解码后的 SESSDATA
-        self.cookies.set("SESSDATA", quote(unquote(auth_info["SESSDATA"])))
-        if auth_info["bili_jct"]:
-            self.cookies.set("bili_jct", auth_info["bili_jct"])
+        self.wbi_img_cache = None
+        self.cookies = cookies_from_auth(auth_info)
 
     def set_proxy(self, proxy: str):
         self.proxy, self.trust_env = resolve_proxy(proxy)
@@ -160,6 +170,36 @@ class FetcherContext:
             return
         async with self.download_semaphore:
             yield
+
+
+class ExecutionScope(FetcherContext):
+    """Request-scoped network resources used by one core execution."""
+
+    client: AsyncClient
+    download_workers: int
+
+    def __init__(
+        self,
+        client: AsyncClient,
+        *,
+        proxy: str | None = DEFAULT_PROXY,
+        trust_env: bool = DEFAULT_TRUST_ENV,
+        headers: dict[str, str] | None = None,
+        cookies: httpx.Cookies | None = None,
+        fetch_workers: int = DEFAULT_FETCH_WORKERS,
+        download_workers: int = DEFAULT_FETCH_WORKERS,
+    ):
+        super().__init__(
+            proxy=proxy,
+            trust_env=trust_env,
+            headers=headers,
+            cookies=cookies,
+        )
+        self.client = client
+        self.download_workers = download_workers
+        self.set_fetch_workers(fetch_workers)
+        self.set_fetch_semaphore(fetch_workers)
+        self.set_download_semaphore(download_workers)
 
 
 class Fetcher:

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import random
-from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import quote, unquote, urlparse
-from weakref import WeakKeyDictionary
 
 import h2.exceptions
 import httpx
@@ -21,7 +19,7 @@ if TYPE_CHECKING:
     from httpx import AsyncClient
 
     from yutto.auth import AuthInfo
-    from yutto.types import UserInfo
+    from yutto.core.execution import ExecutionScope
     from yutto.utils.file_buffer import AsyncFileBuffer
 
 RetT = TypeVar("RetT")
@@ -106,117 +104,20 @@ def cookies_from_auth(auth_info: AuthInfo | None) -> httpx.Cookies:
     return cookies
 
 
-class FetcherContext:
-    proxy: str | None
-    trust_env: bool
-    headers: dict[str, str]
-    cookies: httpx.Cookies
-    fetch_workers: int
-    fetch_semaphore: asyncio.Semaphore | None
-    download_semaphore: asyncio.Semaphore | None
-    user_info_cache: UserInfo | None
-    wbi_img_cache: Mapping[str, str] | None
-    touched_urls: WeakKeyDictionary[AsyncClient, set[str]]
-
-    def __init__(
-        self,
-        *,
-        proxy: str | None = DEFAULT_PROXY,
-        trust_env: bool = DEFAULT_TRUST_ENV,
-        headers: dict[str, str] | None = None,
-        cookies: httpx.Cookies | None = None,
-    ):
-        self.proxy = proxy
-        self.trust_env = trust_env
-        self.headers = dict(DEFAULT_HEADERS if headers is None else headers)
-        self.cookies = httpx.Cookies(DEFAULT_COOKIES if cookies is None else cookies)
-        self.fetch_workers = DEFAULT_FETCH_WORKERS
-        self.fetch_semaphore = None
-        self.download_semaphore = None
-        self.user_info_cache = None
-        self.wbi_img_cache = None
-        self.touched_urls = WeakKeyDictionary()
-
-    def set_fetch_workers(self, fetch_workers: int):
-        # 仅记录并发数，semaphore 需要在事件循环内创建（见 DownloadManager.execute）
-        self.fetch_workers = fetch_workers
-
-    def set_fetch_semaphore(self, fetch_workers: int):
-        self.fetch_semaphore = asyncio.Semaphore(fetch_workers)
-
-    def set_download_semaphore(self, download_workers: int):
-        self.download_semaphore = asyncio.Semaphore(download_workers)
-
-    def set_auth_info(self, auth_info: AuthInfo):
-        self.user_info_cache = None
-        self.wbi_img_cache = None
-        self.cookies = cookies_from_auth(auth_info)
-
-    def set_proxy(self, proxy: str):
-        self.proxy, self.trust_env = resolve_proxy(proxy)
-
-    @asynccontextmanager
-    async def fetch_guard(self):
-        if self.fetch_semaphore is None:
-            yield
-            return
-        async with self.fetch_semaphore:
-            yield
-
-    @asynccontextmanager
-    async def download_guard(self):
-        if self.download_semaphore is None:
-            yield
-            return
-        async with self.download_semaphore:
-            yield
-
-
-class ExecutionScope(FetcherContext):
-    """Request-scoped network resources used by one core execution."""
-
-    client: AsyncClient
-    download_workers: int
-
-    def __init__(
-        self,
-        client: AsyncClient,
-        *,
-        proxy: str | None = DEFAULT_PROXY,
-        trust_env: bool = DEFAULT_TRUST_ENV,
-        headers: dict[str, str] | None = None,
-        cookies: httpx.Cookies | None = None,
-        fetch_workers: int = DEFAULT_FETCH_WORKERS,
-        download_workers: int = DEFAULT_FETCH_WORKERS,
-    ):
-        super().__init__(
-            proxy=proxy,
-            trust_env=trust_env,
-            headers=headers,
-            cookies=cookies,
-        )
-        self.client = client
-        self.download_workers = download_workers
-        self.set_fetch_workers(fetch_workers)
-        self.set_fetch_semaphore(fetch_workers)
-        self.set_download_semaphore(download_workers)
-
-
 class Fetcher:
     @staticmethod
     @MaxRetry(2)
     async def fetch_text(
-        ctx: FetcherContext,
-        client: AsyncClient,
+        scope: ExecutionScope,
         url: str,
         *,
         params: Mapping[str, Any] | None = None,
         encoding: str | None = None,  # TODO(SigureMo): Support this
     ) -> str | None:
-        async with ctx.fetch_guard():
+        async with scope.fetch_guard():
             Logger.debug(f"Fetch text: {url}")
             Logger.status.next_tick()
-            resp = await client.get(url, params=params)
+            resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 return None
             return resp.text
@@ -224,16 +125,15 @@ class Fetcher:
     @staticmethod
     @MaxRetry(2)
     async def fetch_bin(
-        ctx: FetcherContext,
-        client: AsyncClient,
+        scope: ExecutionScope,
         url: str,
         *,
         params: Mapping[str, Any] | None = None,
     ) -> bytes | None:
-        async with ctx.fetch_guard():
+        async with scope.fetch_guard():
             Logger.debug(f"Fetch bin: {url}")
             Logger.status.next_tick()
-            resp = await client.get(url, params=params)
+            resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 return None
             return resp.read()
@@ -241,28 +141,27 @@ class Fetcher:
     @staticmethod
     @MaxRetry(2)
     async def fetch_json(
-        ctx: FetcherContext,
-        client: AsyncClient,
+        scope: ExecutionScope,
         url: str,
         *,
         params: Mapping[str, Any] | None = None,
     ) -> Any:
-        async with ctx.fetch_guard():
+        async with scope.fetch_guard():
             Logger.debug(f"Fetch json: {url}")
             Logger.status.next_tick()
-            resp = await client.get(url, params=params)
+            resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 resp.raise_for_status()
             return resp.json()
 
     @staticmethod
     @MaxRetry(2)
-    async def get_redirected_url(ctx: FetcherContext, client: AsyncClient, url: str) -> str:
+    async def get_redirected_url(scope: ExecutionScope, url: str) -> str:
         # 关于为什么要前往重定向 url，是因为 B 站的 url 类型实在是太多了，比如有 b23.tv 的短链接
         # 为 SEO 的搜索引擎链接、甚至有的 av、BV 链接实际上是番剧页面，一一列举实在太麻烦，而且最后一种
         # 情况需要在 av、BV 解析一部分信息后才能知道是否是番剧页面，处理起来非常麻烦（bilili 就是这么做的）
-        async with ctx.fetch_guard():
-            resp = await client.get(url)
+        async with scope.fetch_guard():
+            resp = await scope.client.get(url)
             redirected_url = str(resp.url)
             if redirected_url == url:
                 Logger.debug(f"Get redircted url: {url}")
@@ -273,11 +172,11 @@ class Fetcher:
 
     @staticmethod
     @MaxRetry(2)
-    async def get_size(ctx: FetcherContext, client: AsyncClient, url: str) -> int | None:
-        async with ctx.fetch_guard():
-            headers = client.headers.copy()
+    async def get_size(scope: ExecutionScope, url: str) -> int | None:
+        async with scope.fetch_guard():
+            headers = scope.client.headers.copy()
             headers["Range"] = "bytes=0-1"
-            resp = await client.get(
+            resp = await scope.client.get(
                 url,
                 headers=headers,
             )
@@ -290,31 +189,28 @@ class Fetcher:
 
     @staticmethod
     @MaxRetry(2)
-    async def touch_url(ctx: FetcherContext, client: AsyncClient, url: str) -> None:
-        # 对于同一 context 中的同一 client，同样的页面没必要重复 touch。
-        touched_urls = ctx.touched_urls.setdefault(client, set())
-        if url in touched_urls:
+    async def touch_url(scope: ExecutionScope, url: str) -> None:
+        if url in scope.touched_urls:
             Logger.debug(f"touch_url cache hit: {url}")
             return
-        async with ctx.fetch_guard():
+        async with scope.fetch_guard():
             Logger.debug(f"Touch url: {url}")
-            await client.get(url)
-            touched_urls.add(url)
+            await scope.client.get(url)
+            scope.touched_urls.add(url)
 
     @staticmethod
     async def download_file_with_offset(
-        ctx: FetcherContext,
-        client: AsyncClient,
+        scope: ExecutionScope,
         url: str,
         mirrors: list[str],
         file_buffer: AsyncFileBuffer,
         offset: int,
         size: int | None,
     ) -> None:
-        async with ctx.download_guard():
+        async with scope.download_guard():
             Logger.debug(f"Start download (offset {offset}, number of mirrors {len(mirrors)}) {url}")
             done = False
-            headers = client.headers.copy()
+            headers = scope.client.headers.copy()
             url_pool = [url] + mirrors
             block_offset = 0
             while not done:
@@ -323,7 +219,7 @@ class Fetcher:
                     headers["Range"] = "bytes={}-{}".format(
                         offset + block_offset, offset + size - 1 if size is not None else ""
                     )
-                    async with client.stream(
+                    async with scope.client.stream(
                         "GET",
                         url,
                         headers=headers,

--- a/src/yutto/validator.py
+++ b/src/yutto/validator.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-import asyncio
 import os
 import sys
 from typing import TYPE_CHECKING
 
 import biliass
 
-from yutto.api.user_info import validate_user_info
 from yutto.auth import format_auth_inline, resolve_auth
 from yutto.exceptions import ErrorCode, WrongArgumentError
 from yutto.input_parser import validate_episodes_selection
 from yutto.media.codec import audio_codec_priority_default, video_codec_priority_default
 from yutto.utils.console.colorful import set_no_color
-from yutto.utils.console.logger import Badge, Logger, set_logger_debug
+from yutto.utils.console.logger import Logger, set_logger_debug
+from yutto.utils.fetcher import resolve_proxy
 from yutto.utils.ffmpeg import FFmpeg
 
 if TYPE_CHECKING:
@@ -21,7 +20,6 @@ if TYPE_CHECKING:
 
     from yutto.auth import AuthInfo
     from yutto.media.codec import VideoCodec
-    from yutto.utils.fetcher import FetcherContext
 
 
 def hydrate_auth(args: argparse.Namespace) -> AuthInfo | None:
@@ -36,7 +34,7 @@ def hydrate_auth(args: argparse.Namespace) -> AuthInfo | None:
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 
 
-def initial_validation(ctx: FetcherContext, args: argparse.Namespace):
+def initial_validation(args: argparse.Namespace):
     """初始化检查，仅执行一次"""
 
     if not args.no_progress:
@@ -52,41 +50,6 @@ def initial_validation(ctx: FetcherContext, args: argparse.Namespace):
         set_logger_debug()
         biliass.enable_tracing()
 
-    # proxy 校验
-    try:
-        ctx.set_proxy(args.proxy)
-    except ValueError as e:
-        Logger.error(str(e))
-        sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
-
-    # 批量解析并发数设置
-    ctx.set_fetch_workers(args.fetch_workers)
-
-    # 大会员身份校验
-    auth = hydrate_auth(args)
-    if not auth:
-        Logger.info(
-            "未提供登录认证信息，无法下载高清视频、字幕等资源哦～请通过 `--auth` 参数提供认证信息，或者先使用 `yutto auth login` 登录存储认证信息后再下载～"
-        )
-    else:
-        ctx.set_auth_info(auth)
-        if asyncio.run(validate_user_info(ctx, {"vip_status": True, "is_login": True})):
-            Logger.custom("成功以大会员身份登录～", badge=Badge("大会员", fore="white", back="magenta", style=["bold"]))
-        else:
-            Logger.warning("以非大会员身份登录，注意无法下载会员专享剧集喔～")
-
-    # cover_only 时自动设置 save_cover
-    if (
-        args.require_cover
-        and not args.require_video
-        and not args.require_audio
-        and not args.require_danmaku
-        and not args.require_subtitle
-        and not args.require_metadata
-        and not args.require_chapter_info
-    ):
-        args.save_cover = True
-
 
 def validate_basic_arguments(args: argparse.Namespace):
     """检查 argparse 无法检查的选项，并设置某些全局的状态"""
@@ -96,6 +59,12 @@ def validate_basic_arguments(args: argparse.Namespace):
     # fetch_workers 检查
     if args.fetch_workers < 1:
         Logger.error(f"fetch_workers 参数值（{args.fetch_workers}）不满足要求哦（应为不小于 1 的整数）")
+        sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
+
+    try:
+        resolve_proxy(args.proxy)
+    except ValueError as e:
+        Logger.error(str(e))
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 
     download_vcodec_priority: list[VideoCodec] = video_codec_priority_default

--- a/src/yutto/validator.py
+++ b/src/yutto/validator.py
@@ -61,6 +61,11 @@ def validate_basic_arguments(args: argparse.Namespace):
         Logger.error(f"fetch_workers 参数值（{args.fetch_workers}）不满足要求哦（应为不小于 1 的整数）")
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 
+    # num_workers 检查
+    if args.num_workers < 1:
+        Logger.error(f"num_workers 参数值（{args.num_workers}）不满足要求哦（应为不小于 1 的整数）")
+        sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
+
     try:
         resolve_proxy(args.proxy)
     except ValueError as e:

--- a/tests/test_api/test_bangumi.py
+++ b/tests/test_api/test_bangumi.py
@@ -9,8 +9,9 @@ from yutto.api.bangumi import (
     get_season_id_by_episode_id,
     get_season_id_by_media_id,
 )
+from yutto.core.execution import ExecutionScope
 from yutto.types import BvId, CId, EpisodeId, MediaId, SeasonId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
 
@@ -19,9 +20,9 @@ from yutto.utils.functional import as_sync
 async def test_get_season_id_by_media_id():
     media_id = MediaId("28223066")
     season_id_excepted = SeasonId("28770")
-    ctx = FetcherContext()
     async with create_client() as client:
-        season_id = await get_season_id_by_media_id(ctx, client, media_id)
+        scope = ExecutionScope(client)
+        season_id = await get_season_id_by_media_id(scope, media_id)
         assert season_id == season_id_excepted
 
 
@@ -30,9 +31,9 @@ async def test_get_season_id_by_media_id():
 @pytest.mark.parametrize("episode_id", [EpisodeId("314477"), EpisodeId("300998")])
 async def test_get_season_id_by_episode_id(episode_id: EpisodeId):
     season_id_excepted = SeasonId("28770")
-    ctx = FetcherContext()
     async with create_client() as client:
-        season_id = await get_season_id_by_episode_id(ctx, client, episode_id)
+        scope = ExecutionScope(client)
+        season_id = await get_season_id_by_episode_id(scope, episode_id)
         assert season_id == season_id_excepted
 
 
@@ -40,9 +41,9 @@ async def test_get_season_id_by_episode_id(episode_id: EpisodeId):
 @as_sync
 async def test_get_bangumi_title():
     season_id = SeasonId("28770")
-    ctx = FetcherContext()
     async with create_client() as client:
-        title = (await get_bangumi_list(ctx, client, season_id))["title"]
+        scope = ExecutionScope(client)
+        title = (await get_bangumi_list(scope, season_id))["title"]
         assert title == "我的三体之章北海传"
 
 
@@ -50,9 +51,9 @@ async def test_get_bangumi_title():
 @as_sync
 async def test_get_bangumi_list():
     season_id = SeasonId("28770")
-    ctx = FetcherContext()
     async with create_client() as client:
-        bangumi_list = (await get_bangumi_list(ctx, client, season_id))["pages"]
+        scope = ExecutionScope(client)
+        bangumi_list = (await get_bangumi_list(scope, season_id))["pages"]
         assert bangumi_list[0]["id"] == 1
         assert bangumi_list[0]["name"] == "第1话"
         assert bangumi_list[0]["cid"] == CId("144541892")
@@ -72,9 +73,9 @@ async def test_get_bangumi_list():
 async def test_get_bangumi_playurl():
     avid = BvId("BV1q7411v7Vd")
     cid = CId("144541892")
-    ctx = FetcherContext()
     async with create_client() as client:
-        playlist = await get_bangumi_playurl(ctx, client, avid, cid)
+        scope = ExecutionScope(client)
+        playlist = await get_bangumi_playurl(scope, avid, cid)
         assert len(playlist[0]) > 0
         assert len(playlist[1]) > 0
 

--- a/tests/test_api/test_cheese.py
+++ b/tests/test_api/test_cheese.py
@@ -9,8 +9,9 @@ from yutto.api.cheese import (
     get_cheese_playurl,
     get_season_id_by_episode_id,
 )
+from yutto.core.execution import ExecutionScope
 from yutto.types import AId, CId, EpisodeId, SeasonId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
@@ -22,9 +23,9 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize("episode_id", [EpisodeId("6945"), EpisodeId("6902")])
 async def test_get_season_id_by_episode_id(episode_id: EpisodeId):
     season_id_excepted = SeasonId("298")
-    ctx = FetcherContext()
     async with create_client() as client:
-        season_id = await get_season_id_by_episode_id(ctx, client, episode_id)
+        scope = ExecutionScope(client)
+        season_id = await get_season_id_by_episode_id(scope, episode_id)
         assert season_id == season_id_excepted
 
 
@@ -32,9 +33,9 @@ async def test_get_season_id_by_episode_id(episode_id: EpisodeId):
 @as_sync
 async def test_get_cheese_title():
     season_id = SeasonId("298")
-    ctx = FetcherContext()
     async with create_client() as client:
-        cheese_list = await get_cheese_list(ctx, client, season_id)
+        scope = ExecutionScope(client)
+        cheese_list = await get_cheese_list(scope, season_id)
         title = cheese_list["title"]
         assert title == "林超：给年轻人的跨学科通识课"
 
@@ -43,9 +44,9 @@ async def test_get_cheese_title():
 @as_sync
 async def test_get_cheese_list():
     season_id = SeasonId("298")
-    ctx = FetcherContext()
     async with create_client() as client:
-        cheese_list = (await get_cheese_list(ctx, client, season_id))["pages"]
+        scope = ExecutionScope(client)
+        cheese_list = (await get_cheese_list(scope, season_id))["pages"]
         assert cheese_list[0]["id"] == 1
         assert cheese_list[0]["name"] == "【先导片】给年轻人的跨学科通识课"
         assert cheese_list[0]["cid"] == CId("344779477")
@@ -62,11 +63,9 @@ async def test_get_cheese_playurl():
     avid = AId("545852212")
     episode_id = EpisodeId("6902")
     cid = CId("344779477")
-    ctx = FetcherContext()
     async with create_client() as client:
-        playlist: tuple[list[VideoUrlMeta], list[AudioUrlMeta]] = await get_cheese_playurl(
-            ctx, client, avid, episode_id, cid
-        )
+        scope = ExecutionScope(client)
+        playlist: tuple[list[VideoUrlMeta], list[AudioUrlMeta]] = await get_cheese_playurl(scope, avid, episode_id, cid)
         assert len(playlist[0]) > 0
         assert len(playlist[1]) > 0
 

--- a/tests/test_api/test_collection.py
+++ b/tests/test_api/test_collection.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import pytest
 
 from yutto.api.collection import get_collection_details
+from yutto.core.execution import ExecutionScope
 from yutto.types import BvId, MId, SeriesId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
 
@@ -14,9 +15,9 @@ async def test_get_collection_details():
     # 测试页面：https://space.bilibili.com/6762654/lists?sid=39879&ctype=0
     series_id = SeriesId("39879")
     mid = MId("6762654")
-    ctx = FetcherContext()
     async with create_client() as client:
-        collection_details = await get_collection_details(ctx, client, series_id=series_id, mid=mid)
+        scope = ExecutionScope(client)
+        collection_details = await get_collection_details(scope, series_id=series_id, mid=mid)
         title = collection_details["title"]
         avids = [page["avid"] for page in collection_details["pages"]]
         assert title == "傻开心整活"

--- a/tests/test_api/test_danmaku.py
+++ b/tests/test_api/test_danmaku.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import pytest
 
 from yutto.api.danmaku import get_danmaku, get_protobuf_danmaku_segment, get_xml_danmaku
+from yutto.core.execution import ExecutionScope
 from yutto.types import AvId, CId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
 
@@ -12,9 +13,9 @@ from yutto.utils.functional import as_sync
 @as_sync
 async def test_xml_danmaku():
     cid = CId("144541892")
-    ctx = FetcherContext()
     async with create_client() as client:
-        danmaku = await get_xml_danmaku(ctx, client, cid=cid)
+        scope = ExecutionScope(client)
+        danmaku = await get_xml_danmaku(scope, cid=cid)
         assert len(danmaku) > 0
 
 
@@ -22,9 +23,9 @@ async def test_xml_danmaku():
 @as_sync
 async def test_protobuf_danmaku():
     cid = CId("144541892")
-    ctx = FetcherContext()
     async with create_client() as client:
-        danmaku = await get_protobuf_danmaku_segment(ctx, client, cid=cid, segment_id=1)
+        scope = ExecutionScope(client)
+        danmaku = await get_protobuf_danmaku_segment(scope, cid=cid, segment_id=1)
         assert len(danmaku) > 0
 
 
@@ -33,9 +34,9 @@ async def test_protobuf_danmaku():
 async def test_danmaku():
     cid = CId("144541892")
     avid = AvId("BV1q7411v7Vd")
-    ctx = FetcherContext()
     async with create_client() as client:
-        danmaku = await get_danmaku(ctx, client, cid=cid, avid=avid, save_type="ass")
+        scope = ExecutionScope(client)
+        danmaku = await get_danmaku(scope, cid=cid, avid=avid, save_type="ass")
         assert len(danmaku["data"]) > 0
         assert danmaku["source_type"] == "xml"
         assert danmaku["save_type"] == "ass"

--- a/tests/test_api/test_space.py
+++ b/tests/test_api/test_space.py
@@ -11,8 +11,9 @@ from yutto.api.space import (
     get_user_name,
     get_user_space_all_videos_avids,
 )
+from yutto.core.execution import ExecutionScope
 from yutto.types import AId, BvId, FId, MId, SeriesId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
 
@@ -21,9 +22,9 @@ from yutto.utils.functional import as_sync
 @as_sync
 async def test_get_user_space_all_videos_avids():
     mid = MId("100969474")
-    ctx = FetcherContext()
     async with create_client() as client:
-        all_avid = await get_user_space_all_videos_avids(ctx, client, mid=mid)
+        scope = ExecutionScope(client)
+        all_avid = await get_user_space_all_videos_avids(scope, mid=mid)
         assert len(all_avid) > 0
         assert AId("371660125") in all_avid or BvId("BV1vZ4y1M7mQ") in all_avid
 
@@ -33,9 +34,9 @@ async def test_get_user_space_all_videos_avids():
 @as_sync
 async def test_get_user_name():
     mid = MId("100969474")
-    ctx = FetcherContext()
     async with create_client() as client:
-        username = await get_user_name(ctx, client, mid=mid)
+        scope = ExecutionScope(client)
+        username = await get_user_name(scope, mid=mid)
         assert username == "时雨千陌"
 
 
@@ -43,9 +44,9 @@ async def test_get_user_name():
 @as_sync
 async def test_get_favourite_info():
     fid = FId("1306978874")
-    ctx = FetcherContext()
     async with create_client() as client:
-        fav_info = await get_favourite_info(ctx, client, fid=fid)
+        scope = ExecutionScope(client)
+        fav_info = await get_favourite_info(scope, fid=fid)
         assert fav_info["fid"] == fid
         assert fav_info["title"] == "Test"
 
@@ -54,9 +55,9 @@ async def test_get_favourite_info():
 @as_sync
 async def test_get_favourite_avids():
     fid = FId("1306978874")
-    ctx = FetcherContext()
     async with create_client() as client:
-        avids = await get_favourite_avids(ctx, client, fid=fid)
+        scope = ExecutionScope(client)
+        avids = await get_favourite_avids(scope, fid=fid)
         assert AId("456782499") in avids or BvId("BV1o541187Wh") in avids
 
 
@@ -64,9 +65,9 @@ async def test_get_favourite_avids():
 @as_sync
 async def test_all_favourites():
     mid = MId("100969474")
-    ctx = FetcherContext()
     async with create_client() as client:
-        fav_list = await get_all_favourites(ctx, client, mid=mid)
+        scope = ExecutionScope(client)
+        fav_list = await get_all_favourites(scope, mid=mid)
         assert {"fid": FId("1306978874"), "title": "Test"} in fav_list
 
 
@@ -75,9 +76,9 @@ async def test_all_favourites():
 async def test_get_medialist_avids():
     series_id = SeriesId("1947439")
     mid = MId("100969474")
-    ctx = FetcherContext()
     async with create_client() as client:
-        avids = await get_medialist_avids(ctx, client, series_id=series_id, mid=mid)
+        scope = ExecutionScope(client)
+        avids = await get_medialist_avids(scope, series_id=series_id, mid=mid)
         assert avids == [BvId("BV1Y441167U2"), BvId("BV1vZ4y1M7mQ")]
 
 
@@ -85,7 +86,7 @@ async def test_get_medialist_avids():
 @as_sync
 async def test_get_medialist_title():
     series_id = SeriesId("1947439")
-    ctx = FetcherContext()
     async with create_client() as client:
-        title = await get_medialist_title(ctx, client, series_id=series_id)
+        scope = ExecutionScope(client)
+        title = await get_medialist_title(scope, series_id=series_id)
         assert title == "一个小视频列表～"

--- a/tests/test_api/test_ugc_video.py
+++ b/tests/test_api/test_ugc_video.py
@@ -8,8 +8,9 @@ from yutto.api.ugc_video import (
     get_ugc_video_playurl,
     get_ugc_video_subtitles,
 )
+from yutto.core.execution import ExecutionScope
 from yutto.types import AId, BvId, CId, EpisodeId
-from yutto.utils.fetcher import FetcherContext, create_client
+from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
 
@@ -21,9 +22,9 @@ async def test_get_ugc_video_info():
     aid = AId("84271171")
     avid = bvid
     episode_id = EpisodeId("300998")
-    ctx = FetcherContext()
     async with create_client() as client:
-        video_info = await get_ugc_video_info(ctx, client, avid=avid)
+        scope = ExecutionScope(client)
+        video_info = await get_ugc_video_info(scope, avid=avid)
         assert video_info["avid"] == aid or video_info["avid"] == bvid
         assert video_info["aid"] == aid
         assert video_info["bvid"] == bvid
@@ -37,9 +38,9 @@ async def test_get_ugc_video_info():
 @as_sync
 async def test_get_ugc_video_title():
     avid = BvId("BV1vZ4y1M7mQ")
-    ctx = FetcherContext()
     async with create_client() as client:
-        title = (await get_ugc_video_list(ctx, client, avid))["title"]
+        scope = ExecutionScope(client)
+        title = (await get_ugc_video_list(scope, avid))["title"]
         assert title == "用 bilili 下载 B 站视频"
 
 
@@ -47,9 +48,9 @@ async def test_get_ugc_video_title():
 @as_sync
 async def test_get_ugc_video_list():
     avid = BvId("BV1vZ4y1M7mQ")
-    ctx = FetcherContext()
     async with create_client() as client:
-        ugc_video_list = (await get_ugc_video_list(ctx, client, avid))["pages"]
+        scope = ExecutionScope(client)
+        ugc_video_list = (await get_ugc_video_list(scope, avid))["pages"]
         assert ugc_video_list[0]["id"] == 1
         assert ugc_video_list[0]["name"] == "bilili 特性以及使用方法简单介绍"
         assert ugc_video_list[0]["cid"] == CId("222190584")
@@ -71,9 +72,9 @@ async def test_get_ugc_video_list():
 async def test_get_ugc_video_playurl():
     avid = BvId("BV1vZ4y1M7mQ")
     cid = CId("222190584")
-    ctx = FetcherContext()
     async with create_client() as client:
-        playlist = await get_ugc_video_playurl(ctx, client, avid, cid)
+        scope = ExecutionScope(client)
+        playlist = await get_ugc_video_playurl(scope, avid, cid)
         assert len(playlist[0]) > 0
         assert len(playlist[1]) > 0
 
@@ -86,8 +87,8 @@ async def test_get_ugc_video_playurl():
 async def test_get_ugc_video_subtitles():
     avid = BvId("BV1Ra411A7kN")
     cid = CId("253246252")
-    ctx = FetcherContext()
     async with create_client() as client:
-        subtitles = await get_ugc_video_subtitles(ctx, client, avid=avid, cid=cid)
+        scope = ExecutionScope(client)
+        subtitles = await get_ugc_video_subtitles(scope, avid=avid, cid=cid)
         assert len(subtitles) > 0
         assert len(subtitles[0]["lines"]) > 0

--- a/tests/test_api/test_user_info.py
+++ b/tests/test_api/test_user_info.py
@@ -5,8 +5,9 @@ from typing import Any, cast
 import pytest
 from returns.result import Success
 
-from yutto.api.user_info import get_user_info, parse_user_info, user_info_matches
-from yutto.utils.fetcher import Fetcher, FetcherContext, create_client
+from yutto.api.user_info import get_user_info, get_wbi_img, parse_user_info, user_info_matches, validate_user_info
+from yutto.types import UserInfo
+from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext, create_client
 from yutto.utils.functional import as_sync
 
 
@@ -54,4 +55,73 @@ async def test_user_info_cache_is_scoped_to_fetcher_context(monkeypatch: pytest.
     assert await get_user_info(first_context, client) == {"vip_status": True, "is_login": True}
     assert await get_user_info(first_context, client) == {"vip_status": True, "is_login": True}
     assert await get_user_info(second_context, client) == {"vip_status": False, "is_login": False}
+    assert calls == 2
+
+
+@pytest.mark.processor
+@as_sync
+async def test_validate_user_info_reuses_execution_scope_client_and_cache(monkeypatch: pytest.MonkeyPatch):
+    client = cast("Any", object())
+    scope = ExecutionScope(client)
+    clients: list[Any] = []
+
+    async def fake_fetch_json(ctx, active_client, url):
+        clients.append(active_client)
+        return Success({"data": {"vipStatus": 1, "isLogin": True}})
+
+    monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
+
+    requirements = UserInfo(vip_status=True, is_login=True)
+    assert await validate_user_info(scope, requirements)
+    assert await validate_user_info(scope, requirements)
+    assert clients == [client]
+
+
+@pytest.mark.processor
+@as_sync
+async def test_wbi_cache_is_scoped_to_context(monkeypatch: pytest.MonkeyPatch):
+    responses = iter(
+        [
+            {
+                "data": {
+                    "wbi_img": {
+                        "img_url": "https://example.com/first-img.png",
+                        "sub_url": "https://example.com/first-sub.png",
+                    }
+                }
+            },
+            {
+                "data": {
+                    "wbi_img": {
+                        "img_url": "https://example.com/second-img.png",
+                        "sub_url": "https://example.com/second-sub.png",
+                    }
+                }
+            },
+        ]
+    )
+    calls = 0
+
+    async def fake_fetch_json(ctx, client, url):
+        nonlocal calls
+        calls += 1
+        return Success(next(responses))
+
+    monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
+    first_context = FetcherContext()
+    second_context = FetcherContext()
+    client = cast("Any", object())
+
+    assert await get_wbi_img(first_context, client) == {
+        "img_key": "first-img",
+        "sub_key": "first-sub",
+    }
+    assert await get_wbi_img(first_context, client) == {
+        "img_key": "first-img",
+        "sub_key": "first-sub",
+    }
+    assert await get_wbi_img(second_context, client) == {
+        "img_key": "second-img",
+        "sub_key": "second-sub",
+    }
     assert calls == 2

--- a/tests/test_api/test_user_info.py
+++ b/tests/test_api/test_user_info.py
@@ -6,8 +6,9 @@ import pytest
 from returns.result import Success
 
 from yutto.api.user_info import get_user_info, get_wbi_img, parse_user_info, user_info_matches, validate_user_info
+from yutto.core.execution import ExecutionScope
 from yutto.types import UserInfo
-from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext, create_client
+from yutto.utils.fetcher import Fetcher, create_client
 from yutto.utils.functional import as_sync
 
 
@@ -24,16 +25,16 @@ def test_user_info_matches():
 @pytest.mark.api
 @as_sync
 async def test_get_user_info():
-    ctx = FetcherContext()
     async with create_client() as client:
-        user_info = await get_user_info(ctx, client)
+        scope = ExecutionScope(client)
+        user_info = await get_user_info(scope)
         assert not user_info["vip_status"]
         assert not user_info["is_login"]
 
 
 @pytest.mark.processor
 @as_sync
-async def test_user_info_cache_is_scoped_to_fetcher_context(monkeypatch: pytest.MonkeyPatch):
+async def test_user_info_cache_is_scoped_to_execution_scope(monkeypatch: pytest.MonkeyPatch):
     responses = iter(
         [
             {"data": {"vipStatus": 1, "isLogin": True}},
@@ -42,19 +43,18 @@ async def test_user_info_cache_is_scoped_to_fetcher_context(monkeypatch: pytest.
     )
     calls = 0
 
-    async def fake_fetch_json(ctx, client, url):
+    async def fake_fetch_json(scope, url):
         nonlocal calls
         calls += 1
         return Success(next(responses))
 
     monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
-    first_context = FetcherContext()
-    second_context = FetcherContext()
-    client = cast("Any", object())
+    first_scope = ExecutionScope(cast("Any", object()))
+    second_scope = ExecutionScope(cast("Any", object()))
 
-    assert await get_user_info(first_context, client) == {"vip_status": True, "is_login": True}
-    assert await get_user_info(first_context, client) == {"vip_status": True, "is_login": True}
-    assert await get_user_info(second_context, client) == {"vip_status": False, "is_login": False}
+    assert await get_user_info(first_scope) == {"vip_status": True, "is_login": True}
+    assert await get_user_info(first_scope) == {"vip_status": True, "is_login": True}
+    assert await get_user_info(second_scope) == {"vip_status": False, "is_login": False}
     assert calls == 2
 
 
@@ -65,8 +65,8 @@ async def test_validate_user_info_reuses_execution_scope_client_and_cache(monkey
     scope = ExecutionScope(client)
     clients: list[Any] = []
 
-    async def fake_fetch_json(ctx, active_client, url):
-        clients.append(active_client)
+    async def fake_fetch_json(active_scope, url):
+        clients.append(active_scope.client)
         return Success({"data": {"vipStatus": 1, "isLogin": True}})
 
     monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
@@ -79,7 +79,7 @@ async def test_validate_user_info_reuses_execution_scope_client_and_cache(monkey
 
 @pytest.mark.processor
 @as_sync
-async def test_wbi_cache_is_scoped_to_context(monkeypatch: pytest.MonkeyPatch):
+async def test_wbi_cache_is_scoped_to_execution_scope(monkeypatch: pytest.MonkeyPatch):
     responses = iter(
         [
             {
@@ -102,25 +102,24 @@ async def test_wbi_cache_is_scoped_to_context(monkeypatch: pytest.MonkeyPatch):
     )
     calls = 0
 
-    async def fake_fetch_json(ctx, client, url):
+    async def fake_fetch_json(scope, url):
         nonlocal calls
         calls += 1
         return Success(next(responses))
 
     monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
-    first_context = FetcherContext()
-    second_context = FetcherContext()
-    client = cast("Any", object())
+    first_scope = ExecutionScope(cast("Any", object()))
+    second_scope = ExecutionScope(cast("Any", object()))
 
-    assert await get_wbi_img(first_context, client) == {
+    assert await get_wbi_img(first_scope) == {
         "img_key": "first-img",
         "sub_key": "first-sub",
     }
-    assert await get_wbi_img(first_context, client) == {
+    assert await get_wbi_img(first_scope) == {
         "img_key": "first-img",
         "sub_key": "first-sub",
     }
-    assert await get_wbi_img(second_context, client) == {
+    assert await get_wbi_img(second_scope) == {
         "img_key": "second-img",
         "sub_key": "second-sub",
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import yutto.validator as validator_module
 from yutto.cli.cli import (
     add_auth_logout_arguments,
     add_auth_status_arguments,
@@ -14,6 +15,7 @@ from yutto.cli.cli import (
     handle_default_subcommand,
 )
 from yutto.cli.settings import YuttoSettings
+from yutto.exceptions import ErrorCode
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -62,6 +64,19 @@ def test_download_parser_rejects_auth_config(tmp_path: Path):
         make_download_parser().parse_args(["https://example.com", "--auth-config", str(auth_file)])
 
     assert exc_info.value.code == 2
+
+
+def test_download_validation_rejects_non_positive_num_workers(monkeypatch: pytest.MonkeyPatch):
+    args = make_download_parser().parse_args(["https://example.com", "--num-workers", "0"])
+    errors: list[str] = []
+    monkeypatch.setattr(validator_module, "FFmpeg", object)
+    monkeypatch.setattr(validator_module.Logger, "error", errors.append)
+
+    with pytest.raises(SystemExit) as exc_info:
+        validator_module.validate_basic_arguments(args)
+
+    assert exc_info.value.code == ErrorCode.WRONG_ARGUMENT_ERROR.value
+    assert errors == ["num_workers 参数值（0）不满足要求哦（应为不小于 1 的整数）"]
 
 
 def test_login_parser_accepts_auth_file(tmp_path: Path):

--- a/tests/test_core/test_application.py
+++ b/tests/test_core/test_application.py
@@ -6,10 +6,10 @@ import pytest
 
 from yutto.core.application import YuttoApplication
 from yutto.core.events import DownloadBatchStarted, DownloadRequestQueued, DownloadStage, DownloadStageChanged
+from yutto.core.execution import ExecutionScopeFactory, RequestExecutionScopeFactory
 from yutto.core.operation import emit_download_event
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ResolveResult
-from yutto.utils.fetcher import FetcherContext
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
@@ -35,8 +35,12 @@ class RecordingWorkflow:
         self.trace = trace
         self.result = DownloadResult()
 
-    async def execute(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> DownloadResult:
-        self.trace.append(("execute", (ctx, tuple(requests))))
+    async def execute(
+        self,
+        scope_factory: ExecutionScopeFactory,
+        requests: Sequence[DownloadRequest],
+    ) -> DownloadResult:
+        self.trace.append(("execute", (scope_factory, tuple(requests))))
         emit_download_event(DownloadStageChanged(name=DownloadStage.RESOLVING))
         return self.result
 
@@ -46,8 +50,12 @@ class RecordingResolveWorkflow:
         self.trace = trace
         self.result = ResolveResult()
 
-    async def execute_resolve(self, ctx: FetcherContext, requests: Sequence[DownloadRequest]) -> ResolveResult:
-        self.trace.append(("execute_resolve", (ctx, tuple(requests))))
+    async def execute_resolve(
+        self,
+        scope_factory: ExecutionScopeFactory,
+        requests: Sequence[DownloadRequest],
+    ) -> ResolveResult:
+        self.trace.append(("execute_resolve", (scope_factory, tuple(requests))))
         emit_download_event(DownloadStageChanged(name=DownloadStage.RESOLVING))
         return self.result
 
@@ -58,20 +66,20 @@ def make_request(url: str) -> DownloadRequest:
 
 @as_sync
 async def test_application_preserves_queue_order_and_emits_batch_events():
-    ctx = FetcherContext()
+    scope_factory = RequestExecutionScopeFactory()
     trace: list[tuple[str, object]] = []
     workflow = RecordingWorkflow(trace)
     sink = RecordingEventSink(trace)
     requests = [make_request("BV1first"), make_request("BV1second")]
 
-    application = YuttoApplication(ctx, workflow=workflow, event_sink=sink)
+    application = YuttoApplication(scope_factory, workflow=workflow, event_sink=sink)
     result = await application.download_all(requests)
 
     assert trace == [
         ("event", DownloadBatchStarted(total=2)),
         ("event", DownloadRequestQueued(url="BV1first", index=1, total=2)),
         ("event", DownloadRequestQueued(url="BV1second", index=2, total=2)),
-        ("execute", (ctx, tuple(requests))),
+        ("execute", (scope_factory, tuple(requests))),
         ("event", DownloadStageChanged(name=DownloadStage.RESOLVING)),
     ]
     assert sink.events == [
@@ -88,10 +96,10 @@ async def test_single_download_does_not_emit_batch_presentation_events():
     trace: list[tuple[str, object]] = []
     workflow = RecordingWorkflow(trace)
     sink = RecordingEventSink(trace)
-    ctx = FetcherContext()
+    scope_factory = RequestExecutionScopeFactory()
     request = make_request("BV1single")
     application = YuttoApplication(
-        ctx,
+        scope_factory,
         workflow=workflow,
         event_sink=sink,
     )
@@ -100,7 +108,7 @@ async def test_single_download_does_not_emit_batch_presentation_events():
 
     assert sink.events == [DownloadStageChanged(name=DownloadStage.RESOLVING)]
     assert trace == [
-        ("execute", (ctx, (request,))),
+        ("execute", (scope_factory, (request,))),
         ("event", DownloadStageChanged(name=DownloadStage.RESOLVING)),
     ]
     assert result is workflow.result
@@ -108,26 +116,31 @@ async def test_single_download_does_not_emit_batch_presentation_events():
 
 @as_sync
 async def test_application_resolve_uses_resolve_workflow_and_event_sink():
-    ctx = FetcherContext()
+    scope_factory = RequestExecutionScopeFactory()
     trace: list[tuple[str, object]] = []
     workflow = RecordingWorkflow(trace)
     resolve_workflow = RecordingResolveWorkflow(trace)
     sink = RecordingEventSink(trace)
     request = make_request("BV1resolve")
-    application = YuttoApplication(ctx, workflow=workflow, event_sink=sink, resolve_workflow=resolve_workflow)
+    application = YuttoApplication(
+        scope_factory,
+        workflow=workflow,
+        event_sink=sink,
+        resolve_workflow=resolve_workflow,
+    )
 
     result = await application.resolve(request)
 
     assert result is resolve_workflow.result
     assert trace == [
-        ("execute_resolve", (ctx, (request,))),
+        ("execute_resolve", (scope_factory, (request,))),
         ("event", DownloadStageChanged(name=DownloadStage.RESOLVING)),
     ]
 
 
 @as_sync
 async def test_application_resolve_requires_resolve_workflow():
-    application = YuttoApplication(FetcherContext(), workflow=RecordingWorkflow([]))
+    application = YuttoApplication(RequestExecutionScopeFactory(), workflow=RecordingWorkflow([]))
 
     with pytest.raises(RuntimeError, match="resolve workflow"):
         await application.resolve(make_request("BV1resolve"))

--- a/tests/test_core/test_execution.py
+++ b/tests/test_core/test_execution.py
@@ -17,6 +17,26 @@ def make_request() -> DownloadRequest:
     return DownloadRequest.model_validate({"source": {"url": "BV1scope"}})
 
 
+@pytest.mark.parametrize(
+    ("fetch_workers", "download_workers", "field"),
+    [
+        (0, 8, "fetch_workers"),
+        (8, 0, "download_workers"),
+    ],
+)
+def test_execution_scope_rejects_non_positive_workers(
+    fetch_workers: int,
+    download_workers: int,
+    field: str,
+):
+    with pytest.raises(ValueError, match=rf"{field} must be at least 1"):
+        ExecutionScope(
+            cast("Any", object()),
+            fetch_workers=fetch_workers,
+            download_workers=download_workers,
+        )
+
+
 @as_sync
 async def test_execution_scope_download_guard_limits_concurrency():
     scope = ExecutionScope(cast("Any", object()), download_workers=2)

--- a/tests/test_core/test_execution.py
+++ b/tests/test_core/test_execution.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
+from yutto.core.request import DownloadRequest
+from yutto.types import UserInfo
+from yutto.utils.functional import as_sync
+
+pytestmark = pytest.mark.processor
+
+
+def make_request() -> DownloadRequest:
+    return DownloadRequest.model_validate({"source": {"url": "BV1scope"}})
+
+
+@as_sync
+async def test_execution_scope_download_guard_limits_concurrency():
+    scope = ExecutionScope(cast("Any", object()), download_workers=2)
+    running = 0
+    max_running = 0
+
+    async def work() -> None:
+        nonlocal running, max_running
+        async with scope.download_guard():
+            running += 1
+            max_running = max(max_running, running)
+            await asyncio.sleep(0)
+            running -= 1
+
+    await asyncio.gather(*(work() for _ in range(8)))
+
+    assert max_running == 2
+
+
+@as_sync
+async def test_scope_factory_opens_fresh_clients_limiters_and_caches():
+    factory = RequestExecutionScopeFactory()
+    request = make_request()
+
+    async with factory.open(request) as first_scope:
+        first_client = first_scope.client
+        first_fetch_limiter = first_scope.fetch_limiter
+        first_download_limiter = first_scope.download_limiter
+        first_scope.user_info_cache = UserInfo(vip_status=True, is_login=True)
+        first_scope.wbi_img_cache = {"img_key": "img", "sub_key": "sub"}
+        first_scope.touched_urls.add("https://example.com")
+
+    assert first_client.is_closed
+
+    async with factory.open(request) as second_scope:
+        assert second_scope.client is not first_client
+        assert second_scope.fetch_limiter is not first_fetch_limiter
+        assert second_scope.download_limiter is not first_download_limiter
+        assert second_scope.user_info_cache is None
+        assert second_scope.wbi_img_cache is None
+        assert second_scope.touched_urls == set()
+
+
+@as_sync
+async def test_scope_factory_closes_client_when_on_open_fails():
+    clients: list[Any] = []
+
+    async def fail_on_open(scope: ExecutionScope, request: DownloadRequest) -> None:
+        clients.append(scope.client)
+        raise RuntimeError("on_open failed")
+
+    factory = RequestExecutionScopeFactory(on_open=fail_on_open)
+
+    with pytest.raises(RuntimeError, match="on_open failed"):
+        async with factory.open(make_request()):
+            pytest.fail("scope should not be yielded")
+
+    assert len(clients) == 1
+    assert clients[0].is_closed

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -238,22 +238,27 @@ def test_adapter_rejects_unvalidated_codec_pair():
 
 
 def test_cover_only_request_keeps_existing_save_cover_semantics():
-    request = DownloadRequest.model_validate(
-        {
-            "source": {"url": "BV1xx"},
-            "resources": {
-                "video": False,
-                "audio": False,
-                "danmaku": False,
-                "subtitle": False,
-                "metadata": False,
-                "cover": True,
-                "chapter_info": False,
-            },
-        }
+    request = download_request_from_namespace(
+        parse_download_args(
+            [
+                "BV1xx",
+                "--cover-only",
+            ]
+        )
     )
 
+    assert request.resources.cover is True
     assert request.resources.save_cover is True
+    assert not any(
+        (
+            request.resources.video,
+            request.resources.audio,
+            request.resources.danmaku,
+            request.resources.subtitle,
+            request.resources.metadata,
+            request.resources.chapter_info,
+        )
+    )
 
 
 def test_core_rejects_save_cover_when_cover_is_disabled():

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -6,7 +6,8 @@ from typing import Any
 
 import pytest
 
-from yutto.cli.cli import add_download_arguments
+import yutto.__main__ as main_module
+from yutto.cli.cli import add_download_arguments, cli, handle_default_subcommand
 from yutto.cli.request_adapter import (
     download_request_from_mapping,
     download_request_from_namespace,
@@ -315,6 +316,55 @@ def test_rpc_mapping_inherits_local_settings_without_credentials():
     assert request.output.directory == Path()
     assert "inline-secret" not in request.model_dump_json()
     assert "legacy-secret" not in request.model_dump_json()
+
+
+def test_task_list_preserves_per_item_network_and_auth_overrides(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    task_list = tmp_path / "downloads.txt"
+    task_list.write_text(
+        "\n".join(
+            [
+                "BV1first --proxy no --fetch-workers 2 --num-workers 3 --auth-profile first",
+                "BV1second --no-inherit --proxy auto --fetch-workers 5 --num-workers 7 --auth-profile second",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    parser = cli()
+    args = parser.parse_args(
+        handle_default_subcommand(
+            [
+                str(task_list),
+                "--proxy",
+                "https://127.0.0.1:7890",
+                "--fetch-workers",
+                "11",
+                "--num-workers",
+                "13",
+                "--auth-profile",
+                "outer",
+            ]
+        )
+    )
+    monkeypatch.setattr(main_module, "validate_basic_arguments", lambda args: None)
+
+    requests = [download_request_from_namespace(item) for item in main_module.flatten_args(args, parser)]
+
+    assert [
+        (
+            request.source.url,
+            request.network.proxy,
+            request.network.fetch_workers,
+            request.network.download_workers,
+            request.access.auth_profile,
+        )
+        for request in requests
+    ] == [
+        ("BV1first", "no", 2, 3, "first"),
+        ("BV1second", "auto", 5, 7, "second"),
+    ]
 
 
 def test_server_request_parser_validates_configured_defaults_eagerly():

--- a/tests/test_core/test_task_service.py
+++ b/tests/test_core/test_task_service.py
@@ -16,12 +16,12 @@ from yutto.core.events import (
     DownloadStage,
     DownloadStageChanged,
 )
+from yutto.core.execution import ExecutionScopeFactory, RequestExecutionScopeFactory
 from yutto.core.operation import emit_download_event
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ItemSkipReason
 from yutto.core.task_service import DownloadTaskService, _encode_runtime_event
 from yutto.runtime import TaskState
-from yutto.utils.fetcher import FetcherContext
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
@@ -40,37 +40,35 @@ def task_ids() -> Iterator[str]:
 class RecordingApplication:
     def __init__(
         self,
-        ctx: FetcherContext,
+        scope_factory: ExecutionScopeFactory,
         event_sink: DownloadEventSink,
-        calls: list[tuple[FetcherContext, str]],
+        calls: list[tuple[ExecutionScopeFactory, str]],
     ):
-        self.ctx = ctx
+        self.scope_factory = scope_factory
         self.event_sink = event_sink
         self.calls = calls
         self.result = DownloadResult()
 
     async def download(self, request: DownloadRequest) -> DownloadResult:
         self.event_sink.emit(DownloadStageChanged(name=DownloadStage.RESOLVING))
-        self.calls.append((self.ctx, request.source.url))
+        self.calls.append((self.scope_factory, request.source.url))
         return self.result
 
 
 @as_sync
 async def test_download_task_service_runs_requests_in_order_and_bridges_events():
     ids = task_ids()
-    contexts: list[FetcherContext] = []
-    calls: list[tuple[FetcherContext, str]] = []
+    scope_factory = RequestExecutionScopeFactory()
+    calls: list[tuple[ExecutionScopeFactory, str]] = []
 
-    def context_factory(request: DownloadRequest) -> FetcherContext:
-        ctx = FetcherContext()
-        contexts.append(ctx)
-        return ctx
-
-    def application_factory(ctx: FetcherContext, event_sink: DownloadEventSink) -> RecordingApplication:
-        return RecordingApplication(ctx, event_sink, calls)
+    def application_factory(
+        factory: ExecutionScopeFactory,
+        event_sink: DownloadEventSink,
+    ) -> RecordingApplication:
+        return RecordingApplication(factory, event_sink, calls)
 
     service = DownloadTaskService(
-        context_factory,
+        scope_factory,
         application_factory=application_factory,
         task_id_factory=lambda: next(ids),
     )
@@ -86,7 +84,7 @@ async def test_download_task_service_runs_requests_in_order_and_bridges_events()
         assert first_done.result == DownloadResult()
         assert second_done.result == DownloadResult()
         assert [url for _, url in calls] == ["BV1first", "BV1second"]
-        assert [ctx for ctx, _ in calls] == contexts
+        assert all(factory is scope_factory for factory, _ in calls)
         first_replay = service.replay(first.task_id)
         assert first_replay is not None
         assert [(event.kind, event.data) for event in first_replay.events if event.kind == "stage"] == [

--- a/tests/test_processor/test_batch_resolve.py
+++ b/tests/test_processor/test_batch_resolve.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from returns.result import Failure, Success
 
+from yutto.core.execution import ExecutionScope
 from yutto.exceptions import MaxRetryError, NotFoundError
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId
-from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
@@ -34,7 +35,7 @@ def make_fake_client() -> httpx.AsyncClient:
     return cast("httpx.AsyncClient", object())
 
 
-async def touch_url_ok(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> Result[None, MaxRetryError]:
+async def touch_url_ok(scope: ExecutionScope, url: str) -> Result[None, MaxRetryError]:
     return Success(None)
 
 
@@ -44,7 +45,7 @@ async def test_resolve_ugc_video_lists_preserves_order(monkeypatch: pytest.Monke
     avids: list[AvId] = [AId("1"), AId("2"), AId("3"), AId("4"), AId("5")]
     filtered_avid = avids[2]
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: AvId) -> UgcVideoList:
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
         # 让完成顺序与传入顺序相反，验证结果顺序不受完成顺序影响
         await asyncio.sleep(0.01 * (len(avids) - avids.index(avid)))
         if avid == filtered_avid:
@@ -55,9 +56,9 @@ async def test_resolve_ugc_video_lists_preserves_order(monkeypatch: pytest.Monke
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", touch_url_ok)
 
+    scope = ExecutionScope(make_fake_client())
     outcome = await resolve_ugc_video_lists(
-        FetcherContext(),
-        make_fake_client(),
+        scope,
         avids,
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
@@ -79,12 +80,12 @@ async def test_resolve_ugc_video_lists_isolates_failures(monkeypatch: pytest.Mon
     not_found_avid = avids[1]
     max_retry_url = avids[2].to_url()
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: AvId) -> UgcVideoList:
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
         if avid == not_found_avid:
             raise NotFoundError(f"啊叻？视频 {avid} 不见了诶")
         return make_ugc_video_list(avid)
 
-    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> Result[None, MaxRetryError]:
+    async def fake_touch_url(scope: ExecutionScope, url: str) -> Result[None, MaxRetryError]:
         # 走真实的 unwrap_fetch_result 抛出路径
         if url == max_retry_url:
             return Failure(MaxRetryError("超出最大重试次数！"))
@@ -93,9 +94,9 @@ async def test_resolve_ugc_video_lists_isolates_failures(monkeypatch: pytest.Mon
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
+    scope = ExecutionScope(make_fake_client())
     outcome = await resolve_ugc_video_lists(
-        FetcherContext(),
-        make_fake_client(),
+        scope,
         avids,
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )
@@ -114,25 +115,24 @@ async def test_resolve_ugc_video_lists_bounded_by_fetch_semaphore(monkeypatch: p
     running = 0
     max_running = 0
 
-    ctx = FetcherContext()
-    ctx.set_fetch_semaphore(fetch_workers=fetch_workers)
+    scope = ExecutionScope(make_fake_client(), fetch_workers=fetch_workers)
 
-    async def occupy_fetch_guard() -> None:
+    async def occupy_fetch_guard(active_scope: ExecutionScope) -> None:
         nonlocal running, max_running
-        # 模拟真实 Fetcher 请求经过 ctx.fetch_guard() 的行为
-        async with ctx.fetch_guard():
+        # 模拟真实 Fetcher 请求经过 scope.fetch_guard() 的行为
+        async with active_scope.fetch_guard():
             running += 1
             max_running = max(max_running, running)
             await asyncio.sleep(0.01)
             running -= 1
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: AvId) -> UgcVideoList:
-        await occupy_fetch_guard()
+    async def fake_get_ugc_video_list(active_scope: ExecutionScope, avid: AvId) -> UgcVideoList:
+        await occupy_fetch_guard(active_scope)
         return make_ugc_video_list(avid)
 
-    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str) -> Result[None, MaxRetryError]:
+    async def fake_touch_url(active_scope: ExecutionScope, url: str) -> Result[None, MaxRetryError]:
         # touch_url 与其他请求共用同一个 fetch semaphore，也计入并发统计
-        await occupy_fetch_guard()
+        await occupy_fetch_guard(active_scope)
         return Success(None)
 
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
@@ -140,8 +140,7 @@ async def test_resolve_ugc_video_lists_bounded_by_fetch_semaphore(monkeypatch: p
 
     avids: list[AvId] = [AId(str(i)) for i in range(10)]
     outcome = await resolve_ugc_video_lists(
-        ctx,
-        make_fake_client(),
+        scope,
         avids,
         publication_time_filter=PublicationTimeFilter.from_strings(),
     )

--- a/tests/test_processor/test_download_result.py
+++ b/tests/test_processor/test_download_result.py
@@ -40,7 +40,6 @@ def make_options(tmp_path: Path) -> DownloaderOptions:
         "output_format_audio_only": "infer",
         "overwrite": False,
         "block_size": 512 * 1024,
-        "num_workers": 1,
         "metadata_format": {},
         "banned_mirrors_pattern": None,
         "danmaku_options": cast("DanmakuOptions", {}),

--- a/tests/test_processor/test_download_result.py
+++ b/tests/test_processor/test_download_result.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from yutto.core.execution import ExecutionScope
 from yutto.core.result import Artifact, ArtifactKind, ItemResult, ItemSkipReason, ItemState
 from yutto.downloader.downloader import process_download
 from yutto.types import AId, CId
 from yutto.utils.danmaku import write_danmaku
-from yutto.utils.fetcher import FetcherContext
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
@@ -92,9 +92,9 @@ def make_resource_only_episode() -> EpisodeData:
 
 @as_sync
 async def test_resource_only_download_returns_final_artifacts_without_temporary_files(tmp_path: Path):
+    scope = ExecutionScope(cast("httpx.AsyncClient", object()))
     result = await process_download(
-        FetcherContext(),
-        cast("httpx.AsyncClient", object()),
+        scope,
         make_resource_only_episode(),
         make_options(tmp_path),
     )
@@ -137,9 +137,9 @@ async def test_existing_media_is_reported_and_temporary_resources_are_cleaned(tm
     output_path.parent.mkdir(parents=True)
     output_path.write_bytes(b"existing")
 
+    scope = ExecutionScope(cast("httpx.AsyncClient", object()))
     result = await process_download(
-        FetcherContext(),
-        cast("httpx.AsyncClient", object()),
+        scope,
         episode,
         options,
     )
@@ -178,9 +178,9 @@ async def test_missing_requested_audio_does_not_clean_uncreated_video_file(tmp_p
     episode["danmaku"] = {"source_type": None, "save_type": None, "data": []}
     episode["cover_data"] = None
 
+    scope = ExecutionScope(cast("httpx.AsyncClient", object()))
     result = await process_download(
-        FetcherContext(),
-        cast("httpx.AsyncClient", object()),
+        scope,
         episode,
         options,
     )

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -5,8 +5,9 @@ import asyncio
 import httpx
 import pytest
 
+from yutto.core.execution import ExecutionScope
 from yutto.downloader.downloader import slice_blocks
-from yutto.utils.fetcher import Fetcher, FetcherContext, create_client, unwrap_fetch_result
+from yutto.utils.fetcher import Fetcher, create_client, unwrap_fetch_result
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import as_sync
 
@@ -21,15 +22,14 @@ async def test_150_kB_downloader():
     # 因为 file-examples-com 挂掉了（GitHub 账号都消失了，因此暂时使用一个别处的 mirror）
     url = "https://github.com/nhegde610/samples-files/raw/main/file_example_MP4_480_1_5MG.mp4"
     file_path = TEST_DIR / "test_150_kB.pdf"
-    ctx = FetcherContext()
     async with await AsyncFileBuffer.open(file_path, overwrite=False) as buffer:
         async with create_client(
             timeout=httpx.Timeout(7, connect=3),
         ) as client:
-            ctx.set_download_semaphore(4)
-            size = unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
+            scope = ExecutionScope(client, download_workers=4)
+            size = unwrap_fetch_result(await Fetcher.get_size(scope, url))
             coroutines = [
-                Fetcher.download_file_with_offset(ctx, client, url, [], buffer, offset, block_size)
+                Fetcher.download_file_with_offset(scope, url, [], buffer, offset, block_size)
                 for offset, block_size in slice_blocks(buffer.written_size, size, 1 * 1024 * 1024)
             ]
 
@@ -46,14 +46,13 @@ async def test_150_kB_no_slice_downloader():
     # url = "https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_480_1_5MG.mp4"
     url = "https://github.com/nhegde610/samples-files/raw/main/file_example_MP4_480_1_5MG.mp4"
     file_path = TEST_DIR / "test_150_kB_no_slice.pdf"
-    ctx = FetcherContext()
     async with await AsyncFileBuffer.open(file_path, overwrite=False) as buffer:
         async with create_client(
             timeout=httpx.Timeout(7, connect=3),
         ) as client:
-            ctx.set_download_semaphore(4)
-            size = unwrap_fetch_result(await Fetcher.get_size(ctx, client, url))
-            coroutines = [Fetcher.download_file_with_offset(ctx, client, url, [], buffer, 0, size)]
+            scope = ExecutionScope(client, download_workers=4)
+            size = unwrap_fetch_result(await Fetcher.get_size(scope, url))
+            coroutines = [Fetcher.download_file_with_offset(scope, url, [], buffer, 0, size)]
 
             print("开始下载……")
             await asyncio.gather(*coroutines)

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -9,6 +9,7 @@ import pytest
 from returns.result import Success
 
 import yutto.download_manager as download_manager_module
+from yutto.core.execution import RequestExecutionScopeFactory
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ItemResult, ItemState
 from yutto.download_manager import (
@@ -21,7 +22,7 @@ from yutto.exceptions import NotLoginError, WrongArgumentError
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import AId, CId, ResolvableEpisode
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 from yutto.utils.time import TIME_FULL_FMT
@@ -29,6 +30,7 @@ from yutto.utils.time import TIME_FULL_FMT
 if TYPE_CHECKING:
     import httpx
 
+    from yutto.auth import AuthInfo
     from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import DownloaderOptions, EpisodeData, ExtractorOptions
 
@@ -183,7 +185,7 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
 
     manager = DownloadManager()
     client = cast("httpx.AsyncClient", object())
-    result = await manager.process_request(client, FetcherContext(), make_request(tmp_dir))
+    result = await manager.process_request(ExecutionScope(client), make_request(tmp_dir))
 
     assert validation_requirements == [
         {"is_login": False, "vip_status": False},
@@ -224,7 +226,6 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
         "output_format_audio_only": "flac",
         "overwrite": True,
         "block_size": 1_310_720,
-        "num_workers": 13,
         "save_cover": True,
         "metadata_format": {"premiered": "%Y", "dateadded": TIME_FULL_FMT},
         "banned_mirrors_pattern": "example\\.com",
@@ -272,8 +273,7 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
     validation_results = iter([True, False])
 
     async def fake_resolve_request(
-        client: httpx.AsyncClient,
-        ctx: FetcherContext,
+        scope: ExecutionScope,
         request: DownloadRequest,
     ) -> ExtractorResolveOutcome:
         return ResolveOutcome(items=episodes)
@@ -297,8 +297,7 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
 
     with pytest.raises(NotLoginError):
         await manager.process_request(
-            cast("httpx.AsyncClient", object()),
-            FetcherContext(),
+            ExecutionScope(cast("httpx.AsyncClient", object())),
             make_request(None),
         )
 
@@ -307,41 +306,76 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
 
 
 @as_sync
-async def test_execute_reuses_session_and_path_resolver_in_request_order():
-    ctx = FetcherContext()
+async def test_execute_uses_request_scopes_and_keeps_path_resolver_order():
     requests = [
-        DownloadRequest.model_validate({"source": {"url": "BV1first"}}),
-        DownloadRequest.model_validate({"source": {"url": "BV1second"}}),
+        DownloadRequest.model_validate(
+            {
+                "source": {"url": "BV1first"},
+                "access": {"auth_profile": "first"},
+                "network": {
+                    "proxy": "no",
+                    "fetch_workers": 2,
+                    "download_workers": 3,
+                },
+            }
+        ),
+        DownloadRequest.model_validate(
+            {
+                "source": {"url": "BV1second"},
+                "access": {"auth_profile": "second"},
+                "network": {
+                    "proxy": "auto",
+                    "fetch_workers": 5,
+                    "download_workers": 7,
+                },
+            }
+        ),
     ]
 
     class RecordingManager(DownloadManager):
         def __init__(self) -> None:
             super().__init__()
-            self.calls: list[tuple[httpx.AsyncClient, FetcherContext, str, str]] = []
+            self.calls: list[tuple[ExecutionScope, str, str]] = []
 
         async def process_request(
             self,
-            client: httpx.AsyncClient,
-            ctx: FetcherContext,
+            scope: ExecutionScope,
             request: DownloadRequest,
         ) -> tuple[ItemResult, ...]:
             path = self.unique_path("same/video.mp4")
-            self.calls.append((client, ctx, request.source.url, path))
+            self.calls.append((scope, request.source.url, path))
             return (ItemResult(state=ItemState.DONE, output_path=Path(path)),)
 
-    manager = RecordingManager()
-    result = await manager.execute(ctx, requests)
+    def resolve_credentials(request: DownloadRequest) -> AuthInfo:
+        return cast(
+            "AuthInfo",
+            {
+                "SESSDATA": f"{request.access.auth_profile},session",
+                "bili_jct": None,
+            },
+        )
 
-    assert [url for _, _, url, _ in manager.calls] == ["BV1first", "BV1second"]
+    manager = RecordingManager()
+    result = await manager.execute(RequestExecutionScopeFactory(resolve_credentials), requests)
+
+    assert [url for _, url, _ in manager.calls] == ["BV1first", "BV1second"]
     # unique_path 返回的字符串使用平台原生分隔符，按 Path 比较
-    assert [Path(path) for _, _, _, path in manager.calls] == [
+    assert [Path(path) for _, _, path in manager.calls] == [
         Path("same/video.mp4"),
         Path("same/video (1).mp4"),
     ]
-    assert manager.calls[0][0] is manager.calls[1][0]
-    assert manager.calls[0][1] is ctx and manager.calls[1][1] is ctx
-    assert manager.calls[0][0].is_closed
-    assert ctx.fetch_semaphore is not None
+    first_scope, second_scope = (scope for scope, _, _ in manager.calls)
+    assert first_scope is not second_scope
+    assert first_scope.client is not second_scope.client
+    assert first_scope.client.is_closed and second_scope.client.is_closed
+    assert (first_scope.proxy, first_scope.trust_env) == (None, False)
+    assert (second_scope.proxy, second_scope.trust_env) == (None, True)
+    assert (first_scope.fetch_workers, first_scope.download_workers) == (2, 3)
+    assert (second_scope.fetch_workers, second_scope.download_workers) == (5, 7)
+    assert first_scope.fetch_semaphore is not second_scope.fetch_semaphore
+    assert first_scope.download_semaphore is not second_scope.download_semaphore
+    assert first_scope.cookies.get("SESSDATA") == "first%2Csession"
+    assert second_scope.cookies.get("SESSDATA") == "second%2Csession"
     assert result == DownloadResult(
         items=(
             ItemResult(state=ItemState.DONE, output_path=Path("same/video.mp4")),
@@ -365,17 +399,16 @@ async def test_execute_stops_on_failure_and_closes_client():
 
         async def process_request(
             self,
-            client: httpx.AsyncClient,
-            ctx: FetcherContext,
+            scope: ExecutionScope,
             request: DownloadRequest,
         ) -> tuple[ItemResult, ...]:
-            self.client = client
+            self.client = scope.client
             self.calls.append(request.source.url)
             raise WrongArgumentError("request failed")
 
     manager = FailingManager()
     with pytest.raises(WrongArgumentError, match="request failed"):
-        await manager.execute(FetcherContext(), requests)
+        await manager.execute(RequestExecutionScopeFactory(), requests)
 
     assert manager.calls == ["BV1first"]
     assert manager.client is not None and manager.client.is_closed
@@ -394,17 +427,16 @@ async def test_execute_cancellation_closes_client():
 
         async def process_request(
             self,
-            client: httpx.AsyncClient,
-            ctx: FetcherContext,
+            scope: ExecutionScope,
             request: DownloadRequest,
         ) -> tuple[ItemResult, ...]:
-            self.client = client
+            self.client = scope.client
             started.set()
             await release.wait()
             return ()
 
     manager = BlockingManager()
-    execution = asyncio.create_task(manager.execute(FetcherContext(), [request]))
+    execution = asyncio.create_task(manager.execute(RequestExecutionScopeFactory(), [request]))
     await started.wait()
     execution.cancel()
 

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -9,7 +9,7 @@ import pytest
 from returns.result import Success
 
 import yutto.download_manager as download_manager_module
-from yutto.core.execution import RequestExecutionScopeFactory
+from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ItemResult, ItemState
 from yutto.download_manager import (
@@ -22,7 +22,7 @@ from yutto.exceptions import NotLoginError, WrongArgumentError
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import AId, CId, ResolvableEpisode
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 from yutto.utils.time import TIME_FULL_FMT
@@ -145,8 +145,7 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
 
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             captured_extractor_options.update(options)
@@ -156,16 +155,15 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
 
             return ResolveOutcome(items=(ResolvableEpisode(info=episode["info"], resolve_data=resolve_episode),))
 
-    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         validation_requirements.append(requirements)
         return True
 
-    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_get_redirected_url(scope: ExecutionScope, url: str):
         return Success(url)
 
     async def fake_process_download(
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         episode_data: EpisodeData,
         options: DownloaderOptions,
     ) -> ItemResult:
@@ -278,12 +276,11 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
     ) -> ExtractorResolveOutcome:
         return ResolveOutcome(items=episodes)
 
-    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return next(validation_results)
 
     async def fake_process_download(
-        ctx: FetcherContext,
-        client: httpx.AsyncClient,
+        scope: ExecutionScope,
         episode_data: EpisodeData,
         options: DownloaderOptions,
     ) -> ItemResult:
@@ -368,14 +365,14 @@ async def test_execute_uses_request_scopes_and_keeps_path_resolver_order():
     assert first_scope is not second_scope
     assert first_scope.client is not second_scope.client
     assert first_scope.client.is_closed and second_scope.client.is_closed
-    assert (first_scope.proxy, first_scope.trust_env) == (None, False)
-    assert (second_scope.proxy, second_scope.trust_env) == (None, True)
-    assert (first_scope.fetch_workers, first_scope.download_workers) == (2, 3)
-    assert (second_scope.fetch_workers, second_scope.download_workers) == (5, 7)
-    assert first_scope.fetch_semaphore is not second_scope.fetch_semaphore
-    assert first_scope.download_semaphore is not second_scope.download_semaphore
-    assert first_scope.cookies.get("SESSDATA") == "first%2Csession"
-    assert second_scope.cookies.get("SESSDATA") == "second%2Csession"
+    assert first_scope.fetch_limiter._value == 2
+    assert first_scope.download_limiter._value == 3
+    assert second_scope.fetch_limiter._value == 5
+    assert second_scope.download_limiter._value == 7
+    assert first_scope.fetch_limiter is not second_scope.fetch_limiter
+    assert first_scope.download_limiter is not second_scope.download_limiter
+    assert first_scope.client.cookies.get("SESSDATA") == "first%2Csession"
+    assert second_scope.client.cookies.get("SESSDATA") == "second%2Csession"
     assert result == DownloadResult(
         items=(
             ItemResult(state=ItemState.DONE, output_path=Path("same/video.mp4")),

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -10,7 +10,7 @@ from returns.result import Success
 import yutto.core.execution as execution_module
 import yutto.download_manager as download_manager_module
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.execution import RequestExecutionScopeFactory
+from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
 from yutto.core.operation import bind_download_event_sink
 from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem, ResolveFailure, ResolveResult
@@ -20,7 +20,7 @@ from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId, CId, ResolvableEpisode
-from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
@@ -80,16 +80,15 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
 
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             return ResolveOutcome(items=(resolvable,))
 
-    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
-    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_get_redirected_url(scope: ExecutionScope, url: str):
         return Success(url)
 
     monkeypatch.setattr(download_manager_module, "UgcVideoExtractor", FakeExtractor)
@@ -162,8 +161,7 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
 
         async def extract(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
             *,
             on_item: EpisodeListedCallback | None = None,
@@ -174,10 +172,10 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
             await on_item(streamed)
             return ResolveOutcome(items=(final_copy, late))
 
-    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
-    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_get_redirected_url(scope: ExecutionScope, url: str):
         return Success(url)
 
     monkeypatch.setattr(download_manager_module, "UgcVideoExtractor", FakeExtractor)
@@ -220,16 +218,15 @@ async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.Mon
 
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             return ResolveOutcome(items=(first, second))
 
-    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
-    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_get_redirected_url(scope: ExecutionScope, url: str):
         return Success(url)
 
     monkeypatch.setattr(download_manager_module, "UgcVideoExtractor", FakeExtractor)
@@ -259,10 +256,10 @@ class _FakeClientContext:
 
 
 def _patch_resolve_network(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_validate_user_info(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
-    async def fake_get_redirected_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_get_redirected_url(scope: ExecutionScope, url: str):
         return Success(url)
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", fake_validate_user_info)
@@ -288,8 +285,7 @@ async def test_execute_resolve_treats_filtered_source_as_empty_success(monkeypat
     class FilteredExtractor(_ShortcutExtractorBase):
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             # 纯过滤（如发布时间过滤 / 选集过滤）没有条目，也没有失败
@@ -307,7 +303,7 @@ async def test_execute_resolve_treats_filtered_source_as_empty_success(monkeypat
 
 @as_sync
 async def test_execute_resolve_raises_original_error_when_batch_source_is_gone(monkeypatch: pytest.MonkeyPatch):
-    async def raise_not_found(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+    async def raise_not_found(scope: ExecutionScope, avid: object):
         raise NotFoundError(f"啊叻？视频 {avid} 不见了诶")
 
     _patch_resolve_network(monkeypatch)
@@ -326,7 +322,7 @@ async def test_execute_resolve_raises_original_error_when_batch_source_is_gone(m
 
 @as_sync
 async def test_execute_resolve_raises_original_error_when_watch_later_needs_login(monkeypatch: pytest.MonkeyPatch):
-    async def raise_not_login(ctx: FetcherContext, client: httpx.AsyncClient):
+    async def raise_not_login(scope: ExecutionScope):
         raise NotLoginError("账号未登录，无法获取稍后再看列表")
 
     _patch_resolve_network(monkeypatch)
@@ -352,8 +348,7 @@ async def test_execute_resolve_reports_partial_failures(monkeypatch: pytest.Monk
     class PartialExtractor(_ShortcutExtractorBase):
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             return ResolveOutcome(
@@ -384,8 +379,7 @@ async def test_execute_resolve_aggregates_multiple_failures(monkeypatch: pytest.
     class AllFailedExtractor(_ShortcutExtractorBase):
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             return ResolveOutcome(
@@ -409,21 +403,21 @@ async def test_resolve_ugc_video_lists_reports_expected_failures(monkeypatch: py
     # pubdate 需落在默认过滤窗口（1971-01-01 起）内，用一个正常的时间戳
     fake_list = {"title": "视频 2", "pubdate": 1700000000, "avid": AId("2"), "pages": []}
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: object):
         if str(avid) == "1":
             raise MaxRetryError("超出最大重试次数！")
         return fake_list
 
-    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_touch_url(scope: ExecutionScope, url: str):
         return Success(None)
 
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
     client = cast("httpx.AsyncClient", object())
+    scope = ExecutionScope(client)
     outcome = await resolve_ugc_video_lists(
-        FetcherContext(),
-        client,
+        scope,
         [AId("1"), AId("2")],
         publication_time_filter=PublicationTimeFilter.from_strings(None, None),
     )
@@ -437,10 +431,10 @@ async def test_resolve_ugc_video_lists_reports_expected_failures(monkeypatch: py
 async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pytest.MonkeyPatch):
     fake_list = {"title": "视频", "pubdate": 1700000000, "avid": AId("2"), "pages": []}
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: object):
         return fake_list
 
-    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_touch_url(scope: ExecutionScope, url: str):
         return Success(None)
 
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
@@ -454,9 +448,9 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
         await asyncio.sleep(0)
 
     client = cast("httpx.AsyncClient", object())
+    scope = ExecutionScope(client)
     outcome = await resolve_ugc_video_lists(
-        FetcherContext(),
-        client,
+        scope,
         [AId("1"), AId("2")],
         publication_time_filter=PublicationTimeFilter.from_strings(None, None),
         on_resolved=on_resolved,
@@ -471,14 +465,14 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
 async def test_resolve_ugc_video_lists_cancels_siblings_on_fatal_error(monkeypatch: pytest.MonkeyPatch):
     first_started = asyncio.Event()
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: object):
         if str(avid) == "1":
             first_started.set()
             await asyncio.sleep(0.05)
             return {"title": "视频 1", "pubdate": 1700000000, "avid": AId("1"), "pages": []}
         raise RuntimeError("boom")
 
-    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_touch_url(scope: ExecutionScope, url: str):
         return Success(None)
 
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
@@ -490,11 +484,11 @@ async def test_resolve_ugc_video_lists_cancels_siblings_on_fatal_error(monkeypat
         calls.append(resolved.index)
 
     client = cast("httpx.AsyncClient", object())
+    scope = ExecutionScope(client)
     # 单个未预期异常直接抛原始异常（而非 ExceptionGroup），wire 错误类型保持稳定
     with pytest.raises(RuntimeError, match="boom"):
         await resolve_ugc_video_lists(
-            FetcherContext(),
-            client,
+            scope,
             [AId("1"), AId("2")],
             publication_time_filter=PublicationTimeFilter.from_strings(None, None),
             on_resolved=on_resolved,
@@ -511,13 +505,13 @@ async def test_resolve_ugc_video_lists_cancels_siblings_on_fatal_error(monkeypat
 async def test_resolve_ugc_video_lists_cancels_workers_when_callback_fails(monkeypatch: pytest.MonkeyPatch):
     resolved: list[str] = []
 
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: httpx.AsyncClient, avid: object):
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: object):
         if str(avid) == "2":
             await asyncio.sleep(0.05)
         resolved.append(str(avid))
         return {"title": str(avid), "pubdate": 1700000000, "avid": avid, "pages": []}
 
-    async def fake_touch_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def fake_touch_url(scope: ExecutionScope, url: str):
         return Success(None)
 
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
@@ -527,10 +521,10 @@ async def test_resolve_ugc_video_lists_cancels_workers_when_callback_fails(monke
         raise RuntimeError("callback boom")
 
     client = cast("httpx.AsyncClient", object())
+    scope = ExecutionScope(client)
     with pytest.raises(RuntimeError, match="callback boom"):
         await resolve_ugc_video_lists(
-            FetcherContext(),
-            client,
+            scope,
             [AId("1"), AId("2")],
             publication_time_filter=PublicationTimeFilter.from_strings(None, None),
             on_resolved=on_resolved,
@@ -547,8 +541,7 @@ async def test_execute_resolve_keeps_genuinely_empty_source_as_success(monkeypat
     class EmptySourceExtractor(_ShortcutExtractorBase):
         async def __call__(
             self,
-            ctx: FetcherContext,
-            client: httpx.AsyncClient,
+            scope: ExecutionScope,
             options: ExtractorOptions,
         ) -> ExtractorResolveOutcome:
             return ResolveOutcome()

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -7,8 +7,10 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from returns.result import Success
 
+import yutto.core.execution as execution_module
 import yutto.download_manager as download_manager_module
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
+from yutto.core.execution import RequestExecutionScopeFactory
 from yutto.core.operation import bind_download_event_sink
 from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem, ResolveFailure, ResolveResult
@@ -18,7 +20,7 @@ from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import AId, CId, ResolvableEpisode
-from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
@@ -100,7 +102,7 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
     request = DownloadRequest.model_validate({"source": {"url": "BV1baseline"}})
 
     with bind_download_event_sink(sink):
-        items = await manager.resolve_items(client, FetcherContext(), request)
+        items = await manager.resolve_items(ExecutionScope(client), request)
 
     expected_item = ResolvedItem(
         avid="1",
@@ -188,7 +190,7 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
     request = DownloadRequest.model_validate({"source": {"url": "BV1stream"}})
 
     with bind_download_event_sink(sink):
-        items = await manager.resolve_items(client, FetcherContext(), request)
+        items = await manager.resolve_items(ExecutionScope(client), request)
 
     listed = [event for event in sink.events if isinstance(event, DownloadItemListed)]
     # 每条恰好一次：流式推送的 P1 在前（提取中），P2 收尾补发
@@ -240,7 +242,7 @@ async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.Mon
     request = DownloadRequest.model_validate({"source": {"url": "BV1equal"}})
 
     with bind_download_event_sink(sink):
-        outcome = await manager.resolve_items(client, FetcherContext(), request)
+        outcome = await manager.resolve_items(ExecutionScope(client), request)
 
     listed = [event for event in sink.events if isinstance(event, DownloadItemListed)]
     assert len(listed) == len(outcome.items) == 2
@@ -265,7 +267,7 @@ def _patch_resolve_network(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", fake_validate_user_info)
     monkeypatch.setattr(Fetcher, "get_redirected_url", fake_get_redirected_url)
-    monkeypatch.setattr(download_manager_module, "create_client", lambda **_: _FakeClientContext())
+    monkeypatch.setattr(execution_module, "create_client", lambda **_: _FakeClientContext())
 
 
 def _patch_resolve_environment(monkeypatch: pytest.MonkeyPatch, extractor: type) -> None:
@@ -298,7 +300,7 @@ async def test_execute_resolve_treats_filtered_source_as_empty_success(monkeypat
     request = DownloadRequest.model_validate({"source": {"url": "BV1filtered"}})
 
     with bind_download_event_sink(RecordingEventSink()):
-        result = await manager.execute_resolve(FetcherContext(), [request])
+        result = await manager.execute_resolve(RequestExecutionScopeFactory(), [request])
 
     assert result == ResolveResult(items=(), failures=())
 
@@ -318,7 +320,7 @@ async def test_execute_resolve_raises_original_error_when_batch_source_is_gone(m
     # 真实 UgcVideoBatchExtractor 错误路径：NotFoundError 被吞成 [] 后不再伪装成空成功，
     # 任务以原始异常失败，wire 错误码是稳定的 NOT_FOUND_ERROR 而非 internal_error
     with bind_download_event_sink(RecordingEventSink()), pytest.raises(NotFoundError) as error_info:
-        await manager.execute_resolve(FetcherContext(), [request])
+        await manager.execute_resolve(RequestExecutionScopeFactory(), [request])
     assert error_info.value.code is ErrorCode.NOT_FOUND_ERROR
 
 
@@ -336,7 +338,7 @@ async def test_execute_resolve_raises_original_error_when_watch_later_needs_logi
 
     # 真实 UserWatchLaterExtractor 错误路径：未登录时不再以空成功掩盖 NotLoginError
     with bind_download_event_sink(RecordingEventSink()), pytest.raises(NotLoginError) as error_info:
-        await manager.execute_resolve(FetcherContext(), [request])
+        await manager.execute_resolve(RequestExecutionScopeFactory(), [request])
     assert error_info.value.code is ErrorCode.NOT_LOGIN_ERROR
 
 
@@ -364,7 +366,7 @@ async def test_execute_resolve_reports_partial_failures(monkeypatch: pytest.Monk
     request = DownloadRequest.model_validate({"source": {"url": "BV1partial"}})
 
     with bind_download_event_sink(RecordingEventSink()):
-        result = await manager.execute_resolve(FetcherContext(), [request])
+        result = await manager.execute_resolve(RequestExecutionScopeFactory(), [request])
 
     # 部分失败：成功条目照常返回，失败以结构化形式保留在 failures 中
     assert len(result.items) == 1
@@ -398,7 +400,7 @@ async def test_execute_resolve_aggregates_multiple_failures(monkeypatch: pytest.
     request = DownloadRequest.model_validate({"source": {"url": "BV1failed"}})
 
     with bind_download_event_sink(RecordingEventSink()), pytest.raises(ResolveFailedError) as error_info:
-        await manager.execute_resolve(FetcherContext(), [request])
+        await manager.execute_resolve(RequestExecutionScopeFactory(), [request])
     assert error_info.value.code is ErrorCode.RESOLVE_FAILED_ERROR
 
 
@@ -556,7 +558,7 @@ async def test_execute_resolve_keeps_genuinely_empty_source_as_success(monkeypat
     request = DownloadRequest.model_validate({"source": {"url": "BV1empty"}})
 
     with bind_download_event_sink(RecordingEventSink()):
-        result = await manager.execute_resolve(FetcherContext(), [request])
+        result = await manager.execute_resolve(RequestExecutionScopeFactory(), [request])
 
     # 真正的空来源（如空收藏夹）仍是成功的空结果，与「全部解析失败」区分开
     assert result == ResolveResult(items=())

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -26,7 +26,7 @@ from yutto.extractor.bangumi import BangumiExtractor
 from yutto.extractor.cheese import CheeseExtractor
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import SeasonId
-from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 from yutto.validator import validate_batch_selection
@@ -87,8 +87,7 @@ async def test_manager_raises_login_error_without_rendering(monkeypatch: pytest.
 
     with pytest.raises(NotLoginError) as exc_info:
         await DownloadManager().process_request(
-            cast("httpx.AsyncClient", object()),
-            FetcherContext(),
+            ExecutionScope(cast("httpx.AsyncClient", object())),
             make_request(),
         )
 
@@ -117,8 +116,7 @@ async def test_manager_raises_url_errors_without_rendering_or_network(monkeypatc
 
     with pytest.raises(WrongUrlError) as exc_info:
         await DownloadManager().process_request(
-            cast("httpx.AsyncClient", object()),
-            FetcherContext(),
+            ExecutionScope(cast("httpx.AsyncClient", object())),
             make_request("not-a-url"),
         )
 
@@ -144,8 +142,7 @@ async def test_manager_reports_unmatched_url_as_structured_error(monkeypatch: py
 
     with pytest.raises(WrongUrlError) as exc_info:
         await DownloadManager().process_request(
-            cast("httpx.AsyncClient", object()),
-            FetcherContext(),
+            ExecutionScope(cast("httpx.AsyncClient", object())),
             make_request("https://example.com/unsupported"),
         )
 
@@ -221,13 +218,14 @@ def configure_download_cli(
     rendered_errors: list[str] = []
     rendered_info: list[str] = []
 
-    def fail_download(ctx: FetcherContext, requests: list[DownloadRequest]):
+    def fail_download(scope_factory: object, requests: list[DownloadRequest]):
         raise failure
 
     monkeypatch.setattr(main_module, "cli", lambda: parser)
     monkeypatch.setattr(main_module.sys, "argv", ["yutto", "BV1structured"])
-    monkeypatch.setattr(main_module, "initial_validation", lambda ctx, args: None)
+    monkeypatch.setattr(main_module, "initial_validation", lambda args: None)
     monkeypatch.setattr(main_module, "flatten_args", lambda args, parser: [args])
+    monkeypatch.setattr(main_module, "hydrate_auth", lambda args: None)
     monkeypatch.setattr(main_module, "download_request_from_namespace", lambda args: make_request())
     monkeypatch.setattr(main_module, "run_download", fail_download)
     if replace_logger:

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -12,6 +12,7 @@ import yutto.__main__ as main_module
 import yutto.download_manager as download_manager_module
 import yutto.extractor.bangumi as bangumi_module
 import yutto.extractor.cheese as cheese_module
+from yutto.core.execution import ExecutionScope
 from yutto.core.request import DownloadRequest
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import (
@@ -26,7 +27,7 @@ from yutto.extractor.bangumi import BangumiExtractor
 from yutto.extractor.cheese import CheeseExtractor
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import SeasonId
-from yutto.utils.fetcher import ExecutionScope, Fetcher, FetcherContext
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 from yutto.validator import validate_batch_selection
@@ -79,7 +80,7 @@ def test_selection_validation_raises_structured_argument_errors():
 async def test_manager_raises_login_error_without_rendering(monkeypatch: pytest.MonkeyPatch):
     rendered_errors: list[str] = []
 
-    async def reject_login(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def reject_login(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return False
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", reject_login)
@@ -104,10 +105,10 @@ async def test_manager_raises_login_error_without_rendering(monkeypatch: pytest.
 async def test_manager_raises_url_errors_without_rendering_or_network(monkeypatch: pytest.MonkeyPatch):
     rendered_errors: list[str] = []
 
-    async def accept_login(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def accept_login(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
-    async def reject_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def reject_url(scope: ExecutionScope, url: str):
         raise httpx.InvalidURL("invalid")
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", accept_login)
@@ -131,10 +132,10 @@ async def test_manager_raises_url_errors_without_rendering_or_network(monkeypatc
 @pytest.mark.processor
 @as_sync
 async def test_manager_reports_unmatched_url_as_structured_error(monkeypatch: pytest.MonkeyPatch):
-    async def accept_login(ctx: FetcherContext, requirements: dict[str, bool]) -> bool:
+    async def accept_login(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
-    async def keep_url(ctx: FetcherContext, client: httpx.AsyncClient, url: str):
+    async def keep_url(scope: ExecutionScope, url: str):
         return Success(url)
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", accept_login)
@@ -186,10 +187,10 @@ async def test_single_extractors_raise_when_episode_is_missing(
     list_getter_name: str,
     url: str,
 ):
-    async def get_season(ctx: FetcherContext, client: httpx.AsyncClient, episode_id: Any) -> SeasonId:
+    async def get_season(scope: ExecutionScope, episode_id: Any) -> SeasonId:
         return SeasonId("1")
 
-    async def get_empty_list(ctx: FetcherContext, client: httpx.AsyncClient, season_id: SeasonId):
+    async def get_empty_list(scope: ExecutionScope, season_id: SeasonId):
         return {"title": "空列表", "pages": []}
 
     monkeypatch.setattr(module, "get_season_id_by_episode_id", get_season)
@@ -200,8 +201,7 @@ async def test_single_extractors_raise_when_episode_is_missing(
 
     with pytest.raises(EpisodeNotFoundError) as exc_info:
         await extractor.extract(
-            FetcherContext(),
-            cast("httpx.AsyncClient", object()),
+            ExecutionScope(cast("httpx.AsyncClient", object())),
             EMPTY_EXTRACTOR_OPTIONS,
         )
 

--- a/tests/test_server/test_service.py
+++ b/tests/test_server/test_service.py
@@ -204,11 +204,10 @@ bili_jct = "csrf-value"
     )
 
     async with policy.build_scope_factory().open(request) as scope:
-        assert scope.proxy is None
-        assert scope.trust_env is False
-        assert scope.fetch_workers == 3
-        assert scope.cookies.get("SESSDATA") == "session%2Cvalue"
-        assert scope.cookies.get("bili_jct") == "csrf-value"
+        assert scope.client.trust_env is False
+        assert scope.fetch_limiter._value == 3
+        assert scope.client.cookies.get("SESSDATA") == "session%2Cvalue"
+        assert scope.client.cookies.get("bili_jct") == "csrf-value"
 
 
 @as_sync
@@ -242,19 +241,17 @@ bili_jct = "csrf-value"
         policy.build_scope_factory().open(request) as server_scope,
     ):
         assert (
-            cli_scope.proxy,
-            cli_scope.trust_env,
-            cli_scope.fetch_workers,
-            cli_scope.download_workers,
-            cli_scope.cookies.get("SESSDATA"),
-            cli_scope.cookies.get("bili_jct"),
+            cli_scope.client.trust_env,
+            cli_scope.fetch_limiter._value,
+            cli_scope.download_limiter._value,
+            cli_scope.client.cookies.get("SESSDATA"),
+            cli_scope.client.cookies.get("bili_jct"),
         ) == (
-            server_scope.proxy,
-            server_scope.trust_env,
-            server_scope.fetch_workers,
-            server_scope.download_workers,
-            server_scope.cookies.get("SESSDATA"),
-            server_scope.cookies.get("bili_jct"),
+            server_scope.client.trust_env,
+            server_scope.fetch_limiter._value,
+            server_scope.download_limiter._value,
+            server_scope.client.cookies.get("SESSDATA"),
+            server_scope.client.cookies.get("bili_jct"),
         )
 
 

--- a/tests/test_server/test_service.py
+++ b/tests/test_server/test_service.py
@@ -146,6 +146,13 @@ def test_policy_rejects_worker_counts_outside_configured_limits(tmp_path: Path, 
         policy.prepare_request(make_request(network=network))
 
 
+def test_prepare_request_rejects_invalid_auth_profile(tmp_path: Path):
+    policy = make_policy(tmp_path)
+
+    with pytest.raises(ServerPolicyError, match="auth profile 名称不合法"):
+        policy.prepare_request(make_request(access={"auth_profile": "bad profile"}))
+
+
 @pytest.mark.parametrize("block_size", [0, -1, 64 * 1024 - 1, 64 * 1024 * 1024 + 1])
 def test_policy_rejects_unsafe_block_sizes(tmp_path: Path, block_size: int):
     policy = make_policy(tmp_path)

--- a/tests/test_server/test_service.py
+++ b/tests/test_server/test_service.py
@@ -8,6 +8,8 @@ from typing import cast
 import pytest
 from pydantic import BaseModel
 
+from yutto.auth import load_auth
+from yutto.core.execution import RequestExecutionScopeFactory
 from yutto.core.request import DownloadRequest
 from yutto.core.result import Artifact, ArtifactKind, DownloadResult, ItemResult, ItemState
 from yutto.runtime import EventReplay, TaskError, TaskEvent, TaskSnapshot, TaskState
@@ -20,6 +22,7 @@ from yutto.server.service import (
     snapshot_summary_to_json,
     snapshot_to_json,
 )
+from yutto.utils.functional import as_sync
 
 pytestmark = pytest.mark.processor
 
@@ -181,7 +184,8 @@ def test_options_reject_non_positive_worker_limits(tmp_path: Path, field: str):
         ServerPolicyOptions(**options)  # ty: ignore[invalid-argument-type]
 
 
-def test_build_context_applies_proxy_fetch_limit_and_selected_auth_profile(tmp_path: Path):
+@as_sync
+async def test_scope_factory_applies_request_network_and_selected_auth_profile(tmp_path: Path):
     policy = make_policy(tmp_path, max_fetch_workers=4)
     policy.options.auth_file.write_text(
         """
@@ -199,20 +203,66 @@ bili_jct = "csrf-value"
         network={"proxy": "no", "fetch_workers": 3},
     )
 
-    context = policy.build_context(request)
+    async with policy.build_scope_factory().open(request) as scope:
+        assert scope.proxy is None
+        assert scope.trust_env is False
+        assert scope.fetch_workers == 3
+        assert scope.cookies.get("SESSDATA") == "session%2Cvalue"
+        assert scope.cookies.get("bili_jct") == "csrf-value"
 
-    assert context.proxy is None
-    assert context.trust_env is False
-    assert context.fetch_workers == 3
-    assert context.cookies.get("SESSDATA") == "session%2Cvalue"
-    assert context.cookies.get("bili_jct") == "csrf-value"
+
+@as_sync
+async def test_cli_and_server_scope_factories_interpret_same_request_equivalently(tmp_path: Path):
+    policy = make_policy(tmp_path)
+    policy.options.auth_file.write_text(
+        """
+[profiles.work]
+sessdata = "session,value"
+bili_jct = "csrf-value"
+""".strip(),
+        encoding="utf-8",
+    )
+    request = make_request(
+        access={"auth_profile": "work"},
+        network={
+            "proxy": "no",
+            "fetch_workers": 3,
+            "download_workers": 4,
+        },
+    )
+    cli_factory = RequestExecutionScopeFactory(
+        lambda active_request: load_auth(
+            policy.options.auth_file,
+            active_request.access.auth_profile,
+        )
+    )
+
+    async with (
+        cli_factory.open(request) as cli_scope,
+        policy.build_scope_factory().open(request) as server_scope,
+    ):
+        assert (
+            cli_scope.proxy,
+            cli_scope.trust_env,
+            cli_scope.fetch_workers,
+            cli_scope.download_workers,
+            cli_scope.cookies.get("SESSDATA"),
+            cli_scope.cookies.get("bili_jct"),
+        ) == (
+            server_scope.proxy,
+            server_scope.trust_env,
+            server_scope.fetch_workers,
+            server_scope.download_workers,
+            server_scope.cookies.get("SESSDATA"),
+            server_scope.cookies.get("bili_jct"),
+        )
 
 
-def test_build_context_rejects_invalid_auth_profile_without_exposing_auth_file(tmp_path: Path):
+def test_scope_factory_rejects_invalid_auth_profile_without_exposing_auth_file(tmp_path: Path):
     policy = make_policy(tmp_path)
 
     with pytest.raises(ServerPolicyError, match="auth profile"):
-        policy.build_context(make_request(access={"auth_profile": "bad profile"}))
+        policy.resolve_credentials(make_request(access={"auth_profile": "bad profile"}))
 
 
 class CredentialPayload(BaseModel):

--- a/tests/test_server/test_websocket.py
+++ b/tests/test_server/test_websocket.py
@@ -17,7 +17,9 @@ from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ResolveResult
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.runtime import TaskContext, TaskRuntime, TaskSnapshot, TaskState, monotonic_seq_allocator
+from yutto.server.service import ServerPolicy, ServerPolicyOptions
 from yutto.server.websocket import (
+    REQUEST_REJECTED_ERROR,
     WebSocketServerOptions,
     YuttoWebSocketServer,
     _SlowConsumerCloser,
@@ -32,6 +34,7 @@ pytestmark = pytest.mark.processor
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from yutto.api.ugc_video import UgcVideoList
     from yutto.extractor.utils.batch import IndexedResolveItem
@@ -181,6 +184,7 @@ async def start_server(
     token: str = "test-token",
     service: FakeDownloadTaskApi | None = None,
     resolve_service: FakeResolveTaskApi | None = None,
+    prepare_request: Callable[[DownloadRequest], DownloadRequest] | None = None,
 ) -> tuple[YuttoWebSocketServer, FakeDownloadTaskApi, str]:
     service = service or FakeDownloadTaskApi()
     server = YuttoWebSocketServer(
@@ -191,6 +195,7 @@ async def start_server(
             port=0,
             allowed_origins=allowed_origins,
         ),
+        prepare_request=prepare_request,
         resolve_service=resolve_service,
     )
     await server.start()
@@ -295,6 +300,74 @@ async def test_server_info_and_exact_origin_allowlist():
                 "code": -32602,
                 "message": "Invalid params",
             }
+    finally:
+        await server.close()
+
+
+@pytest.mark.parametrize(
+    ("method", "request_payload", "reason"),
+    [
+        (
+            "download.start",
+            {
+                "source": {"url": "BV1invalid"},
+                "access": {"auth_profile": "bad profile"},
+            },
+            "auth profile 名称不合法：bad profile",
+        ),
+        (
+            "resolve.start",
+            {
+                "source": {"url": "BV1invalid"},
+                "access": {"auth_profile": "bad profile"},
+            },
+            "auth profile 名称不合法：bad profile",
+        ),
+        (
+            "download.start",
+            {
+                "source": {"url": "BV1invalid"},
+                "network": {"fetch_workers": 0},
+            },
+            "network.fetch_workers must be between 1 and 8",
+        ),
+    ],
+)
+@as_sync
+async def test_server_policy_rejects_invalid_requests_before_task_submission(
+    tmp_path: Path,
+    method: str,
+    request_payload: dict[str, object],
+    reason: str,
+):
+    download_service = FakeDownloadTaskApi()
+    resolve_service = FakeResolveTaskApi()
+    policy = ServerPolicy(
+        ServerPolicyOptions(
+            download_root=tmp_path / "downloads",
+            tmp_root=tmp_path / "temporary",
+            auth_file=tmp_path / "auth.toml",
+        )
+    )
+    server, _, uri = await start_server(
+        service=download_service,
+        resolve_service=resolve_service,
+        prepare_request=policy.prepare_request,
+    )
+    try:
+        async with connect(uri, proxy=None) as connection:
+            await connection.send(rpc_request(1, "server.authenticate", {"token": "test-token"}))
+            await receive_json(connection)
+
+            await connection.send(rpc_request(2, method, {"request": request_payload}))
+            assert (await receive_json(connection))["error"] == {
+                "code": REQUEST_REJECTED_ERROR,
+                "message": "Request rejected",
+                "data": {"reason": reason},
+            }
+
+            assert download_service.list() == ()
+            assert resolve_service.list() == ()
     finally:
         await server.close()
 

--- a/tests/test_server/test_websocket.py
+++ b/tests/test_server/test_websocket.py
@@ -12,6 +12,7 @@ from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 from websockets.typing import Origin
 
+from yutto.core.execution import ExecutionScope
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ResolveResult
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
@@ -23,7 +24,7 @@ from yutto.server.websocket import (
     _task_snapshot_order,
 )
 from yutto.types import AId
-from yutto.utils.fetcher import Fetcher, FetcherContext
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
@@ -137,9 +138,9 @@ class BatchStreamingResolveApi(FakeResolveTaskApi):
                 context.emit("item_listed", {"avid": str(resolved.source), "page": page})
                 await asyncio.sleep(0)
 
+        scope = ExecutionScope(cast("Any", object()))
         await resolve_ugc_video_lists(
-            FetcherContext(),
-            cast("Any", object()),
+            scope,
             [AId(str(index + 1)) for index in range(self.video_count)],
             publication_time_filter=PublicationTimeFilter.from_strings(None, None),
             on_resolved=on_resolved,
@@ -148,11 +149,11 @@ class BatchStreamingResolveApi(FakeResolveTaskApi):
 
 
 def _patch_batch_listing(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_get_ugc_video_list(ctx: FetcherContext, client: Any, avid: Any):
+    async def fake_get_ugc_video_list(scope: ExecutionScope, avid: Any):
         # 立即返回：所有视频几乎同时就绪，复现并发完成的最坏情况
         return {"title": str(avid), "pubdate": 1700000000, "avid": avid, "pages": []}
 
-    async def fake_touch_url(ctx: FetcherContext, client: Any, url: str):
+    async def fake_touch_url(scope: ExecutionScope, url: str):
         return Success(None)
 
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -8,7 +8,8 @@ import httpx
 import pytest
 from returns.result import Failure, Success
 
-from yutto.utils.fetcher import Fetcher, FetcherContext, create_client, create_sync_client, resolve_proxy
+from yutto.core.execution import ExecutionScope
+from yutto.utils.fetcher import Fetcher, create_client, create_sync_client, resolve_proxy
 from yutto.utils.functional import as_sync
 
 
@@ -32,15 +33,6 @@ def test_resolve_proxy_auto_uses_system_proxy():
 
 def test_resolve_proxy_supports_socks5():
     assert resolve_proxy("socks5://127.0.0.1:1080") == ("socks5://127.0.0.1:1080", False)
-
-
-def test_fetcher_context_set_proxy_reuses_shared_rules():
-    ctx = FetcherContext()
-
-    ctx.set_proxy("https://127.0.0.1:7890")
-
-    assert ctx.proxy == "https://127.0.0.1:7890"
-    assert not ctx.trust_env
 
 
 def test_resolve_proxy_rejects_invalid_scheme():
@@ -91,7 +83,8 @@ class _StatusClient:
 
 @as_sync
 async def test_fetch_bin_keeps_non_success_status_as_success_none():
-    match await Fetcher.fetch_bin(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    match await Fetcher.fetch_bin(scope, "https://example.com"):
         case Success(None):
             pass
         case result:
@@ -100,7 +93,8 @@ async def test_fetch_bin_keeps_non_success_status_as_success_none():
 
 @as_sync
 async def test_fetch_json_retries_non_success_status():
-    match await Fetcher.fetch_json(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    match await Fetcher.fetch_json(scope, "https://example.com"):
         case Failure(error):
             assert error.message == "超出最大重试次数！"
         case result:
@@ -109,7 +103,8 @@ async def test_fetch_json_retries_non_success_status():
 
 @as_sync
 async def test_get_redirected_url_keeps_non_success_status_as_url():
-    match await Fetcher.get_redirected_url(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    match await Fetcher.get_redirected_url(scope, "https://example.com"):
         case Success(url):
             assert url == "https://example.com"
         case result:
@@ -118,7 +113,8 @@ async def test_get_redirected_url_keeps_non_success_status_as_url():
 
 @as_sync
 async def test_touch_url_keeps_non_success_status_as_success_none():
-    match await Fetcher.touch_url(FetcherContext(), cast("Any", _StatusClient(404)), "https://example.com"):
+    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    match await Fetcher.touch_url(scope, "https://example.com"):
         case Success(None):
             pass
         case result:
@@ -127,7 +123,7 @@ async def test_touch_url_keeps_non_success_status_as_success_none():
 
 @pytest.mark.processor
 @as_sync
-async def test_touch_url_cache_is_scoped_to_context_and_client():
+async def test_touch_url_cache_is_scoped_to_execution_scope():
     class CountingClient(_StatusClient):
         def __init__(self):
             super().__init__(204)
@@ -139,16 +135,11 @@ async def test_touch_url_cache_is_scoped_to_context_and_client():
 
     first_client = CountingClient()
     second_client = CountingClient()
-    first_context = FetcherContext()
-    second_context = FetcherContext()
+    first_scope = ExecutionScope(cast("Any", first_client))
+    second_scope = ExecutionScope(cast("Any", second_client))
 
-    assert isinstance(await Fetcher.touch_url(first_context, cast("Any", first_client), "https://example.com"), Success)
-    assert isinstance(await Fetcher.touch_url(first_context, cast("Any", first_client), "https://example.com"), Success)
-    assert isinstance(
-        await Fetcher.touch_url(second_context, cast("Any", first_client), "https://example.com"), Success
-    )
-    assert isinstance(
-        await Fetcher.touch_url(second_context, cast("Any", second_client), "https://example.com"), Success
-    )
-    assert first_client.calls == 2
+    assert isinstance(await Fetcher.touch_url(first_scope, "https://example.com"), Success)
+    assert isinstance(await Fetcher.touch_url(first_scope, "https://example.com"), Success)
+    assert isinstance(await Fetcher.touch_url(second_scope, "https://example.com"), Success)
+    assert first_client.calls == 1
     assert second_client.calls == 1


### PR DESCRIPTION
## 动机

`DownloadRequest` 已经包含 proxy、fetch/download workers 和 auth profile 等执行配置，但 CLI 仍会在展开任务列表前创建并复用一份可变 `FetcherContext`，而 server 则按请求单独构建 context。两条 adapter 路径因此可能对同一 request 产生不同执行语义，任务列表中的逐项网络与认证覆盖也无法可靠生效。

此外，WBI key 仍使用模块级缓存，可能跨 auth profile 复用；`validate_user_info` 在缓存未命中时还会额外创建一次性 HTTP client。即使引入 `ExecutionScope`，继续保留可单独构造的 `FetcherContext` 也会形成缺少 client/limiter 的半成品运行时状态。

## 解决方案

- 让 `DownloadRequest` 成为非敏感配置的唯一输入，并由每条 request 显式打开一次 `ExecutionScope`。
- 将唯一 concrete `ExecutionScope` 收进 `core/execution.py`，只持有 client、fetch/download limiter、用户信息/WBI cache 和 touched URLs。
- 删除 `FetcherContext` 及其 proxy/auth/worker mutator；登录流程直接复用 `resolve_proxy`、`cookies_from_auth` 和同步 client helper。
- 将 Fetcher、API、Extractor 与 Downloader 的旧 `(context, client, ...)` 双参数调用统一为 scope-only，从 `scope.client` 获取唯一 client。
- CLI 与 server 共用同一 scope factory；认证 profile 仅在 composition root 解析，不进入 request 或 wire payload。
- 将 `user_info_cache`、`wbi_img_cache` 和 touched URLs 全部限制在单次 execution scope 内。
- 同步更新 `biliass-corpus` 至 `5fb3b2d`，使 corpus 抓取脚本使用新的 scope-only API。

## 影响

内部 Python Fetcher/API/Extractor 调用签名统一为只接收 `ExecutionScope`；仓内调用点与测试已全部迁移。CLI 和 JSON-RPC wire 行为保持不变。

### 验证

- `just fmt`
- `just lint`
- `git diff --check`
- 聚焦 execution/API/server/processor 回归：`115 passed`
- `uv run python -m yutto -h`
- `uv run scripts/fetch-corpus.py --help`（在 biliass-corpus 中）
- 完整 Python 3.11 CI 测试：`265 passed, 1 skipped`；`test_150_kB_downloader` 因 GitHub 样例文件连续连接超时失败，带 3 次 rerun 后仍为外网超时

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本