### PR TITLE
🐛 fix: deduplicate CLI auth announcements

### DIFF
--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -35,6 +35,23 @@ if TYPE_CHECKING:
     from yutto.core.request import DownloadRequest
 
 
+class _CliAuthAnnouncer:
+    """Announce each effective credential once without sharing request caches."""
+
+    def __init__(self):
+        self._announced_credentials: set[tuple[str | None, str | None]] = set()
+
+    async def __call__(self, scope: ExecutionScope, request: DownloadRequest) -> None:
+        credentials = (
+            scope.client.cookies.get("SESSDATA"),
+            scope.client.cookies.get("bili_jct"),
+        )
+        if credentials in self._announced_credentials:
+            return
+        self._announced_credentials.add(credentials)
+        await announce_cli_auth(scope, request)
+
+
 def main():
     parser = cli()
     args = parser.parse_args(handle_default_subcommand(sys.argv[1:]))
@@ -52,7 +69,7 @@ def main():
 
                 scope_factory = RequestExecutionScopeFactory(
                     resolve_credentials,
-                    on_open=announce_cli_auth,
+                    on_open=_CliAuthAnnouncer(),
                 )
                 run_download(scope_factory, requests)
             except YuttoBaseException as e:

--- a/tests/test_core/test_execution.py
+++ b/tests/test_core/test_execution.py
@@ -5,6 +5,8 @@ from typing import Any, cast
 
 import pytest
 
+import yutto.__main__ as main_module
+from yutto.auth import AuthInfo
 from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
 from yutto.core.request import DownloadRequest
 from yutto.types import UserInfo
@@ -96,3 +98,70 @@ async def test_scope_factory_closes_client_when_on_open_fails():
 
     assert len(clients) == 1
     assert clients[0].is_closed
+
+
+@as_sync
+async def test_cli_auth_announcer_deduplicates_effective_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    auth_by_url: dict[str, AuthInfo | None] = {
+        "BV1first": AuthInfo(SESSDATA="member", bili_jct="csrf"),
+        "BV1duplicate": AuthInfo(SESSDATA="member", bili_jct="csrf"),
+        "BV1other": AuthInfo(SESSDATA="ordinary", bili_jct="other-csrf"),
+        "BV1anonymous": None,
+        "BV1anonymousAgain": None,
+    }
+    validation_calls: list[tuple[str | None, str | None]] = []
+    vip_messages: list[str] = []
+    warning_messages: list[str] = []
+    info_messages: list[str] = []
+
+    async def validate(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
+        assert requirements == {"vip_status": True, "is_login": True}
+        credentials = (
+            scope.client.cookies.get("SESSDATA"),
+            scope.client.cookies.get("bili_jct"),
+        )
+        validation_calls.append(credentials)
+        is_vip = credentials[0] == "member"
+        scope.user_info_cache = UserInfo(vip_status=is_vip, is_login=True)
+        return is_vip
+
+    monkeypatch.setattr(main_module, "validate_user_info", validate)
+    monkeypatch.setattr(main_module.Logger, "custom", lambda message, **_kwargs: vip_messages.append(message))
+    monkeypatch.setattr(main_module.Logger, "warning", warning_messages.append)
+    monkeypatch.setattr(main_module.Logger, "info", info_messages.append)
+
+    requests = [
+        DownloadRequest.model_validate({"source": {"url": url}})
+        for url in (
+            "BV1first",
+            "BV1duplicate",
+            "BV1other",
+            "BV1anonymous",
+            "BV1anonymousAgain",
+        )
+    ]
+    factory = RequestExecutionScopeFactory(
+        lambda request: auth_by_url[request.source.url],
+        on_open=main_module._CliAuthAnnouncer(),
+    )
+    caches: list[UserInfo | None] = []
+
+    for request in requests:
+        async with factory.open(request) as scope:
+            caches.append(scope.user_info_cache)
+
+    assert validation_calls == [("member", "csrf"), ("ordinary", "other-csrf")]
+    assert vip_messages == ["成功以大会员身份登录～"]
+    assert warning_messages == ["以非大会员身份登录，注意无法下载会员专享剧集喔～"]
+    assert info_messages == [
+        "未提供登录认证信息，无法下载高清视频、字幕等资源哦～请通过 `--auth` 参数提供认证信息，或者先使用 `yutto auth login` 登录存储认证信息后再下载～"
+    ]
+    assert caches == [
+        UserInfo(vip_status=True, is_login=True),
+        None,
+        UserInfo(vip_status=False, is_login=True),
+        None,
+        None,
+    ]


### PR DESCRIPTION
## 动机

PR #770 合并后，review 指出 CLI 会在每个 Request 的 ExecutionScope 打开时重复执行鉴权预检。对于共享同一组凭据的任务列表，这会重复请求 USER_INFO API 并输出相同登录提示。

Related to #770.

## 解决方案

- 增加 CLI 专用的鉴权提示器，按 ExecutionScope 中实际生效的 `SESSDATA` / `bili_jct` 组合去重。
- 仅去重 CLI 提示与预检，不跨 ExecutionScope 共享 `user_info_cache`，保持 Request 间运行时状态隔离。
- 增加覆盖相同凭据、不同凭据和未登录请求的回归测试。

验证：

- `just fmt`
- `just lint`
- `uv run pytest tests/test_core/test_execution.py tests/test_core/test_request.py -q`（17 passed）
- `git diff --check`

## 类型

-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [x] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

<div align="right">
   <sup>This PR is authored by @codex (gpt-5.6 sol ultra)</sup>
</div>