### PR TITLE
♻️ refactor: canonicalize listing snapshots

### DIFF
--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -128,6 +128,8 @@ yutto serve \
 - `planned_path`：按模板推导的计划路径（POSIX 风格），实际下载时可能因去重而调整；
 - `display_group`：批量解析时的分组名，无分组时为 `null`。
 
+两条输出都来自同一个不可变 listing snapshot；`planned_path` 固定记录 listing 时的计划路径，下载期去重不会回写它。snapshot 中的 `url` 是稳定的条目页面 URL，不包含易过期的音视频资源 URL、资源 bytes 或认证信息。
+
 错误语义：解析过程中预期内的失败（视频不存在 / 无访问权限 / 请求重试耗尽等）会以结构化形式保留 —— 任务完成时 `result.failures` 逐项列出 `type` / `message` / `code`（与任务级错误同构，`code` 来自 yutto 的稳定错误码表）。没有任何条目解析成功且存在失败时，任务以 `failed` 结束且错误码保持稳定（单一失败即原始失败的错误码，多个失败聚合为 `RESOLVE_FAILED_ERROR`），不会伪装成空成功；来源本就为空、或条目全部被过滤（如发布时间过滤）时，任务以 `completed` 返回空 `items` 且 `failures` 为空；部分失败时任务为 `completed`，成功条目在 `items`、失败记录在 `failures`。
 
 ## 本地资源边界

--- a/src/yutto/core/events.py
+++ b/src/yutto/core/events.py
@@ -5,7 +5,10 @@ from enum import StrEnum
 from pathlib import Path  # noqa: TC003 - runtime type hints are part of the event contract
 from typing import Literal, Protocol, TypeAlias
 
-from yutto.core.result import ItemSkipReason  # noqa: TC001 - runtime type hints support schema introspection
+from yutto.core.result import (  # noqa: TC001 - runtime type hints support schema introspection
+    ItemSkipReason,
+    ResolvedItem,
+)
 
 
 class DownloadStage(StrEnum):
@@ -57,19 +60,9 @@ class DownloadArtifactCreated:
 
 @dataclass(frozen=True, slots=True)
 class DownloadItemListed:
-    """One episode enumerated during a resolve run; carries only stable listing data."""
+    """One episode enumerated during a resolve run."""
 
-    avid: str
-    cid: str
-    url: str
-    name: str
-    title: str
-    cover_url: str
-    planned_path: Path
-    display_group: str | None = None
-    uploader: str = ""
-    description: str = ""
-    tags: tuple[str, ...] = ()
+    item: ResolvedItem
 
 
 DownloadEvent: TypeAlias = (

--- a/src/yutto/core/result.py
+++ b/src/yutto/core/result.py
@@ -4,7 +4,9 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, InstanceOf, field_serializer, model_validator
+
+from yutto.types import AvId, CId
 
 
 class _ResultModel(BaseModel):
@@ -58,10 +60,10 @@ class DownloadResult(_ResultModel):
 
 
 class ResolvedItem(_ResultModel):
-    """A stable, listing-time snapshot of one episode; contains no expiring data."""
+    """The canonical immutable snapshot of one listed episode."""
 
-    avid: str
-    cid: str
+    avid: InstanceOf[AvId]
+    cid: InstanceOf[CId]
     url: str
     name: str
     title: str
@@ -71,6 +73,14 @@ class ResolvedItem(_ResultModel):
     uploader: str = ""
     description: str = ""
     tags: tuple[str, ...] = ()
+
+    @field_serializer("avid", "cid", when_used="json", return_type=str)
+    def serialize_id(self, value: AvId | CId) -> str:
+        return str(value)
+
+    @field_serializer("planned_path", when_used="json", return_type=str)
+    def serialize_planned_path(self, value: Path) -> str:
+        return value.as_posix()
 
 
 class ResolveFailure(_ResultModel):

--- a/src/yutto/core/result.py
+++ b/src/yutto/core/result.py
@@ -4,9 +4,9 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field, InstanceOf, field_serializer, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
 
-from yutto.types import AvId, CId
+from yutto.types import AId, AvId, BvId, CId
 
 
 class _ResultModel(BaseModel):
@@ -62,8 +62,8 @@ class DownloadResult(_ResultModel):
 class ResolvedItem(_ResultModel):
     """The canonical immutable snapshot of one listed episode."""
 
-    avid: InstanceOf[AvId]
-    cid: InstanceOf[CId]
+    avid: AvId
+    cid: CId
     url: str
     name: str
     title: str
@@ -73,6 +73,24 @@ class ResolvedItem(_ResultModel):
     uploader: str = ""
     description: str = ""
     tags: tuple[str, ...] = ()
+
+    @field_validator("avid", mode="plain", json_schema_input_type=str)
+    @classmethod
+    def validate_avid(cls, value: object) -> AvId:
+        if isinstance(value, AvId):
+            return value
+        if isinstance(value, str):
+            return BvId(value) if value.casefold().startswith(AvId.PREFIX.casefold()) else AId(value)
+        raise ValueError("avid must be an AvId instance or string")
+
+    @field_validator("cid", mode="plain", json_schema_input_type=str)
+    @classmethod
+    def validate_cid(cls, value: object) -> CId:
+        if isinstance(value, CId):
+            return value
+        if isinstance(value, str):
+            return CId(value)
+        raise ValueError("cid must be a CId instance or string")
 
     @field_serializer("avid", "cid", when_used="json", return_type=str)
     def serialize_id(self, value: AvId | CId) -> str:

--- a/src/yutto/core/serialization.py
+++ b/src/yutto/core/serialization.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from yutto.core.result import ResolvedItem
+
+
+def listing_item_to_wire(item: ResolvedItem) -> dict[str, object]:
+    """Project one canonical listing snapshot onto the stable JSON-RPC v1 shape."""
+    return item.model_dump(mode="json")

--- a/src/yutto/core/task_service.py
+++ b/src/yutto/core/task_service.py
@@ -15,6 +15,7 @@ from yutto.core.events import (
 )
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ResolveResult
+from yutto.core.serialization import listing_item_to_wire
 from yutto.runtime import TaskRuntime
 
 if TYPE_CHECKING:
@@ -192,31 +193,7 @@ def _encode_runtime_event(event: DownloadEvent) -> tuple[str, dict[str, object]]
             return "item_skipped", {"item": item, "reason": reason.value}
         case DownloadArtifactCreated(item=item, path=path):
             return "artifact_created", {"path": path.as_posix(), "item": item}
-        case DownloadItemListed(
-            avid=avid,
-            cid=cid,
-            url=url,
-            name=name,
-            title=title,
-            cover_url=cover_url,
-            planned_path=planned_path,
-            display_group=display_group,
-            uploader=uploader,
-            description=description,
-            tags=tags,
-        ):
-            return "item_listed", {
-                "avid": avid,
-                "cid": cid,
-                "url": url,
-                "name": name,
-                "title": title,
-                "cover_url": cover_url,
-                "planned_path": planned_path.as_posix(),
-                "display_group": display_group,
-                "uploader": uploader,
-                "description": description,
-                "tags": list(tags),
-            }
+        case DownloadItemListed(item=item):
+            return "item_listed", listing_item_to_wire(item)
         case _ as unreachable:
             assert_never(unreachable)

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -68,7 +68,7 @@ def show_batch_episode_title(
     Returns:
         更新后的 current_display_group，供下一次调用使用。
     """
-    display_group = episode_info["display_group"]
+    display_group = episode_info["listing"].display_group
     # 分组变化时打印分组标题（多分 p 视频新出现或切换到另一个多分 p 视频）
     if display_group is not None and display_group != current_display_group:
         Logger.custom(display_group, Badge("列表", fore="black", back="cyan"))
@@ -87,52 +87,15 @@ def show_batch_episode_title(
     return current_display_group
 
 
-def _resolved_item_from(episode: ResolvableEpisode) -> ResolvedItem:
-    info = episode.info
-    return ResolvedItem(
-        avid=str(info["avid"]),
-        cid=str(info["cid"]),
-        url=info["url"],
-        name=info["name"],
-        title=info["title"],
-        cover_url=info["cover_url"],
-        planned_path=info["path"],
-        display_group=info["display_group"],
-        uploader=info["uploader"],
-        description=info["description"],
-        tags=tuple(info["tags"]),
-    )
+def _emit_item_listed(item: ResolvedItem) -> None:
+    emit_download_event(DownloadItemListed(item=item))
 
 
-def _emit_item_listed(episode: ResolvableEpisode) -> None:
-    item = _resolved_item_from(episode)
-    emit_download_event(
-        DownloadItemListed(
-            avid=item.avid,
-            cid=item.cid,
-            url=item.url,
-            name=item.name,
-            title=item.title,
-            cover_url=item.cover_url,
-            planned_path=item.planned_path,
-            display_group=item.display_group,
-            uploader=item.uploader,
-            description=item.description,
-            tags=item.tags,
-        )
-    )
-
-
-def _resolved_item_key(episode: ResolvableEpisode) -> tuple[str, str, str, Path, str | None]:
-    """Return a stable occurrence key for matching streamed and final items."""
-    info = episode.info
-    return (
-        str(info["avid"]),
-        str(info["cid"]),
-        info["url"],
-        info["path"],
-        info["display_group"],
-    )
+@dataclass(eq=False, slots=True)
+class _StreamedResolvedItem:
+    episode: ResolvableEpisode
+    item: ResolvedItem
+    consumed: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,38 +157,51 @@ class DownloadManager:
 
         返回的 planned_path 是模板解析出的计划路径；实际下载时可能因去重而调整。
         item_listed 逐条推送：支持流式的 batch 提取器通过显式 on_item 回调在
-        每个视频解析完成时交出分集，提取结束后按稳定键逐次消费已推送 occurrence，
-        再补发剩余条目；等值但独立的 occurrence 不会被合并，返回列表始终保持
-        提取器的原始顺序。
+        每个视频解析完成时交出分集，提取结束后按 identity 或完整 canonical
+        snapshot 逐次消费已推送 occurrence，再补发剩余条目；等值但独立的
+        occurrence 不会被合并，返回列表始终保持提取器的原始顺序。
         """
-        streamed_by_key: dict[tuple[str, str, str, Path, str | None], deque[ResolvableEpisode]] = {}
+        streamed_by_identity: dict[int, _StreamedResolvedItem] = {}
+        streamed_by_item: dict[ResolvedItem, deque[_StreamedResolvedItem]] = {}
 
         async def stream_episode(episode: ResolvableEpisode) -> None:
-            key = _resolved_item_key(episode)
-            streamed = streamed_by_key.setdefault(key, deque())
-            # 防御同一 occurrence 的重复 callback；不同对象即使 snapshot 等值，
-            # 仍代表两个合法 occurrence，必须分别发送事件。
-            if any(item is episode for item in streamed):
+            streamed = streamed_by_identity.get(id(episode))
+            # identity 只用于防御同一 occurrence 的重复 callback；强引用 episode
+            # 可避免本次 resolve 内 id 重用。等值但不同对象仍分别创建 snapshot。
+            if streamed is not None and streamed.episode is episode:
                 await asyncio.sleep(0)
                 return
-            streamed.append(episode)
-            _emit_item_listed(episode)
+            item = episode.info["listing"]
+            streamed = _StreamedResolvedItem(episode=episode, item=item)
+            streamed_by_identity[id(episode)] = streamed
+            streamed_by_item.setdefault(item, deque()).append(streamed)
+            _emit_item_listed(item)
             await asyncio.sleep(0)
 
         outcome = await self.resolve_request(scope, request, on_item=stream_episode)
         items: list[ResolvedItem] = []
         for episode in outcome.items:
-            key = _resolved_item_key(episode)
-            streamed = streamed_by_key.get(key)
-            if streamed:
-                streamed.popleft()
+            streamed = streamed_by_identity.get(id(episode))
+            if streamed is not None and streamed.episode is episode and not streamed.consumed:
+                streamed.consumed = True
+                item = streamed.item
             else:
-                _emit_item_listed(episode)
-                # 未流式化的提取器仍会在这个无 await 的循环里整批产出 item_listed；
-                # 逐条让出控制权给事件消费者（如 server 每连接的 sender），
-                # 避免超出其发送队列容量触发 slow-consumer 断连
-                await asyncio.sleep(0)
-            items.append(_resolved_item_from(episode))
+                probe = episode.info["listing"]
+                pending = streamed_by_item.get(probe)
+                while pending and pending[0].consumed:
+                    pending.popleft()
+                if pending:
+                    streamed = pending.popleft()
+                    streamed.consumed = True
+                    item = streamed.item
+                else:
+                    item = probe
+                    _emit_item_listed(item)
+                    # 未流式化的提取器仍会在这个无 await 的循环里整批产出 item_listed；
+                    # 逐条让出控制权给事件消费者（如 server 每连接的 sender），
+                    # 避免超出其发送队列容量触发 slow-consumer 断连
+                    await asyncio.sleep(0)
+            items.append(item)
         return _ResolvedItemsOutcome(items=tuple(items), failures=outcome.failures)
 
     async def process_request(

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -14,6 +14,7 @@ from yutto.api.ugc_video import (
     get_ugc_video_playurl,
     get_ugc_video_subtitles,
 )
+from yutto.core.result import ResolvedItem
 from yutto.exceptions import (
     HttpStatusError,
     NoAccessPermissionError,
@@ -78,18 +79,22 @@ def build_bangumi_info(
     subpath_variables_base.update(subpath_variables)
     path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
     uploader, description, tags = _get_display_fields_from_metadata(bangumi_info["metadata"])
+    planned_path = Path(path)
     return EpisodeInfo(
-        avid=avid,
-        cid=bangumi_info["cid"],
-        url=f"https://www.bilibili.com/bangumi/play/ep{bangumi_info['episode_id']}",
-        name=bangumi_info["name"],
-        title=str(subpath_variables_base["title"]),
-        cover_url=bangumi_info["metadata"]["thumb"],
-        uploader=uploader,
-        description=description,
-        tags=tags,
-        path=Path(path),
-        display_group=None,
+        listing=ResolvedItem(
+            avid=avid,
+            cid=bangumi_info["cid"],
+            url=f"https://www.bilibili.com/bangumi/play/ep{bangumi_info['episode_id']}",
+            name=bangumi_info["name"],
+            title=str(subpath_variables_base["title"]),
+            cover_url=bangumi_info["metadata"]["thumb"],
+            uploader=uploader,
+            description=description,
+            tags=tuple(tags),
+            planned_path=planned_path,
+            display_group=None,
+        ),
+        path=planned_path,
     )
 
 
@@ -100,8 +105,9 @@ async def extract_bangumi_data(
     options: ExtractorOptions,
 ) -> EpisodeData | None:
     try:
-        avid = info["avid"]
-        cid = info["cid"]
+        listing = info["listing"]
+        avid = listing.avid
+        cid = listing.cid
         if bangumi_info["is_preview"]:
             Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
         videos, audios = (
@@ -117,7 +123,7 @@ async def extract_bangumi_data(
         )
         metadata = bangumi_info["metadata"] if options["require_metadata"] else None
         cover_data = (
-            (await Fetcher.fetch_bin(scope, info["cover_url"])).value_or(None) if options["require_cover"] else None
+            (await Fetcher.fetch_bin(scope, listing.cover_url)).value_or(None) if options["require_cover"] else None
         )
         return EpisodeData(
             info=info,
@@ -171,18 +177,22 @@ def build_cheese_info(
     subpath_variables_base.update(subpath_variables)
     path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
     uploader, description, tags = _get_display_fields_from_metadata(cheese_info["metadata"])
+    planned_path = Path(path)
     return EpisodeInfo(
-        avid=avid,
-        cid=cheese_info["cid"],
-        url=f"https://www.bilibili.com/cheese/play/ep{cheese_info['episode_id']}",
-        name=cheese_info["name"],
-        title=str(subpath_variables_base["title"]),
-        cover_url=cheese_info["metadata"]["thumb"],
-        uploader=uploader,
-        description=description,
-        tags=tags,
-        path=Path(path),
-        display_group=None,
+        listing=ResolvedItem(
+            avid=avid,
+            cid=cheese_info["cid"],
+            url=f"https://www.bilibili.com/cheese/play/ep{cheese_info['episode_id']}",
+            name=cheese_info["name"],
+            title=str(subpath_variables_base["title"]),
+            cover_url=cheese_info["metadata"]["thumb"],
+            uploader=uploader,
+            description=description,
+            tags=tuple(tags),
+            planned_path=planned_path,
+            display_group=None,
+        ),
+        path=planned_path,
     )
 
 
@@ -194,8 +204,9 @@ async def extract_cheese_data(
     options: ExtractorOptions,
 ) -> EpisodeData | None:
     try:
-        avid = info["avid"]
-        cid = info["cid"]
+        listing = info["listing"]
+        avid = listing.avid
+        cid = listing.cid
         videos, audios = (
             await get_cheese_playurl(scope, avid, episode_id, cid)
             if options["require_video"] or options["require_audio"]
@@ -209,7 +220,7 @@ async def extract_cheese_data(
         )
         metadata = cheese_info["metadata"] if options["require_metadata"] else None
         cover_data = (
-            (await Fetcher.fetch_bin(scope, info["cover_url"])).value_or(None) if options["require_cover"] else None
+            (await Fetcher.fetch_bin(scope, listing.cover_url)).value_or(None) if options["require_cover"] else None
         )
         return EpisodeData(
             info=info,
@@ -273,18 +284,22 @@ def build_ugc_video_info(
     subpath_variables_base.update(subpath_variables)
     path = resolve_path_template(options["subpath_template"], auto_subpath_template, subpath_variables_base)
     uploader, description, tags = _get_display_fields_from_metadata(ugc_video_info["metadata"])
+    planned_path = Path(path)
     return EpisodeInfo(
-        avid=avid,
-        cid=ugc_video_info["cid"],
-        url=f"{avid.to_url()}?p={ugc_video_info['id']}",
-        name=ugc_video_info["name"],
-        title=str(subpath_variables_base["title"]),
-        cover_url=ugc_video_info["metadata"]["thumb"],
-        uploader=uploader,
-        description=description,
-        tags=tags,
-        path=Path(path),
-        display_group=display_group,
+        listing=ResolvedItem(
+            avid=avid,
+            cid=ugc_video_info["cid"],
+            url=f"{avid.to_url()}?p={ugc_video_info['id']}",
+            name=ugc_video_info["name"],
+            title=str(subpath_variables_base["title"]),
+            cover_url=ugc_video_info["metadata"]["thumb"],
+            uploader=uploader,
+            description=description,
+            tags=tuple(tags),
+            planned_path=planned_path,
+            display_group=display_group,
+        ),
+        path=planned_path,
     )
 
 
@@ -295,8 +310,9 @@ async def extract_ugc_video_data(
     options: ExtractorOptions,
 ) -> EpisodeData | None:
     try:
-        avid = info["avid"]
-        cid = info["cid"]
+        listing = info["listing"]
+        avid = listing.avid
+        cid = listing.cid
         videos, audios = (
             await get_ugc_video_playurl(scope, avid, cid, options["ai_translation_language"])
             if options["require_video"] or options["require_audio"]
@@ -313,7 +329,7 @@ async def extract_ugc_video_data(
         if metadata and chapter_info_data:
             attach_chapter_info(metadata, chapter_info_data)
         cover_data = (
-            (await Fetcher.fetch_bin(scope, info["cover_url"])).value_or(None) if options["require_cover"] else None
+            (await Fetcher.fetch_bin(scope, listing.cover_url)).value_or(None) if options["require_cover"] else None
         )
         return EpisodeData(
             info=info,

--- a/src/yutto/server/service.py
+++ b/src/yutto/server/service.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel
 
 from yutto.auth import load_auth, validate_profile
 from yutto.core.execution import RequestExecutionScopeFactory
+from yutto.core.result import ResolvedItem, ResolveResult
+from yutto.core.serialization import listing_item_to_wire
 from yutto.utils.fetcher import resolve_proxy
 
 if TYPE_CHECKING:
@@ -307,6 +309,12 @@ def _to_json_value(value: object) -> JsonValue:
     if isinstance(value, Path):
         # wire 上的路径统一使用正斜杠，避免协议输出随 server 所在平台变化
         return value.as_posix()
+    if isinstance(value, ResolveResult):
+        result = value.model_dump(mode="python")
+        result["items"] = [listing_item_to_wire(item) for item in value.items]
+        return _to_json_value(result)
+    if isinstance(value, ResolvedItem):
+        return _to_json_value(listing_item_to_wire(value))
     if isinstance(value, BaseModel):
         # python mode 保留 Path 等原生类型，统一交由本函数的分支序列化
         return _to_json_value(value.model_dump(mode="python"))

--- a/src/yutto/types.py
+++ b/src/yutto/types.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
 
+    from yutto.core.result import ResolvedItem
     from yutto.media.codec import AudioCodec, VideoCodec
     from yutto.media.quality import AudioQuality, VideoQuality
     from yutto.utils.danmaku import DanmakuData, DanmakuOptions, DanmakuSaveType
@@ -231,23 +232,14 @@ class ExtractorOptions(TypedDict):
 
 
 class EpisodeInfo(TypedDict):
-    """条目在 listing 阶段即可得的稳定信息，不含 playurl 等易失数据"""
+    """下载期条目信息：不可变 listing 快照与可调整的实际路径。"""
 
-    avid: AvId
-    cid: CId
-    url: str  # 指向该条目自身的原子 URL，可直接作为单集下载的入口
-    name: str
-    title: str
-    cover_url: str
-    uploader: str  # UP 主名称，listing 元数据缺失时为空串
-    description: str  # 视频简介，listing 元数据缺失时为空串
-    tags: list[str]
-    path: Path  # 模板解析出的计划路径，下载时可能因去重而调整
-    display_group: str | None  # 多分 p 视频的分组标题，单集为 None
+    listing: ResolvedItem
+    path: Path  # 初始等于 listing.planned_path，下载时可能因去重而调整
 
 
 class EpisodeData(TypedDict):
-    """剧集数据 = 稳定的条目信息（info）+ 下载所需的资源数据"""
+    """剧集数据 = canonical listing + 下载期路径 + 下载所需的资源数据。"""
 
     info: EpisodeInfo
     videos: list[VideoUrlMeta]

--- a/tests/test_core/test_result.py
+++ b/tests/test_core/test_result.py
@@ -5,7 +5,16 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from yutto.core.result import Artifact, ArtifactKind, DownloadResult, ItemResult, ItemSkipReason, ItemState
+from yutto.core.result import (
+    Artifact,
+    ArtifactKind,
+    DownloadResult,
+    ItemResult,
+    ItemSkipReason,
+    ItemState,
+    ResolvedItem,
+)
+from yutto.types import AId, CId
 
 pytestmark = pytest.mark.processor
 
@@ -17,6 +26,41 @@ def test_result_models_are_frozen_and_reject_extra_fields():
         result.items = ()  # ty: ignore[invalid-assignment]
     with pytest.raises(ValidationError, match="Extra inputs"):
         Artifact(kind=ArtifactKind.MEDIA, path=Path("video.mp4"), size=1)  # ty: ignore[unknown-argument]
+
+
+def test_resolved_item_is_a_typed_immutable_listing_snapshot():
+    payload: dict[str, object] = {
+        "avid": AId("1"),
+        "cid": CId("10"),
+        "url": "https://www.bilibili.com/video/av1?p=1",
+        "name": "P1",
+        "title": "标题",
+        "cover_url": "https://example.com/cover.jpg",
+        "planned_path": Path("标题/P1"),
+        "display_group": "标题",
+        "uploader": "某UP主",
+        "description": "视频简介",
+        "tags": ("标签A", "标签B"),
+    }
+    item = ResolvedItem.model_validate(payload)
+
+    assert isinstance(item.avid, AId)
+    assert isinstance(item.cid, CId)
+    assert item.tags == ("标签A", "标签B")
+    assert set(type(item).model_fields) == set(payload)
+    serialized = item.model_dump(mode="json")
+    assert serialized["avid"] == "1"
+    assert serialized["cid"] == "10"
+    assert serialized["planned_path"] == "标题/P1"
+    assert serialized["tags"] == ["标签A", "标签B"]
+    schema = ResolvedItem.model_json_schema(mode="serialization")
+    assert schema["properties"]["avid"]["type"] == "string"
+    assert schema["properties"]["cid"]["type"] == "string"
+
+    with pytest.raises(ValidationError, match="frozen"):
+        item.name = "changed"  # ty: ignore[invalid-assignment]
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        ResolvedItem.model_validate({**payload, "play_url": "https://example.com/expiring"})
 
 
 def test_item_result_validates_skip_reason_without_requiring_artifacts():

--- a/tests/test_core/test_result.py
+++ b/tests/test_core/test_result.py
@@ -13,8 +13,9 @@ from yutto.core.result import (
     ItemSkipReason,
     ItemState,
     ResolvedItem,
+    ResolveResult,
 )
-from yutto.types import AId, CId
+from yutto.types import AId, BvId, CId
 
 pytestmark = pytest.mark.processor
 
@@ -61,6 +62,33 @@ def test_resolved_item_is_a_typed_immutable_listing_snapshot():
         item.name = "changed"  # ty: ignore[invalid-assignment]
     with pytest.raises(ValidationError, match="Extra inputs"):
         ResolvedItem.model_validate({**payload, "play_url": "https://example.com/expiring"})
+
+
+@pytest.mark.parametrize("avid", [AId("808982399"), BvId("BV1f34y1k7D5"), BvId("bv1f34y1k7D5")])
+def test_listing_results_round_trip_through_json_with_typed_ids(avid: AId | BvId):
+    cid = CId("144541892")
+    item = ResolvedItem(
+        avid=avid,
+        cid=cid,
+        url="https://www.bilibili.com/video/av808982399?p=1",
+        name="P1",
+        title="标题",
+        cover_url="https://example.com/cover.jpg",
+        planned_path=Path("标题/P1"),
+        tags=("标签A", "标签B"),
+    )
+    assert item.avid is avid
+    assert item.cid is cid
+
+    restored_item = ResolvedItem.model_validate_json(item.model_dump_json())
+    restored_result = ResolveResult.model_validate_json(ResolveResult(items=(item,)).model_dump_json())
+
+    assert restored_item == item
+    assert type(restored_item.avid) is type(avid)
+    assert isinstance(restored_item.cid, CId)
+    assert restored_result.items == (item,)
+    assert type(restored_result.items[0].avid) is type(avid)
+    assert isinstance(restored_result.items[0].cid, CId)
 
 
 def test_item_result_validates_skip_reason_without_requiring_artifacts():

--- a/tests/test_core/test_task_service.py
+++ b/tests/test_core/test_task_service.py
@@ -19,9 +19,10 @@ from yutto.core.events import (
 from yutto.core.execution import ExecutionScopeFactory, RequestExecutionScopeFactory
 from yutto.core.operation import emit_download_event
 from yutto.core.request import DownloadRequest
-from yutto.core.result import DownloadResult, ItemSkipReason
+from yutto.core.result import DownloadResult, ItemSkipReason, ResolvedItem
 from yutto.core.task_service import DownloadTaskService, _encode_runtime_event
 from yutto.runtime import TaskState
+from yutto.types import AId, CId
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
@@ -139,36 +140,26 @@ def test_runtime_event_encoding_preserves_protocol(event, expected):
 def test_download_event_annotations_are_available_at_runtime():
     assert get_type_hints(DownloadArtifactCreated)["path"] is Path
     assert get_type_hints(DownloadItemSkipped)["reason"] is ItemSkipReason
+    assert get_type_hints(DownloadItemListed)["item"] is ResolvedItem
 
 
 def test_encode_runtime_event_item_listed_carries_full_wire_fields():
-    kind, data = _encode_runtime_event(
-        DownloadItemListed(
-            avid="1",
-            cid="10",
-            url="https://www.bilibili.com/video/av1?p=1",
-            name="P1",
-            title="标题",
-            cover_url="https://example.com/cover.jpg",
-            planned_path=Path("标题/P1"),
-            display_group="标题",
-            uploader="某UP主",
-            description="视频简介",
-            tags=("标签A", "标签B"),
-        )
+    item = ResolvedItem(
+        avid=AId("1"),
+        cid=CId("10"),
+        url="https://www.bilibili.com/video/av1?p=1",
+        name="P1",
+        title="标题",
+        cover_url="https://example.com/cover.jpg",
+        planned_path=Path("标题/P1"),
+        display_group="标题",
+        uploader="某UP主",
+        description="视频简介",
+        tags=("标签A", "标签B"),
     )
+    kind, data = _encode_runtime_event(DownloadItemListed(item=item))
     assert kind == "item_listed"
-    # 逐字段钉死 wire 编码：planned_path 必须是 POSIX 风格字符串，tags 必须是 list
-    assert data == {
-        "avid": "1",
-        "cid": "10",
-        "url": "https://www.bilibili.com/video/av1?p=1",
-        "name": "P1",
-        "title": "标题",
-        "cover_url": "https://example.com/cover.jpg",
-        "planned_path": "标题/P1",
-        "display_group": "标题",
-        "uploader": "某UP主",
-        "description": "视频简介",
-        "tags": ["标签A", "标签B"],
-    }
+    assert data["avid"] == "1"
+    assert data["cid"] == "10"
+    assert data["planned_path"] == "标题/P1"
+    assert data["tags"] == ["标签A", "标签B"]

--- a/tests/test_processor/test_download_result.py
+++ b/tests/test_processor/test_download_result.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 
 from yutto.core.execution import ExecutionScope
-from yutto.core.result import Artifact, ArtifactKind, ItemResult, ItemSkipReason, ItemState
+from yutto.core.result import Artifact, ArtifactKind, ItemResult, ItemSkipReason, ItemState, ResolvedItem
 from yutto.downloader.downloader import process_download
 from yutto.types import AId, CId
 from yutto.utils.danmaku import write_danmaku
@@ -47,19 +47,19 @@ def make_options(tmp_path: Path) -> DownloaderOptions:
 
 
 def make_resource_only_episode() -> EpisodeData:
+    planned_path = Path("series/episode")
     return {
         "info": {
-            "avid": AId("1"),
-            "cid": CId("1"),
-            "url": "https://www.bilibili.com/video/av1?p=1",
-            "name": "episode",
-            "title": "episode",
-            "cover_url": "",
-            "uploader": "",
-            "description": "",
-            "tags": [],
-            "path": Path("series/episode"),
-            "display_group": None,
+            "listing": ResolvedItem(
+                avid=AId("1"),
+                cid=CId("1"),
+                url="https://www.bilibili.com/video/av1?p=1",
+                name="episode",
+                title="episode",
+                cover_url="",
+                planned_path=planned_path,
+            ),
+            "path": planned_path,
         },
         "videos": [],
         "audios": [],

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -11,7 +11,7 @@ from returns.result import Success
 import yutto.download_manager as download_manager_module
 from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
 from yutto.core.request import DownloadRequest
-from yutto.core.result import DownloadResult, ItemResult, ItemState
+from yutto.core.result import DownloadResult, ItemResult, ItemState, ResolvedItem
 from yutto.download_manager import (
     DownloadManager,
     ensure_output_path_is_scoped,
@@ -38,19 +38,20 @@ pytestmark = pytest.mark.processor
 
 
 def make_episode(path: str, display_group: str | None = None) -> EpisodeData:
+    planned_path = Path(path)
     return {
         "info": {
-            "avid": AId("1"),
-            "cid": CId("1"),
-            "url": "https://www.bilibili.com/video/av1?p=1",
-            "name": Path(path).name,
-            "title": Path(path).name,
-            "cover_url": "",
-            "uploader": "",
-            "description": "",
-            "tags": [],
-            "path": Path(path),
-            "display_group": display_group,
+            "listing": ResolvedItem(
+                avid=AId("1"),
+                cid=CId("1"),
+                url="https://www.bilibili.com/video/av1?p=1",
+                name=planned_path.name,
+                title=planned_path.name,
+                cover_url="",
+                planned_path=planned_path,
+                display_group=display_group,
+            ),
+            "path": planned_path,
         },
         "videos": [],
         "audios": [],
@@ -459,6 +460,7 @@ def test_ensure_unique_path_updates_episode_and_only_warns_on_rename(monkeypatch
 
     assert result is renamed_episode
     assert result["info"]["path"] == Path("group/video (1).mp4")
+    assert result["info"]["listing"].planned_path == Path("group/video.mp4")
     assert resolved_paths == [str(Path("group/video.mp4"))]
     assert warnings == ["文件名重复，已重命名为 video (1).mp4"]
 

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -36,19 +36,36 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.processor
 
 
-def make_info(name: str, display_group: str | None = None) -> EpisodeInfo:
+def make_info(
+    name: str,
+    display_group: str | None = None,
+    *,
+    description: str = "视频简介",
+    tags: tuple[str, ...] = ("标签A", "标签B"),
+) -> EpisodeInfo:
+    planned_path = Path(f"标题/{name}")
     return {
-        "avid": AId("1"),
-        "cid": CId("10"),
-        "url": "https://www.bilibili.com/video/av1?p=1",
-        "name": name,
-        "title": "标题",
-        "cover_url": "https://example.com/cover.jpg",
-        "uploader": "某UP主",
-        "description": "视频简介",
-        "tags": ["标签A", "标签B"],
-        "path": Path(f"标题/{name}"),
-        "display_group": display_group,
+        "listing": ResolvedItem(
+            avid=AId("1"),
+            cid=CId("10"),
+            url="https://www.bilibili.com/video/av1?p=1",
+            name=name,
+            title="标题",
+            cover_url="https://example.com/cover.jpg",
+            uploader="某UP主",
+            description=description,
+            tags=tags,
+            planned_path=planned_path,
+            display_group=display_group,
+        ),
+        "path": planned_path,
+    }
+
+
+def copy_info(info: EpisodeInfo) -> EpisodeInfo:
+    return {
+        "listing": info["listing"].model_copy(),
+        "path": info["path"],
     }
 
 
@@ -104,8 +121,8 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
         items = await manager.resolve_items(ExecutionScope(client), request)
 
     expected_item = ResolvedItem(
-        avid="1",
-        cid="10",
+        avid=AId("1"),
+        cid=CId("10"),
         url="https://www.bilibili.com/video/av1?p=1",
         name="P1",
         title="标题",
@@ -122,20 +139,14 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
     assert executed == []
     assert sink.events == [
         DownloadStageChanged(name=DownloadStage.RESOLVING),
-        DownloadItemListed(
-            avid="1",
-            cid="10",
-            url="https://www.bilibili.com/video/av1?p=1",
-            name="P1",
-            title="标题",
-            cover_url="https://example.com/cover.jpg",
-            planned_path=Path("标题/P1"),
-            display_group="标题",
-            uploader="某UP主",
-            description="视频简介",
-            tags=("标签A", "标签B"),
-        ),
+        DownloadItemListed(item=expected_item),
     ]
+    listed = sink.events[1]
+    assert isinstance(listed, DownloadItemListed)
+    assert listed.item is items.items[0]
+    info["path"] = Path("标题/下载期重命名")
+    assert items.items[0].tags == ("标签A", "标签B")
+    assert items.items[0].planned_path == Path("标题/P1")
 
 
 @as_sync
@@ -148,8 +159,15 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
         resolved.append("ran")
         return None
 
-    streamed = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
-    final_copy = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+    first_info = make_info("P1", display_group="标题", description="先完成", tags=("first",))
+    second_info = make_info("P1", display_group="标题", description="后完成", tags=("second",))
+    final_first_info = copy_info(first_info)
+    final_second_info = copy_info(second_info)
+
+    streamed_first = ResolvableEpisode(info=first_info, resolve_data=noop)
+    streamed_second = ResolvableEpisode(info=second_info, resolve_data=noop)
+    final_first = ResolvableEpisode(info=final_first_info, resolve_data=noop)
+    final_second = ResolvableEpisode(info=final_second_info, resolve_data=noop)
     late = ResolvableEpisode(info=make_info("P2", display_group="标题"), resolve_data=noop)
 
     class FakeExtractor(BatchExtractor):
@@ -166,11 +184,13 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
             *,
             on_item: EpisodeListedCallback | None = None,
         ) -> ExtractorResolveOutcome:
-            # 流式提取器：解析过程中先推送 P1；P2 留给 resolve_items 收尾补发
+            # first/second 的旧五字段 key 相同但 metadata 不同；最终顺序反转，
+            # 用于保证 occurrence 由完整 canonical snapshot 匹配。
             assert on_item is not None
-            await on_item(streamed)
-            await on_item(streamed)
-            return ResolveOutcome(items=(final_copy, late))
+            await on_item(streamed_first)
+            await on_item(streamed_first)
+            await on_item(streamed_second)
+            return ResolveOutcome(items=(final_second, final_first, late))
 
     async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
@@ -191,37 +211,51 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
         items = await manager.resolve_items(ExecutionScope(client), request)
 
     listed = [event for event in sink.events if isinstance(event, DownloadItemListed)]
-    # 每条恰好一次：流式推送的 P1 在前（提取中），P2 收尾补发
-    assert [event.name for event in listed] == ["P1", "P2"]
+    # 同一对象的重复 callback 不会重复发送；P2 在收尾阶段补发。
+    assert [event.item.name for event in listed] == ["P1", "P1", "P2"]
+    assert [event.item.description for event in listed] == ["先完成", "后完成", "视频简介"]
     # 返回列表保持提取器给出的顺序
-    assert [item.name for item in items.items] == ["P1", "P2"]
+    assert [item.name for item in items.items] == ["P1", "P1", "P2"]
+    assert [item.description for item in items.items] == ["后完成", "先完成", "视频简介"]
+    # event 与 result 复用同一 snapshot，即使最终 extractor 返回的是等值 copy。
+    assert listed[0].item is items.items[1]
+    assert listed[1].item is items.items[0]
+    assert listed[2].item is items.items[2]
     # resolve-only 路径不会调用 data resolver，也不会提前创建 coroutine
     assert resolved == []
 
 
 @as_sync
 async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.MonkeyPatch):
-    """字段完全相同的独立结果条目仍各自对应一条 item_listed 事件。"""
+    """流式回调中字段完全相同的独立条目仍各自对应一条事件。"""
 
     async def noop() -> EpisodeData | None:
         return None
 
     first = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
     second = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+    final_first = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
+    final_second = ResolvableEpisode(info=make_info("P1", display_group="标题"), resolve_data=noop)
 
-    class FakeExtractor:
+    class FakeExtractor(BatchExtractor):
         def resolve_shortcut(self, id: str) -> tuple[bool, str]:
             return True, f"https://example.com/{id}"
 
         def match(self, url: str) -> bool:
             return url == "https://example.com/BV1equal"
 
-        async def __call__(
+        async def extract(
             self,
             scope: ExecutionScope,
             options: ExtractorOptions,
+            *,
+            on_item: EpisodeListedCallback | None = None,
         ) -> ExtractorResolveOutcome:
-            return ResolveOutcome(items=(first, second))
+            assert on_item is not None
+            await on_item(first)
+            await on_item(first)
+            await on_item(second)
+            return ResolveOutcome(items=(final_first, final_second))
 
     async def fake_validate_user_info(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
@@ -243,8 +277,12 @@ async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.Mon
 
     listed = [event for event in sink.events if isinstance(event, DownloadItemListed)]
     assert len(listed) == len(outcome.items) == 2
-    assert listed[0] == listed[1]
+    assert listed[0].item == listed[1].item
+    assert listed[0].item is not listed[1].item
     assert outcome.items[0] == outcome.items[1]
+    assert outcome.items[0] is not outcome.items[1]
+    assert listed[0].item is outcome.items[0]
+    assert listed[1].item is outcome.items[1]
 
 
 class _FakeClientContext:

--- a/tests/test_server/test_service.py
+++ b/tests/test_server/test_service.py
@@ -9,9 +9,19 @@ import pytest
 from pydantic import BaseModel
 
 from yutto.auth import load_auth
+from yutto.core.events import DownloadItemListed
 from yutto.core.execution import RequestExecutionScopeFactory
 from yutto.core.request import DownloadRequest
-from yutto.core.result import Artifact, ArtifactKind, DownloadResult, ItemResult, ItemState
+from yutto.core.result import (
+    Artifact,
+    ArtifactKind,
+    DownloadResult,
+    ItemResult,
+    ItemState,
+    ResolvedItem,
+    ResolveResult,
+)
+from yutto.core.task_service import _encode_runtime_event
 from yutto.runtime import EventReplay, TaskError, TaskEvent, TaskSnapshot, TaskState
 from yutto.server.service import (
     ServerPolicy,
@@ -22,6 +32,7 @@ from yutto.server.service import (
     snapshot_summary_to_json,
     snapshot_to_json,
 )
+from yutto.types import AId, CId
 from yutto.utils.functional import as_sync
 
 pytestmark = pytest.mark.processor
@@ -376,6 +387,94 @@ def test_download_result_serializes_paths_enums_and_tuples():
             }
         ]
     }
+
+
+def test_listing_event_and_result_share_jsonrpc_wire_shape():
+    created_at = datetime(2026, 7, 12, 11, 12, 13, tzinfo=UTC)
+
+    def serialize_both(item: ResolvedItem) -> tuple[dict[str, object], dict[str, object]]:
+        kind, data = _encode_runtime_event(DownloadItemListed(item=item))
+        event = TaskEvent(
+            task_id="task-listing",
+            seq=1,
+            kind=kind,
+            state=TaskState.RUNNING,
+            created_at=created_at,
+            data=data,
+        )
+        snapshot = TaskSnapshot[DownloadRequest, ResolveResult](
+            task_id="task-listing",
+            state=TaskState.COMPLETED,
+            payload=make_request(),
+            result=ResolveResult(items=(item,)),
+            error=None,
+            created_at=created_at,
+            started_at=created_at,
+            finished_at=created_at,
+            last_event_seq=1,
+        )
+        event_wire = cast("dict[str, object]", event_to_json(event)["data"])
+        result = cast("dict[str, object]", snapshot_to_json(snapshot)["result"])
+        result_wire = cast("list[dict[str, object]]", result["items"])[0]
+        return event_wire, result_wire
+
+    item = ResolvedItem(
+        avid=AId("1"),
+        cid=CId("10"),
+        url="https://www.bilibili.com/video/av1?p=1",
+        name="P1",
+        title="标题",
+        cover_url="https://example.com/cover.jpg",
+        planned_path=Path("标题/P1"),
+        display_group="标题",
+        uploader="某UP主",
+        description="视频简介",
+        tags=("标签A", "标签B"),
+    )
+    expected = {
+        "avid": "1",
+        "cid": "10",
+        "url": "https://www.bilibili.com/video/av1?p=1",
+        "name": "P1",
+        "title": "标题",
+        "cover_url": "https://example.com/cover.jpg",
+        "planned_path": "标题/P1",
+        "display_group": "标题",
+        "uploader": "某UP主",
+        "description": "视频简介",
+        "tags": ["标签A", "标签B"],
+    }
+    event_wire, result_wire = serialize_both(item)
+
+    assert event_wire == result_wire == expected
+    assert type(event_wire["avid"]) is str
+    assert type(event_wire["planned_path"]) is str
+    assert type(event_wire["tags"]) is list
+
+    default_item = ResolvedItem(
+        avid=AId("2"),
+        cid=CId("20"),
+        url="https://www.bilibili.com/video/av2?p=1",
+        name="单集",
+        title="单集",
+        cover_url="",
+        planned_path=Path("单集"),
+    )
+    default_expected = {
+        "avid": "2",
+        "cid": "20",
+        "url": "https://www.bilibili.com/video/av2?p=1",
+        "name": "单集",
+        "title": "单集",
+        "cover_url": "",
+        "planned_path": "单集",
+        "display_group": None,
+        "uploader": "",
+        "description": "",
+        "tags": [],
+    }
+
+    assert serialize_both(default_item) == (default_expected, default_expected)
 
 
 def test_event_and_replay_serialization_use_enum_values_iso_dates_and_redaction():


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

resolve listing 的同一组字段此前同时存在于 `EpisodeInfo`、`ResolvedItem`、`DownloadItemListed` 和手写 wire 字典中。新增字段需要同步修改多个层次，而且流式 `item_listed.data` 与最终 `result.items[]` 使用不同序列化路径，存在 schema 漂移风险。

同时，listing 时的计划路径需要保持稳定，不能被下载期文件名去重产生的实际路径覆盖。

## 解决方案

- 将 `ResolvedItem` 作为唯一、不可变的 canonical listing snapshot，保留 `AvId` / `CId` typed ID，并显式定义稳定 JSON 序列化。
- 将 `EpisodeInfo` 收敛为 canonical `listing` 与独立 mutable `path` 的组合；下载期去重只调整实际路径，不回写 `planned_path`。
- 让 `DownloadItemListed` 和 `ResolveResult` 复用同一 snapshot，并通过同一个 listing projector 生成 JSON-RPC v1 wire shape。
- 使用完整 snapshot + occurrence queue 匹配流式回调与最终结果，保留等值但独立条目的计数、顺序和 identity 复用语义。
- 增加 event/result parity、typed ID、POSIX path、tuple/list、默认/null 字段和 equal occurrence contract tests，并补充 server 文档。

对外 CLI 与 JSON-RPC v1 wire shape 不变；有意变化仅限内部 extractor 的 `EpisodeInfo` 结构。

### 验证

- `just fmt`
- `just lint`
- Python 3.11 CI 集合（排除单个外部 GitHub raw 下载样例）：`238 passed, 1 skipped`
- Python 3.14 定向 core / processor / server：`74 passed`
- VitePress 文档构建通过

本地完整 `just ci-test 3.11` 中，`tests/test_processor/test_downloader.py::test_150_kB_downloader` 因 GitHub raw 样例请求超时失败；排除该外部网络用例后其余测试全部通过。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [x] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol ultra)</sup>
</div>