### PR TITLE
♻️ refactor: establish presentation boundary

### DIFF
--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -14,6 +14,7 @@ from yutto.cli.event_renderer import CliApplicationEventRenderer
 from yutto.cli.request_adapter import download_request_from_namespace
 from yutto.core.application import YuttoApplication
 from yutto.core.execution import ExecutionScopeFactory, RequestExecutionScopeFactory
+from yutto.core.operation import bind_download_report_sink
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, YuttoBaseException
 from yutto.input_parser import file_scheme_parser
@@ -54,30 +55,36 @@ class _CliAuthAnnouncer:
 
 def main():
     parser = cli()
-    args = parser.parse_args(handle_default_subcommand(sys.argv[1:]))
+    renderer = CliApplicationEventRenderer()
+    with bind_download_report_sink(renderer.report):
+        args = parser.parse_args(handle_default_subcommand(sys.argv[1:]))
     match args.command:
         case "download":
-            try:
-                initial_validation(args)
-                args_list = flatten_args(args, parser)
-                auth_list = [hydrate_auth(item) for item in args_list]
-                requests = [download_request_from_namespace(item) for item in args_list]
-                credentials_by_request = {id(request): auth for request, auth in zip(requests, auth_list, strict=True)}
+            renderer.progress_enabled = not args.no_progress and sys.stdout.isatty()
+            with bind_download_report_sink(renderer.report):
+                try:
+                    initial_validation(args)
+                    args_list = flatten_args(args, parser)
+                    auth_list = [hydrate_auth(item) for item in args_list]
+                    requests = [download_request_from_namespace(item) for item in args_list]
+                    credentials_by_request = {
+                        id(request): auth for request, auth in zip(requests, auth_list, strict=True)
+                    }
 
-                def resolve_credentials(request: DownloadRequest) -> AuthInfo | None:
-                    return credentials_by_request[id(request)]
+                    def resolve_credentials(request: DownloadRequest) -> AuthInfo | None:
+                        return credentials_by_request[id(request)]
 
-                scope_factory = RequestExecutionScopeFactory(
-                    resolve_credentials,
-                    on_open=_CliAuthAnnouncer(),
-                )
-                run_download(scope_factory, requests)
-            except YuttoBaseException as e:
-                Logger.error(e.message)
-                sys.exit(e.code.value)
-            except (KeyboardInterrupt, asyncio.exceptions.CancelledError):
-                Logger.info("已终止下载，再次运行即可继续下载～")
-                sys.exit(ErrorCode.PAUSED_DOWNLOAD.value)
+                    scope_factory = RequestExecutionScopeFactory(
+                        resolve_credentials,
+                        on_open=_CliAuthAnnouncer(),
+                    )
+                    run_download(scope_factory, requests, renderer)
+                except YuttoBaseException as e:
+                    Logger.error(e.message)
+                    sys.exit(e.code.value)
+                except (KeyboardInterrupt, asyncio.exceptions.CancelledError):
+                    Logger.info("已终止下载，再次运行即可继续下载～")
+                    sys.exit(ErrorCode.PAUSED_DOWNLOAD.value)
         case "auth":
             match args.auth_command:
                 case "login":
@@ -93,7 +100,8 @@ def main():
             from yutto.server.command import run_server_command
 
             try:
-                run_server_command(args)
+                with bind_download_report_sink(renderer.report):
+                    run_server_command(args)
             except KeyboardInterrupt:
                 Logger.info("yutto server 已停止")
             except (FFmpegNotFoundError, OSError, ValueError) as e:
@@ -108,13 +116,16 @@ def main():
 async def run_download(
     scope_factory: ExecutionScopeFactory,
     requests: list[DownloadRequest],
+    renderer: CliApplicationEventRenderer,
 ):
-    application = YuttoApplication(
-        scope_factory,
-        workflow=DownloadManager(),
-        event_sink=CliApplicationEventRenderer(),
-    )
-    await application.download_all(requests)
+    async with renderer:
+        application = YuttoApplication(
+            scope_factory,
+            workflow=DownloadManager(),
+            event_sink=renderer,
+        )
+        with bind_download_report_sink(renderer.report):
+            await application.download_all(requests)
 
 
 async def announce_cli_auth(scope: ExecutionScope, _request: DownloadRequest) -> None:

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from returns.result import Failure
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
@@ -108,7 +108,10 @@ async def get_bangumi_playurl(
     video_info = resp_json["result"]["video_info"]
     if video_info["is_preview"] == 1:
         # Maybe always 0 in v2 API
-        emit_download_report(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）", "warning")
+        emit_download_report(
+            f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）",
+            ReportLevel.WARNING,
+        )
     if video_info.get("dash") is None:
         raise UnSupportedTypeError(f"该视频（{format_ids(avid, cid)}）尚不支持 DASH 格式")
 
@@ -159,7 +162,7 @@ async def get_bangumi_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> 
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
         emit_download_report(
             f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}",
-            "warning",
+            ReportLevel.WARNING,
         )
         return []
     subtitles_info = subtitles_json_info["data"]["subtitle"]
@@ -171,7 +174,7 @@ async def get_bangumi_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> 
         if subtitle_url is None or not subtitle_url.strip():
             emit_download_report(
                 f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}",
-                "warning",
+                ReportLevel.WARNING,
             )
             continue
 

--- a/src/yutto/api/bangumi.py
+++ b/src/yutto/api/bangumi.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from returns.result import Failure
 
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
@@ -16,7 +17,6 @@ from yutto.types import (
     VideoUrlMeta,
     format_ids,
 )
-from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.functional import data_has_chained_keys
 from yutto.utils.metadata import MetaData
@@ -108,7 +108,7 @@ async def get_bangumi_playurl(
     video_info = resp_json["result"]["video_info"]
     if video_info["is_preview"] == 1:
         # Maybe always 0 in v2 API
-        Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
+        emit_download_report(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）", "warning")
     if video_info.get("dash") is None:
         raise UnSupportedTypeError(f"该视频（{format_ids(avid, cid)}）尚不支持 DASH 格式")
 
@@ -157,7 +157,10 @@ async def get_bangumi_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> 
     if subtitles_json_info is None:
         return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
-        Logger.warning(f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}")
+        emit_download_report(
+            f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}",
+            "warning",
+        )
         return []
     subtitles_info = subtitles_json_info["data"]["subtitle"]
     results: list[MultiLangSubtitle] = []
@@ -166,7 +169,10 @@ async def get_bangumi_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> 
 
         # 检查 subtitle_url 是否有效
         if subtitle_url is None or not subtitle_url.strip():
-            Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
+            emit_download_report(
+                f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}",
+                "warning",
+            )
             continue
 
         subtitle_text = (await Fetcher.fetch_json(scope, "https:" + subtitle_url)).value_or(None)

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from returns.result import Failure
 
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
@@ -15,7 +16,6 @@ from yutto.types import (
     VideoUrlMeta,
     format_ids,
 )
-from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.functional import data_has_chained_keys
 from yutto.utils.metadata import MetaData
@@ -91,7 +91,7 @@ async def get_cheese_playurl(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
         )
     if resp_json["data"]["is_preview"] == 1:
-        Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
+        emit_download_report(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）", "warning")
     if resp_json["data"].get("dash") is None:
         raise UnSupportedTypeError(f"该视频（{format_ids(avid, cid)}）尚不支持 DASH 格式")
     return (
@@ -127,7 +127,10 @@ async def get_cheese_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> l
     if subtitles_json_info is None:
         return []
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
-        Logger.warning(f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}")
+        emit_download_report(
+            f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}",
+            "warning",
+        )
         return []
     subtitles_info = subtitles_json_info["data"]["subtitle"]
     results: list[MultiLangSubtitle] = []
@@ -136,7 +139,10 @@ async def get_cheese_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> l
 
         # 检查 subtitle_url 是否有效
         if subtitle_url is None or not subtitle_url.strip():
-            Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
+            emit_download_report(
+                f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}",
+                "warning",
+            )
             continue
 
         subtitle_text = (await Fetcher.fetch_json(scope, "https:" + subtitle_url)).value_or(None)

--- a/src/yutto/api/cheese.py
+++ b/src/yutto/api/cheese.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from returns.result import Failure
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import NoAccessPermissionError, UnSupportedTypeError
 from yutto.media.codec import audio_codec_map, video_codec_map
 from yutto.types import (
@@ -91,7 +91,10 @@ async def get_cheese_playurl(
             f"无法获取该视频链接（{format_ids(avid, cid)}），原因：{resp_json.get('message')}"
         )
     if resp_json["data"]["is_preview"] == 1:
-        emit_download_report(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）", "warning")
+        emit_download_report(
+            f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）",
+            ReportLevel.WARNING,
+        )
     if resp_json["data"].get("dash") is None:
         raise UnSupportedTypeError(f"该视频（{format_ids(avid, cid)}）尚不支持 DASH 格式")
     return (
@@ -129,7 +132,7 @@ async def get_cheese_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> l
     if not data_has_chained_keys(subtitles_json_info, ["data", "subtitle", "subtitles"]):
         emit_download_report(
             f"无法获取该视频的字幕（{format_ids(avid, cid)}），原因：{subtitles_json_info.get('message')}",
-            "warning",
+            ReportLevel.WARNING,
         )
         return []
     subtitles_info = subtitles_json_info["data"]["subtitle"]
@@ -141,7 +144,7 @@ async def get_cheese_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -> l
         if subtitle_url is None or not subtitle_url.strip():
             emit_download_report(
                 f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}",
-                "warning",
+                ReportLevel.WARNING,
             )
             continue
 

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Any, cast
 from returns.result import Failure, Result, Success
 
 from yutto.api.user_info import encode_wbi, get_wbi_img
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import NotLoginError
 from yutto.types import BvId, FavouriteMetaData, FavouriteVideoData, FId
-from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
@@ -51,10 +51,10 @@ async def get_user_space_all_videos_avids(
                         if _should_stop_user_space_pagination(video_infos, stop_before_timestamp):
                             break
                     case Failure(error):
-                        Logger.error(f"获取用户空间视频列表第 {pn} 页失败：{error}")
+                        emit_download_report(f"获取用户空间视频列表第 {pn} 页失败：{error}", "error")
                         break
             case Failure(error):
-                Logger.error(f"获取用户空间视频列表第 {pn} 页失败：{error}")
+                emit_download_report(f"获取用户空间视频列表第 {pn} 页失败：{error}", "error")
                 break
         pn += 1
     return all_avid
@@ -103,15 +103,16 @@ async def get_user_name(scope: ExecutionScope, mid: MId) -> str:
         case Success({"code": 0, "data": {"name": username}}):
             return str(username)
         case Success({"code": -404}):
-            Logger.warning(f"用户 {mid} 不存在，疑似注销或被封禁")
+            emit_download_report(f"用户 {mid} 不存在，疑似注销或被封禁", "warning")
         case Success({"message": message}):
-            Logger.error(
-                f"获取用户名失败了呢，错误信息：{message}，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～"
+            emit_download_report(
+                f"获取用户名失败了呢，错误信息：{message}，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～",
+                "error",
             )
         case Success(user_info):
-            Logger.error(f"获取用户名失败了呢，返回值异常：{user_info}")
+            emit_download_report(f"获取用户名失败了呢，返回值异常：{user_info}", "error")
         case Failure(error):
-            Logger.error(f"获取用户名失败：{error}")
+            emit_download_report(f"获取用户名失败：{error}", "error")
     return f"「用户{mid}」"
 
 

--- a/src/yutto/api/space.py
+++ b/src/yutto/api/space.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 from returns.result import Failure, Result, Success
 
 from yutto.api.user_info import encode_wbi, get_wbi_img
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import NotLoginError
 from yutto.types import BvId, FavouriteMetaData, FavouriteVideoData, FId
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
@@ -51,10 +51,10 @@ async def get_user_space_all_videos_avids(
                         if _should_stop_user_space_pagination(video_infos, stop_before_timestamp):
                             break
                     case Failure(error):
-                        emit_download_report(f"获取用户空间视频列表第 {pn} 页失败：{error}", "error")
+                        emit_download_report(f"获取用户空间视频列表第 {pn} 页失败：{error}", ReportLevel.ERROR)
                         break
             case Failure(error):
-                emit_download_report(f"获取用户空间视频列表第 {pn} 页失败：{error}", "error")
+                emit_download_report(f"获取用户空间视频列表第 {pn} 页失败：{error}", ReportLevel.ERROR)
                 break
         pn += 1
     return all_avid
@@ -103,16 +103,16 @@ async def get_user_name(scope: ExecutionScope, mid: MId) -> str:
         case Success({"code": 0, "data": {"name": username}}):
             return str(username)
         case Success({"code": -404}):
-            emit_download_report(f"用户 {mid} 不存在，疑似注销或被封禁", "warning")
+            emit_download_report(f"用户 {mid} 不存在，疑似注销或被封禁", ReportLevel.WARNING)
         case Success({"message": message}):
             emit_download_report(
                 f"获取用户名失败了呢，错误信息：{message}，可尝试检查 `--auth` 参数正确性或者通过 `yutto auth login` 登录账号后重试～",
-                "error",
+                ReportLevel.ERROR,
             )
         case Success(user_info):
-            emit_download_report(f"获取用户名失败了呢，返回值异常：{user_info}", "error")
+            emit_download_report(f"获取用户名失败了呢，返回值异常：{user_info}", ReportLevel.ERROR)
         case Failure(error):
-            emit_download_report(f"获取用户名失败：{error}", "error")
+            emit_download_report(f"获取用户名失败：{error}", ReportLevel.ERROR)
     return f"「用户{mid}」"
 
 

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from returns.result import Failure
 
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import (
     NoAccessPermissionError,
     NotFoundError,
@@ -21,8 +22,6 @@ from yutto.types import (
     VideoUrlMeta,
     format_ids,
 )
-from yutto.utils.console.colorful import colored_string
-from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.functional.data_access import data_has_chained_keys
 from yutto.utils.metadata import Actor, ChapterInfoData, MetaData
@@ -100,7 +99,7 @@ async def get_ugc_video_info(scope: ExecutionScope, avid: AvId) -> _UgcVideoInfo
     assert res_json_data is not None, "响应数据无 data 域"
     if res_json_data.get("forward"):
         forward_avid = AId(str(res_json_data["forward"]))
-        Logger.info(f"视频 {avid} 撞车了哦！正在跳转到原视频 {forward_avid}～")
+        emit_download_report(f"视频 {avid} 撞车了哦！正在跳转到原视频 {forward_avid}～")
         return await get_ugc_video_info(scope, forward_avid)
     episode_id = EpisodeId("")
     if res_json_data.get("redirect_url") and (ep_match := regex_ep.match(res_json_data["redirect_url"])):
@@ -147,7 +146,7 @@ async def get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
     list_api = "https://api.bilibili.com/x/player/pagelist?aid={aid}&bvid={bvid}&jsonp=jsonp"
     res_json = (await Fetcher.fetch_json(scope, list_api.format(**avid.to_dict()))).value_or(None)
     if res_json is None or res_json.get("data") is None:
-        Logger.warning(f"啊叻？视频 {avid} 不见了诶")
+        emit_download_report(f"啊叻？视频 {avid} 不见了诶", "warning")
         return result
 
     # 对无意义的分 p 视频名进行修改
@@ -177,14 +176,20 @@ def show_ai_translation_language(resp_json: dict[str, Any], ai_translation_langu
     # AI 原声翻译功能检测和展示，Example: BV1G3HEz5ETU
     if not data_has_chained_keys(resp_json, ["data", "language", "items"]):
         if ai_translation_language:
-            Logger.warning(f"该视频未启用 AI 原声翻译功能, 无法获得 {ai_translation_language} 语言翻译哦～")
+            emit_download_report(
+                f"该视频未启用 AI 原声翻译功能, 无法获得 {ai_translation_language} 语言翻译哦～",
+                "warning",
+            )
         return
     if not resp_json["data"]["language"]["items"]:
         if ai_translation_language:
-            Logger.warning(f"该视频未启用 AI 原声翻译功能, 无法获得 {ai_translation_language} 语言翻译哦～")
+            emit_download_report(
+                f"该视频未启用 AI 原声翻译功能, 无法获得 {ai_translation_language} 语言翻译哦～",
+                "warning",
+            )
         return
     current_lang_id = -1
-    Logger.info("该视频已启用的 AI 原声翻译语言列表：")
+    emit_download_report("该视频已启用的 AI 原声翻译语言列表：")
     for i, lang_info in enumerate(resp_json["data"]["language"]["items"]):
         if lang_info["lang"] == ai_translation_language:
             current_lang_id = i
@@ -195,15 +200,16 @@ def show_ai_translation_language(resp_json: dict[str, Any], ai_translation_langu
             lang_info["lang"],
         )
         if i == current_lang_id:
-            log = colored_string(log, "green")
-        Logger.info(log)
+            emit_download_report(log, color="green")
+        else:
+            emit_download_report(log)
     if current_lang_id != -1:
         # language found, do nothing
         return
     if ai_translation_language:
-        Logger.warning(f"该视频未为语言 {ai_translation_language} 支持 AI 原声翻译功能哦～")
+        emit_download_report(f"该视频未为语言 {ai_translation_language} 支持 AI 原声翻译功能哦～", "warning")
         return
-    Logger.info("若想启用 AI 原声翻译功能，可以使用 `--ai-translation-language=<code>` 参数指定目标语言喔～")
+    emit_download_report("若想启用 AI 原声翻译功能，可以使用 `--ai-translation-language=<code>` 参数指定目标语言喔～")
 
 
 async def get_ugc_video_playurl(
@@ -299,7 +305,10 @@ async def get_ugc_video_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -
 
         # 检查 subtitle_url 是否有效
         if subtitle_url is None or not subtitle_url.strip():
-            Logger.warning(f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}")
+            emit_download_report(
+                f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}",
+                "warning",
+            )
             continue
 
         subtitle_text = (await Fetcher.fetch_json(scope, "https:" + subtitle_url)).value_or(None)
@@ -321,7 +330,10 @@ async def get_ugc_video_chapters(scope: ExecutionScope, avid: AvId, cid: CId) ->
     if chapter_json_info is None:
         return []
     if not data_has_chained_keys(chapter_json_info, ["data", "view_points"]):
-        Logger.warning(f"无法获取该视频的章节信息（{format_ids(avid, cid)}），原因：{chapter_json_info.get('message')}")
+        emit_download_report(
+            f"无法获取该视频的章节信息（{format_ids(avid, cid)}），原因：{chapter_json_info.get('message')}",
+            "warning",
+        )
         return []
 
     raw_chapter_info = chapter_json_info["data"]["view_points"]
@@ -381,7 +393,7 @@ def _parse_actor_info(video_info: dict[str, Any]):
             )
         )
     else:
-        Logger.warning("未找到演职人员信息")
+        emit_download_report("未找到演职人员信息", "warning")
     return actors
 
 

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from returns.result import Failure
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportColor, ReportLevel, emit_download_report
 from yutto.exceptions import (
     NoAccessPermissionError,
     NotFoundError,
@@ -146,7 +146,7 @@ async def get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
     list_api = "https://api.bilibili.com/x/player/pagelist?aid={aid}&bvid={bvid}&jsonp=jsonp"
     res_json = (await Fetcher.fetch_json(scope, list_api.format(**avid.to_dict()))).value_or(None)
     if res_json is None or res_json.get("data") is None:
-        emit_download_report(f"啊叻？视频 {avid} 不见了诶", "warning")
+        emit_download_report(f"啊叻？视频 {avid} 不见了诶", ReportLevel.WARNING)
         return result
 
     # 对无意义的分 p 视频名进行修改
@@ -178,14 +178,14 @@ def show_ai_translation_language(resp_json: dict[str, Any], ai_translation_langu
         if ai_translation_language:
             emit_download_report(
                 f"该视频未启用 AI 原声翻译功能, 无法获得 {ai_translation_language} 语言翻译哦～",
-                "warning",
+                ReportLevel.WARNING,
             )
         return
     if not resp_json["data"]["language"]["items"]:
         if ai_translation_language:
             emit_download_report(
                 f"该视频未启用 AI 原声翻译功能, 无法获得 {ai_translation_language} 语言翻译哦～",
-                "warning",
+                ReportLevel.WARNING,
             )
         return
     current_lang_id = -1
@@ -200,14 +200,17 @@ def show_ai_translation_language(resp_json: dict[str, Any], ai_translation_langu
             lang_info["lang"],
         )
         if i == current_lang_id:
-            emit_download_report(log, color="green")
+            emit_download_report(log, color=ReportColor.GREEN)
         else:
             emit_download_report(log)
     if current_lang_id != -1:
         # language found, do nothing
         return
     if ai_translation_language:
-        emit_download_report(f"该视频未为语言 {ai_translation_language} 支持 AI 原声翻译功能哦～", "warning")
+        emit_download_report(
+            f"该视频未为语言 {ai_translation_language} 支持 AI 原声翻译功能哦～",
+            ReportLevel.WARNING,
+        )
         return
     emit_download_report("若想启用 AI 原声翻译功能，可以使用 `--ai-translation-language=<code>` 参数指定目标语言喔～")
 
@@ -307,7 +310,7 @@ async def get_ugc_video_subtitles(scope: ExecutionScope, avid: AvId, cid: CId) -
         if subtitle_url is None or not subtitle_url.strip():
             emit_download_report(
                 f"跳过无效的字幕URL（{format_ids(avid, cid)}），语言：{sub_info.get('lan_doc', '未知')}",
-                "warning",
+                ReportLevel.WARNING,
             )
             continue
 
@@ -332,7 +335,7 @@ async def get_ugc_video_chapters(scope: ExecutionScope, avid: AvId, cid: CId) ->
     if not data_has_chained_keys(chapter_json_info, ["data", "view_points"]):
         emit_download_report(
             f"无法获取该视频的章节信息（{format_ids(avid, cid)}），原因：{chapter_json_info.get('message')}",
-            "warning",
+            ReportLevel.WARNING,
         )
         return []
 
@@ -393,7 +396,7 @@ def _parse_actor_info(video_info: dict[str, Any]):
             )
         )
     else:
-        emit_download_report("未找到演职人员信息", "warning")
+        emit_download_report("未找到演职人员信息", ReportLevel.WARNING)
     return actors
 
 

--- a/src/yutto/auth.py
+++ b/src/yutto/auth.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
 import os
+import platform
 import re
 import tomllib
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 
-from yutto.cli.settings import xdg_config_home
-
 if TYPE_CHECKING:
     from argparse import Namespace
-    from pathlib import Path
 
 PROFILE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def xdg_config_home() -> Path:
+    if (env := os.environ.get("XDG_CONFIG_HOME")) and (path := Path(env)).is_absolute():
+        return path
+    home = Path.home()
+    if platform.system() == "Windows":
+        return home / "AppData" / "Roaming"
+    return home / ".config"
 
 
 class AuthInfo(TypedDict):

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -1,13 +1,116 @@
 from __future__ import annotations
 
-from yutto.core.events import DownloadBatchStarted, DownloadEvent, DownloadRequestQueued
+import asyncio
+from typing import TYPE_CHECKING, Self
+
+from yutto.core.events import (
+    DownloadBatchStarted,
+    DownloadEvent,
+    DownloadItemSkipped,
+    DownloadProgress,
+    DownloadRequestQueued,
+    DownloadStageChanged,
+)
+from yutto.core.result import ItemSkipReason
+from yutto.utils.console.attributes import get_terminal_size
+from yutto.utils.console.colorful import RGBColor, colored_string
+from yutto.utils.console.formatter import size_format
 from yutto.utils.console.logger import Badge, Logger
+
+if TYPE_CHECKING:
+    from yutto.core.operation import ReportColor, ReportLevel
+    from yutto.utils.console.colorful import Color, Style
+
+
+def _render_bar(data: float, color: Color, width: int) -> str:
+    length = width * min(max(data, 0), 1)
+    whole = int(length)
+    if whole == width:
+        return "━" * width
+    symbol = "╸━"[int((length - whole) * 2)]
+    return colored_string("━" * whole + symbol, fore=color) + colored_string(
+        "━" * (width - whole - 1),
+        fore=RGBColor(64, 64, 64),
+    )
 
 
 class CliApplicationEventRenderer:
+    def __init__(self, *, progress_enabled: bool = True):
+        self.progress_enabled = progress_enabled
+        self._progress_active = False
+        self._spinner_task: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> Self:
+        if self.progress_enabled:
+            self._spinner_task = asyncio.create_task(self._run_spinner())
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        if self._spinner_task is not None:
+            self._spinner_task.cancel()
+            await asyncio.gather(self._spinner_task, return_exceptions=True)
+        Logger.status.clear()
+
+    async def _run_spinner(self) -> None:
+        while True:
+            if not self._progress_active:
+                Logger.status.next_tick()
+            await asyncio.sleep(1)
+
+    def report(
+        self,
+        message: str,
+        level: ReportLevel,
+        badge: str | None,
+        color: ReportColor | None,
+    ) -> None:
+        if color is not None:
+            message = colored_string(message, fore=color)
+        if badge is not None:
+            Logger.custom(message, Badge(badge, fore="black", back="cyan"))
+            return
+        getattr(Logger, "print" if level == "plain" else level)(message)
+
     def emit(self, event: DownloadEvent) -> None:
         match event:
             case DownloadBatchStarted(total=total):
                 Logger.info(f"列表里共检测到 {total} 项")
             case DownloadRequestQueued(url=url, index=index, total=total):
                 Logger.custom(f"列表项 {url}", Badge(f"[{index}/{total}]", fore="black", back="cyan"))
+            case DownloadStageChanged():
+                self._progress_active = False
+            case DownloadProgress() as progress if self.progress_enabled:
+                self._progress_active = True
+                self._render_progress(progress)
+            case DownloadProgress():
+                pass
+            case DownloadItemSkipped(item=item, reason=ItemSkipReason.ALREADY_EXISTS):
+                Logger.info(f"文件 {item} 已存在")
+            case _:
+                pass
+
+    def _render_progress(self, progress: DownloadProgress) -> None:
+        is_fast = progress.speed_per_second >= 8 * 1024 * 1024
+        is_congested = progress.buffered_blocks > 2048
+        bar_color: Color = "red" if is_congested else ("green" if is_fast else "cyan")
+        bar_width = min(get_terminal_size()[0] - 40, 50)
+        bar = (
+            _render_bar(progress.current / progress.total, bar_color, bar_width)
+            if bar_width >= 10 and progress.total > 0
+            else ""
+        )
+        speed_color: Color = "green" if is_fast else "cyan"
+        speed_style: list[Style] | None = ["bold"] if is_fast else None
+        speed_suffix = "/⚡" if is_fast else "/s"
+        Logger.status.set(
+            "{}{:>10}/{:>10} {:>12}  ".format(
+                bar + " " if bar else "",
+                size_format(progress.current),
+                size_format(progress.total),
+                colored_string(
+                    size_format(progress.speed_per_second) + speed_suffix,
+                    fore=speed_color,
+                    style=speed_style,
+                ),
+            )
+        )

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -11,6 +11,7 @@ from yutto.core.events import (
     DownloadRequestQueued,
     DownloadStageChanged,
 )
+from yutto.core.operation import ReportColor, ReportLevel
 from yutto.core.result import ItemSkipReason
 from yutto.utils.console.attributes import get_terminal_size
 from yutto.utils.console.colorful import RGBColor, colored_string
@@ -18,7 +19,6 @@ from yutto.utils.console.formatter import size_format
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
-    from yutto.core.operation import ReportColor, ReportLevel
     from yutto.utils.console.colorful import Color, Style
 
 
@@ -65,11 +65,26 @@ class CliApplicationEventRenderer:
         color: ReportColor | None,
     ) -> None:
         if color is not None:
-            message = colored_string(message, fore=color)
+            report_colors: dict[ReportColor, Color] = {
+                ReportColor.BLUE: "blue",
+                ReportColor.GREEN: "green",
+                ReportColor.MAGENTA: "magenta",
+            }
+            message = colored_string(message, fore=report_colors[color])
         if badge is not None:
             Logger.custom(message, Badge(badge, fore="black", back="cyan"))
             return
-        getattr(Logger, "print" if level == "plain" else level)(message)
+        match level:
+            case ReportLevel.DEBUG:
+                Logger.debug(message)
+            case ReportLevel.ERROR:
+                Logger.error(message)
+            case ReportLevel.INFO:
+                Logger.info(message)
+            case ReportLevel.PLAIN:
+                Logger.print(message)
+            case ReportLevel.WARNING:
+                Logger.warning(message)
 
     def emit(self, event: DownloadEvent) -> None:
         match event:
@@ -92,6 +107,8 @@ class CliApplicationEventRenderer:
     def _render_progress(self, progress: DownloadProgress) -> None:
         is_fast = progress.speed_per_second >= 8 * 1024 * 1024
         is_congested = progress.buffered_blocks > 2048
+        if is_congested:
+            Logger.debug(f"number blocks in buffer: {progress.buffered_blocks}")
         bar_color: Color = "red" if is_congested else ("green" if is_fast else "cyan")
         bar_width = min(get_terminal_size()[0] - 40, 50)
         bar = (

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -94,11 +94,12 @@ class CliApplicationEventRenderer:
                 Logger.custom(f"列表项 {url}", Badge(f"[{index}/{total}]", fore="black", back="cyan"))
             case DownloadStageChanged():
                 self._progress_active = False
-            case DownloadProgress() as progress if self.progress_enabled:
-                self._progress_active = True
-                self._render_progress(progress)
-            case DownloadProgress():
-                pass
+            case DownloadProgress() as progress:
+                if progress.buffered_blocks > 2048:
+                    Logger.debug(f"number blocks in buffer: {progress.buffered_blocks}")
+                if self.progress_enabled:
+                    self._progress_active = True
+                    self._render_progress(progress)
             case DownloadItemSkipped(item=item, reason=ItemSkipReason.ALREADY_EXISTS):
                 Logger.info(f"文件 {item} 已存在")
             case _:
@@ -107,8 +108,6 @@ class CliApplicationEventRenderer:
     def _render_progress(self, progress: DownloadProgress) -> None:
         is_fast = progress.speed_per_second >= 8 * 1024 * 1024
         is_congested = progress.buffered_blocks > 2048
-        if is_congested:
-            Logger.debug(f"number blocks in buffer: {progress.buffered_blocks}")
         bar_color: Color = "red" if is_congested else ("green" if is_fast else "cyan")
         bar_width = min(get_terminal_size()[0] - 40, 50)
         bar = (

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -1,28 +1,18 @@
 from __future__ import annotations
 
-import os
-import platform
 import tomllib
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
+from yutto.auth import xdg_config_home
 from yutto.media.quality import (
     AudioQuality,
     VideoQuality,
 )
 from yutto.utils.console.logger import Logger
 from yutto.utils.time import TIME_DATE_FMT
-
-
-def xdg_config_home() -> Path:
-    if (env := os.environ.get("XDG_CONFIG_HOME")) and (path := Path(env)).is_absolute():
-        return path
-    home = Path.home()
-    if platform.system() == "Windows":
-        return home / "AppData" / "Roaming"
-    return home / ".config"
 
 
 class YuttoBasicSettings(BaseModel):

--- a/src/yutto/core/events.py
+++ b/src/yutto/core/events.py
@@ -44,6 +44,7 @@ class DownloadProgress:
     speed_per_second: float
     phase: DownloadStage = DownloadStage.DOWNLOADING
     unit: Literal["bytes"] = "bytes"
+    buffered_blocks: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/yutto/core/events.py
+++ b/src/yutto/core/events.py
@@ -44,6 +44,7 @@ class DownloadProgress:
     speed_per_second: float
     phase: DownloadStage = DownloadStage.DOWNLOADING
     unit: Literal["bytes"] = "bytes"
+    # CLI-local congestion telemetry; intentionally excluded from the v1 task event payload.
     buffered_blocks: int = 0
 
 

--- a/src/yutto/core/operation.py
+++ b/src/yutto/core/operation.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from yutto.core.events import DownloadEvent, DownloadEventSink
 
+ReportLevel: TypeAlias = Literal["debug", "error", "info", "plain", "warning"]
+ReportColor: TypeAlias = Literal["blue", "green", "magenta"]
+ReportSink: TypeAlias = Callable[[str, ReportLevel, str | None, ReportColor | None], None]
+
 _event_sink: ContextVar[DownloadEventSink | None] = ContextVar("yutto_download_event_sink", default=None)
+_report_sink: ContextVar[ReportSink | None] = ContextVar("yutto_download_report_sink", default=None)
 
 
 @contextmanager
@@ -21,7 +27,27 @@ def bind_download_event_sink(sink: DownloadEventSink) -> Iterator[None]:
         _event_sink.reset(token)
 
 
+@contextmanager
+def bind_download_report_sink(sink: ReportSink) -> Iterator[None]:
+    token = _report_sink.set(sink)
+    try:
+        yield
+    finally:
+        _report_sink.reset(token)
+
+
 def emit_download_event(event: DownloadEvent) -> None:
     sink = _event_sink.get()
     if sink is not None:
         sink.emit(event)
+
+
+def emit_download_report(
+    message: str,
+    level: ReportLevel = "info",
+    badge: str | None = None,
+    color: ReportColor | None = None,
+) -> None:
+    sink = _report_sink.get()
+    if sink is not None:
+        sink(message, level, badge, color)

--- a/src/yutto/core/operation.py
+++ b/src/yutto/core/operation.py
@@ -3,15 +3,29 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from enum import StrEnum
+from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from yutto.core.events import DownloadEvent, DownloadEventSink
 
-ReportLevel: TypeAlias = Literal["debug", "error", "info", "plain", "warning"]
-ReportColor: TypeAlias = Literal["blue", "green", "magenta"]
+
+class ReportLevel(StrEnum):
+    DEBUG = "debug"
+    ERROR = "error"
+    INFO = "info"
+    PLAIN = "plain"
+    WARNING = "warning"
+
+
+class ReportColor(StrEnum):
+    BLUE = "blue"
+    GREEN = "green"
+    MAGENTA = "magenta"
+
+
 ReportSink: TypeAlias = Callable[[str, ReportLevel, str | None, ReportColor | None], None]
 
 _event_sink: ContextVar[DownloadEventSink | None] = ContextVar("yutto_download_event_sink", default=None)
@@ -44,7 +58,7 @@ def emit_download_event(event: DownloadEvent) -> None:
 
 def emit_download_report(
     message: str,
-    level: ReportLevel = "info",
+    level: ReportLevel = ReportLevel.INFO,
     badge: str | None = None,
     color: ReportColor | None = None,
 ) -> None:

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -11,7 +11,7 @@ from biliass import BlockOptions
 
 from yutto.api.user_info import validate_user_info
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.operation import emit_download_event, emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_event, emit_download_report
 from yutto.core.result import DownloadResult, ItemResult, ResolvedItem, ResolveFailure, ResolveResult
 from yutto.downloader.downloader import process_download
 from yutto.exceptions import NotLoginError, ResolveFailedError, WrongArgumentError, WrongUrlError
@@ -279,8 +279,8 @@ class DownloadManager:
                 },
             )
             item_results.append(previous_result)
-            emit_download_report("", "plain")
-        emit_download_report("", "plain")
+            emit_download_report("", ReportLevel.PLAIN)
+        emit_download_report("", ReportLevel.PLAIN)
         return tuple(item_results)
 
     async def resolve_request(
@@ -385,7 +385,7 @@ def ensure_unique_path(episode_data: EpisodeData, unique_name_resolver: Callable
     new_path = Path(unique_name_resolver(str(original_path)))
     episode_data["info"]["path"] = new_path
     if original_path != new_path:
-        emit_download_report(f"文件名重复，已重命名为 {new_path.name}", "warning")
+        emit_download_report(f"文件名重复，已重命名为 {new_path.name}", ReportLevel.WARNING)
     return episode_data
 
 

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -11,7 +11,7 @@ from biliass import BlockOptions
 
 from yutto.api.user_info import validate_user_info
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
-from yutto.core.operation import emit_download_event
+from yutto.core.operation import emit_download_event, emit_download_report
 from yutto.core.result import DownloadResult, ItemResult, ResolvedItem, ResolveFailure, ResolveResult
 from yutto.downloader.downloader import process_download
 from yutto.exceptions import NotLoginError, ResolveFailedError, WrongArgumentError, WrongUrlError
@@ -30,15 +30,13 @@ from yutto.extractor import (
     UserWatchLaterExtractor,
 )
 from yutto.extractor._abc import BatchExtractor
+from yutto.input_parser import validate_batch_selection
 from yutto.path_templates import create_unique_path_resolver
 from yutto.types import EpisodeData, ExtractorOptions
-from yutto.utils.asynclib import sleep_with_status_bar_refresh
-from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import DanmakuOptions
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.time import TIME_FULL_FMT
-from yutto.validator import validate_batch_selection
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -71,7 +69,7 @@ def show_batch_episode_title(
     display_group = episode_info["listing"].display_group
     # 分组变化时打印分组标题（多分 p 视频新出现或切换到另一个多分 p 视频）
     if display_group is not None and display_group != current_display_group:
-        Logger.custom(display_group, Badge("列表", fore="black", back="cyan"))
+        emit_download_report(display_group, badge="列表")
         current_display_group = display_group
     elif display_group is None:
         current_display_group = None
@@ -80,10 +78,7 @@ def show_batch_episode_title(
     if display_group is not None:
         # 多分 p 条目缩进显示，以区分分组标题行
         display_name = f"  {display_name}"
-    Logger.custom(
-        display_name,
-        Badge(f"[{index}/{total}]", fore="black", back="cyan"),
-    )
+    emit_download_report(display_name, badge=f"[{index}/{total}]")
     return current_display_group
 
 
@@ -231,8 +226,8 @@ class DownloadManager:
                 and previous_result.has_downloaded_media
                 and request.network.download_interval > 0
             ):
-                Logger.info(f"下载间隔 {request.network.download_interval} 秒")
-                await sleep_with_status_bar_refresh(request.network.download_interval)
+                emit_download_report(f"下载间隔 {request.network.download_interval} 秒")
+                await asyncio.sleep(request.network.download_interval)
 
             # 这时候才真正开始解析链接
             episode_data = await episode.resolve_data()
@@ -284,8 +279,8 @@ class DownloadManager:
                 },
             )
             item_results.append(previous_result)
-            Logger.new_line()
-        Logger.new_line()
+            emit_download_report("", "plain")
+        emit_download_report("", "plain")
         return tuple(item_results)
 
     async def resolve_request(
@@ -390,7 +385,7 @@ def ensure_unique_path(episode_data: EpisodeData, unique_name_resolver: Callable
     new_path = Path(unique_name_resolver(str(original_path)))
     episode_data["info"]["path"] = new_path
     if original_path != new_path:
-        Logger.warning(f"文件名重复，已重命名为 {new_path.name}")
+        emit_download_report(f"文件名重复，已重命名为 {new_path.name}", "warning")
     return episode_data
 
 

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -11,15 +11,13 @@ from yutto.core.events import (
     DownloadStage,
     DownloadStageChanged,
 )
-from yutto.core.operation import emit_download_event
+from yutto.core.operation import emit_download_event, emit_download_report
 from yutto.core.result import Artifact, ArtifactKind, ItemResult, ItemSkipReason, ItemState
 from yutto.downloader.progressbar import show_progress
 from yutto.downloader.selector import select_audio, select_video
 from yutto.exceptions import PostprocessingError
 from yutto.media.quality import audio_quality_map, video_quality_map
 from yutto.utils.asynclib import first_successful_with_check, make_coroutine_factory
-from yutto.utils.console.colorful import colored_string
-from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.danmaku import write_danmaku
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
@@ -73,9 +71,9 @@ def slice_blocks(start: int, total_size: int | None, block_size: int | None = No
 def show_videos_info(videos: list[VideoUrlMeta], selected: int):
     """显示视频详细信息"""
     if not videos:
-        Logger.info("不包含任何视频流")
+        emit_download_report("不包含任何视频流")
         return
-    Logger.info(f"共包含以下 {len(videos)} 个视频流：")
+    emit_download_report(f"共包含以下 {len(videos)} 个视频流：")
     for i, video in enumerate(videos):
         log = "{}{:2} [{:^4}] [{:>4}x{:<4}] <{:^8}> #{}".format(
             "*" if i == selected else " ",
@@ -86,24 +84,20 @@ def show_videos_info(videos: list[VideoUrlMeta], selected: int):
             video_quality_map[video["quality"]]["description"],
             len(video["mirrors"]) + 1,
         )
-        if i == selected:
-            log = colored_string(log, fore="blue")
-        Logger.info(log)
+        emit_download_report(log, color="blue" if i == selected else None)
 
 
 def show_audios_info(audios: list[AudioUrlMeta], selected: int):
     """显示音频详细信息"""
     if not audios:
-        Logger.info("不包含任何音频流")
+        emit_download_report("不包含任何音频流")
         return
-    Logger.info(f"共包含以下 {len(audios)} 个音频流：")
+    emit_download_report(f"共包含以下 {len(audios)} 个音频流：")
     for i, audio in enumerate(audios):
         log = "{}{:2} [{:^4}] <{:^8}>".format(
             "*" if i == selected else " ", i, audio["codec"].upper(), audio_quality_map[audio["quality"]]["description"]
         )
-        if i == selected:
-            log = colored_string(log, fore="magenta")
-        Logger.info(log)
+        emit_download_report(log, color="magenta" if i == selected else None)
 
 
 def create_mirrors_filter(banned_mirrors_pattern: str | None) -> Callable[[list[str]], list[str]]:
@@ -216,10 +210,10 @@ async def download_video_and_audio(
             0,
             defer_progress(list(filter_none_values(buffers)), sum(filter_none_values(sizes))),
         )
-        Logger.info("开始下载……")
+        emit_download_report("开始下载……")
         lifecycle_started = True
         await _run_download_lifecycle(coroutine_factories, filter_none_values(buffers))
-        Logger.info("下载完成！")
+        emit_download_report("下载完成！")
     finally:
         if not lifecycle_started:
             for buffer in filter_none_values(buffers):
@@ -277,7 +271,7 @@ async def merge_video_and_audio(
 
     ffmpeg = FFmpeg()
     command_builder = FFmpegCommandBuilder()
-    Logger.info("开始合并……")
+    emit_download_report("开始合并……")
     video_save_codec = options["video_save_codec"]
     audio_save_codec = options["audio_save_codec"]
 
@@ -291,7 +285,7 @@ async def merge_video_and_audio(
     if audio is not None:
         resolved_audio_save_codec = resolve_audio_save_codec(audio["codec"], audio_save_codec, output_path.suffix)
         if resolved_audio_save_codec not in {audio_save_codec, "copy"}:
-            Logger.info(
+            emit_download_report(
                 f"输出容器 {output_path.suffix} 无法直接封装 {audio['codec']} 音频，将自动转码为 {resolved_audio_save_codec}"
             )
         audio_save_codec = resolved_audio_save_codec
@@ -337,11 +331,11 @@ async def merge_video_and_audio(
             message += f"\n{detail}"
         raise PostprocessingError(message)
     else:
-        Logger.debug(result.stderr.decode())
+        emit_download_report(result.stderr.decode(), level="debug")
 
     if not output_path.exists():
         raise PostprocessingError("合并失败：FFmpeg 未生成目标文件！")
-    Logger.info("合并完成！")
+    emit_download_report("合并完成！")
 
 
 def cleanup_tmp_files(
@@ -396,7 +390,7 @@ async def process_download(
     require_audio = options["require_audio"]
     metadata_format = options["metadata_format"]
     danmaku_options = options["danmaku_options"]
-    Logger.info(f"开始处理视频 {filename}")
+    emit_download_report(f"开始处理视频 {filename}")
     emit_download_event(DownloadStageChanged(name=DownloadStage.PREPARING, item=filename))
     output_dir.mkdir(parents=True, exist_ok=True)
     tmp_dir.mkdir(parents=True, exist_ok=True)
@@ -447,9 +441,9 @@ async def process_download(
         for subtitle in subtitles:
             subtitle_path = write_subtitle(subtitle["lines"], output_path, subtitle["lang"])
             artifacts.append(Artifact(kind=ArtifactKind.SUBTITLE, path=subtitle_path))
-        Logger.custom(
+        emit_download_report(
             "{} 字幕已全部生成".format(", ".join([subtitle["lang"] for subtitle in subtitles])),
-            badge=Badge("字幕", fore="black", back="cyan"),
+            badge="字幕",
         )
 
     # 保存弹幕
@@ -462,15 +456,13 @@ async def process_download(
             danmaku_options,
         )
         artifacts.extend(Artifact(kind=ArtifactKind.DANMAKU, path=path) for path in danmaku_paths)
-        Logger.custom(
-            "{} 弹幕已生成".format(danmaku["save_type"]).upper(), badge=Badge("弹幕", fore="black", back="cyan")
-        )
+        emit_download_report("{} 弹幕已生成".format(danmaku["save_type"]).upper(), badge="弹幕")
 
     # 保存媒体描述文件
     if metadata is not None:
         metadata_path = write_metadata(metadata, output_path, metadata_format)
         artifacts.append(Artifact(kind=ArtifactKind.METADATA, path=metadata_path))
-        Logger.custom("NFO 媒体描述文件已生成", badge=Badge("描述文件", fore="black", back="cyan"))
+        emit_download_report("NFO 媒体描述文件已生成", badge="描述文件")
 
     # 保存封面
     if cover_data is not None:
@@ -479,14 +471,14 @@ async def process_download(
             cover_save_path = output_dir.joinpath(f"{filename}-poster.jpg")
             cover_save_path.write_bytes(cover_data)
             artifacts.append(Artifact(kind=ArtifactKind.COVER, path=cover_save_path))
-            Logger.custom("封面已生成", badge=Badge("封面", fore="black", back="cyan"))
+            emit_download_report("封面已生成", badge="封面")
 
     # 保存章节信息
     if chapter_info_data:
         write_chapter_info(filename, chapter_info_data, chapter_info_path)
 
     if not (will_download_audio or will_download_video):
-        Logger.warning("没有音视频需要下载")
+        emit_download_report("没有音视频需要下载", level="warning")
         cleanup_tmp_files(
             None,
             None,
@@ -518,7 +510,6 @@ async def process_download(
 
     if output_path.exists():
         if not options["overwrite"]:
-            Logger.info(f"文件 {filename} 已存在")
             emit_download_event(
                 DownloadItemSkipped(
                     item=filename,
@@ -543,7 +534,7 @@ async def process_download(
                 artifacts=tuple(artifacts),
             )
         else:
-            Logger.info("文件已存在，因启用 overwrite 选项强制删除……")
+            emit_download_report("文件已存在，因启用 overwrite 选项强制删除……")
             output_path.unlink()
 
     video = video if will_download_video else None

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -11,7 +11,7 @@ from yutto.core.events import (
     DownloadStage,
     DownloadStageChanged,
 )
-from yutto.core.operation import emit_download_event, emit_download_report
+from yutto.core.operation import ReportColor, ReportLevel, emit_download_event, emit_download_report
 from yutto.core.result import Artifact, ArtifactKind, ItemResult, ItemSkipReason, ItemState
 from yutto.downloader.progressbar import show_progress
 from yutto.downloader.selector import select_audio, select_video
@@ -84,7 +84,7 @@ def show_videos_info(videos: list[VideoUrlMeta], selected: int):
             video_quality_map[video["quality"]]["description"],
             len(video["mirrors"]) + 1,
         )
-        emit_download_report(log, color="blue" if i == selected else None)
+        emit_download_report(log, color=ReportColor.BLUE if i == selected else None)
 
 
 def show_audios_info(audios: list[AudioUrlMeta], selected: int):
@@ -97,7 +97,7 @@ def show_audios_info(audios: list[AudioUrlMeta], selected: int):
         log = "{}{:2} [{:^4}] <{:^8}>".format(
             "*" if i == selected else " ", i, audio["codec"].upper(), audio_quality_map[audio["quality"]]["description"]
         )
-        emit_download_report(log, color="magenta" if i == selected else None)
+        emit_download_report(log, color=ReportColor.MAGENTA if i == selected else None)
 
 
 def create_mirrors_filter(banned_mirrors_pattern: str | None) -> Callable[[list[str]], list[str]]:
@@ -331,7 +331,7 @@ async def merge_video_and_audio(
             message += f"\n{detail}"
         raise PostprocessingError(message)
     else:
-        emit_download_report(result.stderr.decode(), level="debug")
+        emit_download_report(result.stderr.decode(), level=ReportLevel.DEBUG)
 
     if not output_path.exists():
         raise PostprocessingError("合并失败：FFmpeg 未生成目标文件！")
@@ -478,7 +478,7 @@ async def process_download(
         write_chapter_info(filename, chapter_info_data, chapter_info_path)
 
     if not (will_download_audio or will_download_video):
-        emit_download_report("没有音视频需要下载", level="warning")
+        emit_download_report("没有音视频需要下载", level=ReportLevel.WARNING)
         cleanup_tmp_files(
             None,
             None,

--- a/src/yutto/downloader/progressbar.py
+++ b/src/yutto/downloader/progressbar.py
@@ -1,67 +1,23 @@
 from __future__ import annotations
 
 import asyncio
-import math
 import time
 from collections import deque
 from typing import TYPE_CHECKING
 
 from yutto.core.events import DownloadProgress
 from yutto.core.operation import emit_download_event
-from yutto.utils.console.attributes import get_terminal_size
-from yutto.utils.console.colorful import RGBColor, colored_string
-from yutto.utils.console.formatter import size_format
-from yutto.utils.console.logger import Logger
 
 if TYPE_CHECKING:
-    from yutto.utils.console.colorful import Color, Style
     from yutto.utils.file_buffer import AsyncFileBuffer
 
 SMOOTHING_WINDOW_SIZE = 10
-
-
-class ProgressBar:
-    def __init__(self, symbols: str | list[str] = "▏▎▍▌▋▊▉█", remaining_symbol: str = " ", width: int = 50):
-        super().__init__()
-        self.width = width
-        self.symbols = symbols
-        self.remaining_symbol = remaining_symbol
-        assert len(symbols) >= 2, "symbols 至少为 2 个"
-        self.num_symbol = len(symbols)
-
-    def render(
-        self,
-        data: float,
-        bar_fore_color: Color | None = None,
-        bar_back_color: Color | None = None,
-        remaining_bar_fore_color: Color | None = None,
-        remaining_bar_back_color: Color | None = None,
-        width: int | None = None,  # 如果需要实时调整宽度，可通过此传入
-    ) -> str:
-        width = width or self.width
-        if data == 1:
-            return self.symbols[-1] * width
-        length: float = width * data
-        length_int: int = int(length)
-        length_float: float = length - length_int
-
-        return colored_string(
-            length_int * self.symbols[-1] + self.symbols[math.floor(length_float * self.num_symbol)],
-            fore=bar_fore_color,
-            back=bar_back_color,
-        ) + colored_string(
-            (width - length_int - 1) * self.remaining_symbol,
-            fore=remaining_bar_fore_color,
-            back=remaining_bar_back_color,
-        )
 
 
 async def show_progress(file_buffers: list[AsyncFileBuffer], total_size: int):
     t: float = time.time()
     size: int = sum([file_buffer.written_size for file_buffer in file_buffers])
     time_with_size_window = deque([(t, size)], maxlen=SMOOTHING_WINDOW_SIZE)
-    progress_bar = ProgressBar("╸━", "━")
-    bar_min_width, bar_max_width = 10, 50
     while True:
         size_in_buffer: int = sum(
             [sum([len(chunk.data) for chunk in file_buffer.buffer]) for file_buffer in file_buffers]
@@ -78,40 +34,7 @@ async def show_progress(file_buffers: list[AsyncFileBuffer], total_size: int):
                 current=size_now,
                 total=total_size,
                 speed_per_second=speed,
-            )
-        )
-
-        # 进度条默认颜色为青色
-        # 当速度过快导致 buffer 中的块数过多时（>2048 块，每块 2**15Bytes，缓冲区共 64MiB），使用红色进行警告
-        # 在速度高于 8MiB/s 时，使用绿色示意高速下载中
-        speed_threshold = 8 * 1024 * 1024
-        num_blocks_in_buffer_threshold = 2048
-        is_fast = speed >= speed_threshold
-        bar_color = "red" if num_blocks_in_buffer > num_blocks_in_buffer_threshold else ("green" if is_fast else "cyan")
-        # 40：后面还有至少 37 个字符，因此这里取 40
-        bar_width = min(get_terminal_size()[0] - 40, bar_max_width)
-        if bar_width < bar_min_width:
-            bar = ""
-        else:
-            bar = progress_bar.render(
-                size_now / total_size,
-                bar_fore_color=bar_color,
-                remaining_bar_fore_color=RGBColor(64, 64, 64),
-                width=bar_width,
-            )
-        # 速度文本同时也使用绿色与青色作为速度标志
-        speed_text_color: Color = "green" if is_fast else "cyan"
-        speed_text_style: list[Style] | None = ["bold"] if is_fast else None
-        speed_text_suffix: str = "/⚡" if is_fast else "/s"
-
-        if num_blocks_in_buffer > num_blocks_in_buffer_threshold:
-            Logger.debug(f"number blocks in buffer: {num_blocks_in_buffer}")
-        Logger.status.set(
-            "{}{:>10}/{:>10} {:>12}  ".format(
-                bar + " " if bar else bar,
-                size_format(size_now),
-                size_format(total_size),
-                colored_string(size_format(speed) + speed_text_suffix, fore=speed_text_color, style=speed_text_style),
+                buffered_blocks=num_blocks_in_buffer,
             )
         )
 

--- a/src/yutto/exceptions.py
+++ b/src/yutto/exceptions.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import sys
 from enum import Enum
-from typing import TYPE_CHECKING, Any, TypeAlias
-
-if TYPE_CHECKING:
-    from types import TracebackType
+from typing import TypeAlias
 
 
 class ErrorCode(Enum):
@@ -91,22 +87,3 @@ class ResolveFailedError(YuttoBaseException):
     """解析任务未得到任何条目，且存在预期内的失败（多个失败聚合时使用；单一失败直接抛原始异常）"""
 
     code = ErrorCode.RESOLVE_FAILED_ERROR
-
-
-def handle_uncaught_exception(
-    exctype: type[BaseException], exception: BaseException, trace: TracebackType | None
-) -> Any:
-    old_hook(exctype, exception, trace)
-    if isinstance(exception, YuttoBaseException):
-        sys.exit(exception.code.value)
-
-
-sys.excepthook, old_hook = handle_uncaught_exception, sys.excepthook
-
-
-if __name__ == "__main__":
-    try:
-        raise HttpStatusError("HTTP 错误")
-    except (HttpStatusError, UnSupportedTypeError) as e:
-        print(e.code.value, e.message)
-        raise e

--- a/src/yutto/extractor/bangumi.py
+++ b/src/yutto/extractor/bangumi.py
@@ -4,7 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.bangumi import get_bangumi_list, get_season_id_by_episode_id
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import (
     EpisodeNotFoundError,
     HttpStatusError,
@@ -77,5 +77,5 @@ class BangumiExtractor(SingleExtractor):
                 )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-            emit_download_report(e.message, "error")
+            emit_download_report(e.message, ReportLevel.ERROR)
             return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/bangumi.py
+++ b/src/yutto/extractor/bangumi.py
@@ -4,6 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.bangumi import get_bangumi_list, get_season_id_by_episode_id
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import (
     EpisodeNotFoundError,
     HttpStatusError,
@@ -15,7 +16,6 @@ from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import make_bangumi_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import EpisodeId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
@@ -54,7 +54,7 @@ class BangumiExtractor(SingleExtractor):
     ) -> ExtractorResolveOutcome:
         season_id = await get_season_id_by_episode_id(scope, self.episode_id)
         bangumi_list = await get_bangumi_list(scope, season_id)
-        Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))
+        emit_download_report(bangumi_list["title"], badge="番剧")
         try:
             for bangumi_item in bangumi_list["pages"]:
                 if bangumi_item["episode_id"] == self.episode_id:
@@ -77,5 +77,5 @@ class BangumiExtractor(SingleExtractor):
                 )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-            Logger.error(e.message)
+            emit_download_report(e.message, "error")
             return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -8,12 +8,12 @@ from yutto.api.bangumi import (
     get_season_id_by_episode_id,
     get_season_id_by_media_id,
 )
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_bangumi_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import EpisodeId, MediaId, SeasonId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
@@ -80,7 +80,7 @@ class BangumiBatchExtractor(BatchExtractor):
         await self._parse_ids(scope)
 
         bangumi_list = await get_bangumi_list(scope, self.season_id)
-        Logger.custom(bangumi_list["title"], Badge("番剧", fore="black", back="cyan"))
+        emit_download_report(bangumi_list["title"], badge="番剧")
         # 如果没有 with_section 则不需要专区内容
         bangumi_list["pages"] = list(
             filter(lambda item: options["with_section"] or not item["is_section"], bangumi_list["pages"])

--- a/src/yutto/extractor/cheese.py
+++ b/src/yutto/extractor/cheese.py
@@ -4,6 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.cheese import get_cheese_list, get_season_id_by_episode_id
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import (
     EpisodeNotFoundError,
     HttpStatusError,
@@ -15,7 +16,6 @@ from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import make_cheese_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import EpisodeId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
@@ -55,7 +55,7 @@ class CheeseExtractor(SingleExtractor):
     ) -> ExtractorResolveOutcome:
         season_id = await get_season_id_by_episode_id(scope, self.episode_id)
         cheese_list = await get_cheese_list(scope, season_id)
-        Logger.custom(cheese_list["title"], Badge("课程", fore="black", back="cyan"))
+        emit_download_report(cheese_list["title"], badge="课程")
         try:
             for cheese_item in cheese_list["pages"]:
                 if cheese_item["episode_id"] == self.episode_id:
@@ -79,5 +79,5 @@ class CheeseExtractor(SingleExtractor):
                 )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-            Logger.error(e.message)
+            emit_download_report(e.message, "error")
             return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/cheese.py
+++ b/src/yutto/extractor/cheese.py
@@ -4,7 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.cheese import get_cheese_list, get_season_id_by_episode_id
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import (
     EpisodeNotFoundError,
     HttpStatusError,
@@ -79,5 +79,5 @@ class CheeseExtractor(SingleExtractor):
                 )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-            emit_download_report(e.message, "error")
+            emit_download_report(e.message, ReportLevel.ERROR)
             return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/cheese_batch.py
+++ b/src/yutto/extractor/cheese_batch.py
@@ -4,12 +4,12 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from yutto.api.cheese import get_cheese_list, get_season_id_by_episode_id
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_cheese_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import EpisodeId, SeasonId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
@@ -65,7 +65,7 @@ class CheeseBatchExtractor(BatchExtractor):
         await self._parse_ids(scope)
 
         cheese_list = await get_cheese_list(scope, self.season_id)
-        Logger.custom(cheese_list["title"], Badge("课程", fore="black", back="cyan"))
+        emit_download_report(cheese_list["title"], badge="课程")
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(cheese_list["pages"]))
         cheese_list["pages"] = list(filter(lambda item: item["id"] in episodes, cheese_list["pages"]))

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from yutto.api.collection import get_collection_details
 from yutto.api.space import get_user_name
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
@@ -76,7 +76,7 @@ class CollectionExtractor(BatchExtractor):
             if len(ugc_video_list["pages"]) != 1:
                 emit_download_report(
                     f"视频合集 {collection_title} 中的视频 {items[index]['avid']} 包含多个视频！",
-                    "error",
+                    ReportLevel.ERROR,
                 )
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING
 
 from yutto.api.collection import get_collection_details
 from yutto.api.space import get_user_name
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import MId, SeriesId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.api.ugc_video import UgcVideoList
@@ -58,7 +58,7 @@ class CollectionExtractor(BatchExtractor):
             get_collection_details(scope, self.series_id, self.mid),
         )
         collection_title = collection_details["title"]
-        Logger.custom(collection_title, Badge("视频合集", fore="black", back="cyan"))
+        emit_download_report(collection_title, badge="视频合集")
 
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(collection_details["pages"]))
@@ -74,7 +74,10 @@ class CollectionExtractor(BatchExtractor):
             index = resolved.index
             ugc_video_list = resolved.value
             if len(ugc_video_list["pages"]) != 1:
-                Logger.error(f"视频合集 {collection_title} 中的视频 {items[index]['avid']} 包含多个视频！")
+                emit_download_report(
+                    f"视频合集 {collection_title} 中的视频 {items[index]['avid']} 包含多个视频！",
+                    "error",
+                )
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -14,7 +14,7 @@ from yutto.api.ugc_video import (
     get_ugc_video_playurl,
     get_ugc_video_subtitles,
 )
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.core.result import ResolvedItem
 from yutto.exceptions import (
     HttpStatusError,
@@ -111,7 +111,7 @@ async def extract_bangumi_data(
         if bangumi_info["is_preview"]:
             emit_download_report(
                 f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）",
-                "warning",
+                ReportLevel.WARNING,
             )
         videos, audios = (
             await get_bangumi_playurl(scope, avid, cid)
@@ -139,7 +139,7 @@ async def extract_bangumi_data(
             chapter_info_data=[],
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-        emit_download_report(e.message, "error")
+        emit_download_report(e.message, ReportLevel.ERROR)
         return None
 
 
@@ -236,7 +236,7 @@ async def extract_cheese_data(
             chapter_info_data=[],
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-        emit_download_report(e.message, "error")
+        emit_download_report(e.message, ReportLevel.ERROR)
         return None
 
 
@@ -345,7 +345,7 @@ async def extract_ugc_video_data(
             chapter_info_data=chapter_info_data,
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-        emit_download_report(e.message, "error")
+        emit_download_report(e.message, ReportLevel.ERROR)
         return None
 
 

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -14,6 +14,7 @@ from yutto.api.ugc_video import (
     get_ugc_video_playurl,
     get_ugc_video_subtitles,
 )
+from yutto.core.operation import emit_download_report
 from yutto.core.result import ResolvedItem
 from yutto.exceptions import (
     HttpStatusError,
@@ -27,7 +28,6 @@ from yutto.path_templates import (
 )
 from yutto.types import EpisodeData, EpisodeInfo, ResolvableEpisode, format_ids
 from yutto.utils.asynclib import make_coroutine_factory
-from yutto.utils.console.logger import Logger
 from yutto.utils.danmaku import EmptyDanmakuData
 from yutto.utils.fetcher import Fetcher
 from yutto.utils.metadata import MetaData, attach_chapter_info
@@ -109,7 +109,10 @@ async def extract_bangumi_data(
         avid = listing.avid
         cid = listing.cid
         if bangumi_info["is_preview"]:
-            Logger.warning(f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）")
+            emit_download_report(
+                f"视频（{format_ids(avid, cid)}）是预览视频（疑似未登录或非大会员用户）",
+                "warning",
+            )
         videos, audios = (
             await get_bangumi_playurl(scope, avid, cid)
             if options["require_video"] or options["require_audio"]
@@ -136,7 +139,7 @@ async def extract_bangumi_data(
             chapter_info_data=[],
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-        Logger.error(e.message)
+        emit_download_report(e.message, "error")
         return None
 
 
@@ -233,7 +236,7 @@ async def extract_cheese_data(
             chapter_info_data=[],
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-        Logger.error(e.message)
+        emit_download_report(e.message, "error")
         return None
 
 
@@ -342,7 +345,7 @@ async def extract_ugc_video_data(
             chapter_info_data=chapter_info_data,
         )
     except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-        Logger.error(e.message)
+        emit_download_report(e.message, "error")
         return None
 
 

--- a/src/yutto/extractor/favourites.py
+++ b/src/yutto/extractor/favourites.py
@@ -5,13 +5,13 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_favourite_info, get_favourite_items, get_user_name
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.extractor.utils.favourite import normalize_favourite_video_item
 from yutto.types import FId, MId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.api.ugc_video import UgcVideoList
@@ -48,7 +48,7 @@ class FavouritesExtractor(BatchExtractor):
             get_user_name(scope, self.mid),
             get_favourite_info(scope, self.fid),
         )
-        Logger.custom(favourite_info["title"], Badge("收藏夹", fore="black", back="cyan"))
+        emit_download_report(favourite_info["title"], badge="收藏夹")
 
         favourite_videos = await get_favourite_items(scope, self.fid)
         avids = [favourite_video["avid"] for favourite_video in favourite_videos]

--- a/src/yutto/extractor/series.py
+++ b/src/yutto/extractor/series.py
@@ -5,12 +5,12 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_medialist_avids, get_medialist_title, get_user_name
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import MId, SeriesId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.api.ugc_video import UgcVideoList
@@ -47,7 +47,7 @@ class SeriesExtractor(BatchExtractor):
         username, series_title = await asyncio.gather(
             get_user_name(scope, self.mid), get_medialist_title(scope, self.series_id)
         )
-        Logger.custom(series_title, Badge("视频列表", fore="black", back="cyan"))
+        emit_download_report(series_title, badge="视频列表")
 
         avids = await get_medialist_avids(scope, self.series_id, self.mid)
 

--- a/src/yutto/extractor/ugc_video.py
+++ b/src/yutto/extractor/ugc_video.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 from yutto.api.ugc_video import get_ugc_video_list
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import (
     HttpStatusError,
     NoAccessPermissionError,
@@ -15,7 +16,6 @@ from yutto.extractor._abc import SingleExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import AId, BvId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
@@ -71,7 +71,7 @@ class UgcVideoExtractor(SingleExtractor):
                     assert len(p_queries) == 1, f"p should only have one value in url `{url}`, but got {len(p_queries)}"
                     self.page = int(p_queries[0])
                 except (ValueError, AssertionError) as e:
-                    Logger.error(f"url 的 page 信息不正确, `{e}`, 请检查 `p=` 的值是否为整数且唯一～")
+                    emit_download_report(f"url 的 page 信息不正确, `{e}`, 请检查 `p=` 的值是否为整数且唯一～", "error")
                     return False
             return True
         else:
@@ -85,7 +85,7 @@ class UgcVideoExtractor(SingleExtractor):
         try:
             ugc_video_list = await get_ugc_video_list(scope, self.avid)
             self.avid = ugc_video_list["avid"]  # 当视频撞车时，使用新的 avid 替代原有 avid，见 #96
-            Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
+            emit_download_report(ugc_video_list["title"], badge="投稿视频")
             return ResolveOutcome(
                 items=(
                     make_ugc_video_episode(
@@ -102,5 +102,5 @@ class UgcVideoExtractor(SingleExtractor):
                 )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-            Logger.error(e.message)
+            emit_download_report(e.message, "error")
             return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/ugc_video.py
+++ b/src/yutto/extractor/ugc_video.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlparse
 
 from yutto.api.ugc_video import get_ugc_video_list
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import (
     HttpStatusError,
     NoAccessPermissionError,
@@ -71,7 +71,10 @@ class UgcVideoExtractor(SingleExtractor):
                     assert len(p_queries) == 1, f"p should only have one value in url `{url}`, but got {len(p_queries)}"
                     self.page = int(p_queries[0])
                 except (ValueError, AssertionError) as e:
-                    emit_download_report(f"url 的 page 信息不正确, `{e}`, 请检查 `p=` 的值是否为整数且唯一～", "error")
+                    emit_download_report(
+                        f"url 的 page 信息不正确, `{e}`, 请检查 `p=` 的值是否为整数且唯一～",
+                        ReportLevel.ERROR,
+                    )
                     return False
             return True
         else:
@@ -102,5 +105,5 @@ class UgcVideoExtractor(SingleExtractor):
                 )
             )
         except (NoAccessPermissionError, HttpStatusError, UnSupportedTypeError, NotFoundError) as e:
-            emit_download_report(e.message, "error")
+            emit_download_report(e.message, ReportLevel.ERROR)
             return ResolveOutcome(failures=(e,))

--- a/src/yutto/extractor/ugc_video_batch.py
+++ b/src/yutto/extractor/ugc_video_batch.py
@@ -4,13 +4,13 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.ugc_video import get_ugc_video_list
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import NoAccessPermissionError, NotFoundError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.input_parser import parse_episodes_selection
 from yutto.types import AId, BvId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
@@ -71,10 +71,10 @@ class UgcVideoBatchExtractor(BatchExtractor):
     ) -> ExtractorResolveOutcome:
         try:
             ugc_video_list = await get_ugc_video_list(scope, self.avid)
-            Logger.custom(ugc_video_list["title"], Badge("投稿视频", fore="black", back="cyan"))
+            emit_download_report(ugc_video_list["title"], badge="投稿视频")
         except (NotFoundError, NoAccessPermissionError) as e:
             # 由于获取 info 时候也会因为视频不存在而报错，因此这里需要捕捉下
-            Logger.error(e.message)
+            emit_download_report(e.message, "error")
             return ResolveOutcome(failures=(e,))
 
         # 选集过滤

--- a/src/yutto/extractor/ugc_video_batch.py
+++ b/src/yutto/extractor/ugc_video_batch.py
@@ -4,7 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.ugc_video import get_ugc_video_list
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import NoAccessPermissionError, NotFoundError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
@@ -74,7 +74,7 @@ class UgcVideoBatchExtractor(BatchExtractor):
             emit_download_report(ugc_video_list["title"], badge="投稿视频")
         except (NotFoundError, NoAccessPermissionError) as e:
             # 由于获取 info 时候也会因为视频不存在而报错，因此这里需要捕捉下
-            emit_download_report(e.message, "error")
+            emit_download_report(e.message, ReportLevel.ERROR)
             return ResolveOutcome(failures=(e,))
 
         # 选集过滤

--- a/src/yutto/extractor/user_all_favourites.py
+++ b/src/yutto/extractor/user_all_favourites.py
@@ -5,13 +5,13 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_all_favourites, get_favourite_items, get_user_name
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.extractor.utils.favourite import normalize_favourite_video_item
 from yutto.types import MId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.api.space import FavouriteVideoData
@@ -45,7 +45,7 @@ class UserAllFavouritesExtractor(BatchExtractor):
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         username = await get_user_name(scope, self.mid)
-        Logger.custom(username, Badge("用户收藏夹", fore="black", back="cyan"))
+        emit_download_report(username, badge="用户收藏夹")
 
         all_episodes: list[ResolvableEpisode] = []
         failures: list[YuttoBaseException] = []

--- a/src/yutto/extractor/user_all_ugc_videos.py
+++ b/src/yutto/extractor/user_all_ugc_videos.py
@@ -5,12 +5,12 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_user_name, get_user_space_all_videos_avids
+from yutto.core.operation import emit_download_report
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.types import MId
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.api.ugc_video import UgcVideoList
@@ -42,7 +42,7 @@ class UserAllUgcVideosExtractor(BatchExtractor):
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
         username = await get_user_name(scope, self.mid)
-        Logger.custom(username, Badge("UP 主投稿视频", fore="black", back="cyan"))
+        emit_download_report(username, badge="UP 主投稿视频")
 
         publication_time_filter = options["publication_time_filter"]
         avids = await get_user_space_all_videos_avids(

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -5,12 +5,12 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_watch_later_avids
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import NotLoginError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
-from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
     from yutto.api.ugc_video import UgcVideoList
@@ -39,12 +39,12 @@ class UserWatchLaterExtractor(BatchExtractor):
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
-        Logger.custom("当前用户", Badge("稍后再看", fore="black", back="cyan"))
+        emit_download_report("当前用户", badge="稍后再看")
 
         try:
             avid_list = await get_watch_later_avids(scope)
         except NotLoginError as e:
-            Logger.error(e.message)
+            emit_download_report(e.message, "error")
             return ResolveOutcome(failures=(e,))
 
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。

--- a/src/yutto/extractor/user_watch_later.py
+++ b/src/yutto/extractor/user_watch_later.py
@@ -5,7 +5,7 @@ import re
 from typing import TYPE_CHECKING
 
 from yutto.api.space import get_watch_later_avids
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import NotLoginError
 from yutto.extractor._abc import BatchExtractor
 from yutto.extractor.common import make_ugc_video_episode
@@ -44,7 +44,7 @@ class UserWatchLaterExtractor(BatchExtractor):
         try:
             avid_list = await get_watch_later_avids(scope)
         except NotLoginError as e:
-            emit_download_report(e.message, "error")
+            emit_download_report(e.message, ReportLevel.ERROR)
             return ResolveOutcome(failures=(e,))
 
         # 逐视频解析完成即构建分集并通过显式回调推流，最终按 index 重排。

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from yutto.api.ugc_video import UgcVideoList, get_ugc_video_list
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import MaxRetryError, NoAccessPermissionError, NotFoundError
 from yutto.extractor.outcome import ResolveOutcome
-from yutto.utils.console.logger import Logger
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
@@ -70,17 +70,20 @@ async def resolve_ugc_video_lists(
         try:
             ugc_video_list = await get_ugc_video_list(scope, avid)
             if not publication_time_filter.matches(ugc_video_list["pubdate"]):
-                Logger.debug(f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}")
+                emit_download_report(
+                    f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}",
+                    "debug",
+                )
                 return _FilteredResolveItem(index=index, source=avid)
             # 在使用 SESSDATA 时，如果不去事先 touch 一下视频链接的话，是无法获取 episode_data 的
             # 至于为什么前面那俩（投稿视频页和番剧页）不需要额外 touch，因为在 get_redirected_url 阶段连接过了呀
             unwrap_fetch_result(await Fetcher.touch_url(scope, avid.to_url()))
             return IndexedResolveItem(index=index, source=avid, value=ugc_video_list)
         except (NotFoundError, NoAccessPermissionError) as e:
-            Logger.error(e.message)
+            emit_download_report(e.message, "error")
             return IndexedResolveFailure(index=index, source=avid, error=e)
         except MaxRetryError as e:
-            Logger.error(f"获取视频 {avid} 信息失败：{e.message}")
+            emit_download_report(f"获取视频 {avid} 信息失败：{e.message}", "error")
             return IndexedResolveFailure(index=index, source=avid, error=e)
 
     Completion = IndexedResolveItem[UgcVideoList] | IndexedResolveFailure | _FilteredResolveItem

--- a/src/yutto/extractor/utils/batch.py
+++ b/src/yutto/extractor/utils/batch.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from yutto.api.ugc_video import UgcVideoList, get_ugc_video_list
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import MaxRetryError, NoAccessPermissionError, NotFoundError
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
@@ -72,7 +72,7 @@ async def resolve_ugc_video_lists(
             if not publication_time_filter.matches(ugc_video_list["pubdate"]):
                 emit_download_report(
                     f"因为发布时间为 {ugc_video_list['pubdate']}，跳过 {ugc_video_list['title']}",
-                    "debug",
+                    ReportLevel.DEBUG,
                 )
                 return _FilteredResolveItem(index=index, source=avid)
             # 在使用 SESSDATA 时，如果不去事先 touch 一下视频链接的话，是无法获取 episode_data 的
@@ -80,10 +80,10 @@ async def resolve_ugc_video_lists(
             unwrap_fetch_result(await Fetcher.touch_url(scope, avid.to_url()))
             return IndexedResolveItem(index=index, source=avid, value=ugc_video_list)
         except (NotFoundError, NoAccessPermissionError) as e:
-            emit_download_report(e.message, "error")
+            emit_download_report(e.message, ReportLevel.ERROR)
             return IndexedResolveFailure(index=index, source=avid, error=e)
         except MaxRetryError as e:
-            emit_download_report(f"获取视频 {avid} 信息失败：{e.message}", "error")
+            emit_download_report(f"获取视频 {avid} 信息失败：{e.message}", ReportLevel.ERROR)
             return IndexedResolveFailure(index=index, source=avid, error=e)
 
     Completion = IndexedResolveItem[UgcVideoList] | IndexedResolveFailure | _FilteredResolveItem

--- a/src/yutto/input_parser.py
+++ b/src/yutto/input_parser.py
@@ -5,8 +5,8 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import WrongArgumentError
-from yutto.utils.console.logger import Logger
 
 
 def path_from_cli(path: str) -> Path:
@@ -37,7 +37,7 @@ def alias_parser(file_path: str) -> dict[str, str]:
 def file_scheme_parser(url: str) -> list[str]:
     file_url: str = urllib.parse.urlparse(url).path
     file_path = path_from_cli(urllib.request.url2pathname(file_url))
-    Logger.info(f"解析下载列表 {file_path} 中...")
+    emit_download_report(f"解析下载列表 {file_path} 中...")
     result: list[str] = []
     with file_path.open("r", encoding="utf-8") as f:
         for line in f:
@@ -56,11 +56,20 @@ def validate_episodes_selection(episodes_str: str) -> bool:
     return bool(re.match(rf"{regex_compose}$", episodes_str))
 
 
+def validate_batch_selection(episodes: str) -> None:
+    """检查 Core 请求中的批量选集格式。"""
+    if not validate_episodes_selection(episodes):
+        raise WrongArgumentError(f"选集参数（{episodes}）格式不正确呀～重新检查一下下～")
+
+
 def parse_episodes_selection(episodes_str: str, total: int) -> list[int]:
     """将选集字符串转为列表（标号从 1 开始）"""
 
     if total == 0:
-        Logger.warning("该剧集列表无任何剧集，猜测正片尚未上线，如果想要下载 PV 等特殊剧集，请添加参数 -s")
+        emit_download_report(
+            "该剧集列表无任何剧集，猜测正片尚未上线，如果想要下载 PV 等特殊剧集，请添加参数 -s",
+            "warning",
+        )
         return []
 
     def resolve_negative(value: int) -> int:
@@ -69,7 +78,7 @@ def parse_episodes_selection(episodes_str: str, total: int) -> list[int]:
         return value if value > 0 else value + total + 1
 
     # 解析字符串为列表
-    Logger.info(f"全 {total} 话")
+    emit_download_report(f"全 {total} 话")
     if validate_episodes_selection(episodes_str):
         episodes_str = episodes_str.replace("$", "-1")
         episode_list: list[int] = []
@@ -104,9 +113,9 @@ def parse_episodes_selection(episodes_str: str, total: int) -> list[int]:
         else:
             out_of_range.append(episode)
     if out_of_range:
-        Logger.warning("剧集 {} 不存在".format(",".join(list(map(str, out_of_range)))))
+        emit_download_report("剧集 {} 不存在".format(",".join(list(map(str, out_of_range)))), "warning")
 
-    Logger.info("已选择第 {} 话".format(",".join(list(map(str, episodes)))))
+    emit_download_report("已选择第 {} 话".format(",".join(list(map(str, episodes)))))
     if not episodes:
-        Logger.warning("没有选中任何剧集")
+        emit_download_report("没有选中任何剧集", "warning")
     return episodes

--- a/src/yutto/input_parser.py
+++ b/src/yutto/input_parser.py
@@ -5,7 +5,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import WrongArgumentError
 
 
@@ -68,7 +68,7 @@ def parse_episodes_selection(episodes_str: str, total: int) -> list[int]:
     if total == 0:
         emit_download_report(
             "该剧集列表无任何剧集，猜测正片尚未上线，如果想要下载 PV 等特殊剧集，请添加参数 -s",
-            "warning",
+            ReportLevel.WARNING,
         )
         return []
 
@@ -113,9 +113,12 @@ def parse_episodes_selection(episodes_str: str, total: int) -> list[int]:
         else:
             out_of_range.append(episode)
     if out_of_range:
-        emit_download_report("剧集 {} 不存在".format(",".join(list(map(str, out_of_range)))), "warning")
+        emit_download_report(
+            "剧集 {} 不存在".format(",".join(list(map(str, out_of_range)))),
+            ReportLevel.WARNING,
+        )
 
     emit_download_report("已选择第 {} 话".format(",".join(list(map(str, episodes)))))
     if not episodes:
-        emit_download_report("没有选中任何剧集", "warning")
+        emit_download_report("没有选中任何剧集", ReportLevel.WARNING)
     return episodes

--- a/src/yutto/path_templates.py
+++ b/src/yutto/path_templates.py
@@ -5,7 +5,7 @@ from html import unescape
 from pathlib import Path
 from typing import Literal
 
-from yutto.utils.console.logger import Logger
+from yutto.core.operation import emit_download_report
 from yutto.utils.time import get_time_str_by_stamp
 
 PathTemplateVariable = Literal[
@@ -86,7 +86,7 @@ def resolve_path_template(
     for key, value in subpath_variables.items():
         # 未知变量警告
         if f"{{{key}}}" in path_template and value == UNKNOWN:
-            Logger.warning("使用了未知的变量，可能导致产生错误的下载路径")
+            emit_download_report("使用了未知的变量，可能导致产生错误的下载路径", "warning")
         # 只对字符串值修改，int 型不修改以适配高级模板
         if isinstance(value, str):
             subpath_variables[key] = repair_filename(value)

--- a/src/yutto/path_templates.py
+++ b/src/yutto/path_templates.py
@@ -5,7 +5,7 @@ from html import unescape
 from pathlib import Path
 from typing import Literal
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.utils.time import get_time_str_by_stamp
 
 PathTemplateVariable = Literal[
@@ -86,7 +86,7 @@ def resolve_path_template(
     for key, value in subpath_variables.items():
         # 未知变量警告
         if f"{{{key}}}" in path_template and value == UNKNOWN:
-            emit_download_report("使用了未知的变量，可能导致产生错误的下载路径", "warning")
+            emit_download_report("使用了未知的变量，可能导致产生错误的下载路径", ReportLevel.WARNING)
         # 只对字符串值修改，int 型不修改以适配高级模板
         if isinstance(value, str):
             subpath_variables[key] = repair_filename(value)

--- a/src/yutto/utils/asynclib.py
+++ b/src/yutto/utils/asynclib.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-import time
-import types
-from functools import partial, wraps
+from functools import partial
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from typing_extensions import ParamSpec
-
-from yutto.utils.console.logger import Logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Iterable
@@ -27,39 +22,6 @@ def make_coroutine_factory(
         return partial(fn, *args, **kwargs)
 
     return bind
-
-
-async def sleep_with_status_bar_refresh(seconds: float):
-    current_time = start_time = time.time()
-    while current_time - start_time < seconds:
-        Logger.status.next_tick()
-        await asyncio.sleep(min(1, seconds - (current_time - start_time)))
-        current_time = time.time()
-
-
-def async_cache(
-    args_to_cache_key: Callable[[inspect.BoundArguments], str],
-) -> Callable[[Callable[P, Coroutine[Any, Any, RetT]]], Callable[P, Coroutine[Any, Any, RetT]]]:
-    def decorator(fn: Callable[P, Coroutine[Any, Any, RetT]]) -> Callable[P, Coroutine[Any, Any, RetT]]:
-        CACHE: dict[str, RetT] = {}
-
-        @wraps(fn)
-        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> RetT:
-            assert isinstance(fn, types.FunctionType)
-
-            sig = inspect.signature(fn)
-            bound_args = sig.bind(*args, **kwargs)
-            bound_args.apply_defaults()
-            cache_key = args_to_cache_key(bound_args)
-            if cache_key in CACHE:
-                Logger.debug(f"{fn.__name__} cache hit: {cache_key}")
-                return CACHE[cache_key]
-            Logger.debug(f"{fn.__name__} cache miss: {cache_key}, all cache keys: {list(CACHE.keys())}")
-            return CACHE.setdefault(cache_key, await fn(*args, **kwargs))
-
-        return wrapper
-
-    return decorator
 
 
 async def first_successful(coros: Iterable[Coroutine[Any, Any, RetT]]) -> list[RetT]:

--- a/src/yutto/utils/console/logger.py
+++ b/src/yutto/utils/console/logger.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 from yutto.utils.console.colorful import colored_string
@@ -103,49 +102,6 @@ class Logger:
         Logger.custom(string, DEBUG_BADGE, *print_args, **print_kwargs)
 
     @classmethod
-    def custom_multiline(cls, string: Any, badge: Badge, *print_args: Any, **print_kwargs: Any):
-        prefix = badge + " "
-        lines = string.split("\n")
-        multiline_string = prefix + "\n".join(
-            [((" " * get_string_width(prefix)) if i != 0 else "") + line for i, line in enumerate(lines)]
-        )
-        print(multiline_string, *print_args, **print_kwargs)
-
-    @classmethod
-    def warning_multiline(cls, string: Any, *print_args: Any, **print_kwargs: Any):
-        Logger.custom_multiline(string, WARNING_BADGE, *print_args, **print_kwargs)
-
-    @classmethod
-    def error_multiline(cls, string: Any, *print_args: Any, **print_kwargs: Any):
-        Logger.custom_multiline(string, ERROR_BADGE, *print_args, **print_kwargs)
-
-    @classmethod
-    def info_multiline(cls, string: Any, *print_args: Any, **print_kwargs: Any):
-        Logger.custom_multiline(string, INFO_BADGE, *print_args, **print_kwargs)
-
-    @classmethod
-    def deprecated_warning_multiline(cls, string: Any, *print_args: Any, **print_kwargs: Any):
-        Logger.custom_multiline(string, DEPRECATED_BADGE, *print_args, **print_kwargs)
-
-    @classmethod
-    def debug_multiline(cls, string: Any, *print_args: Any, **print_kwargs: Any):
-        if not _logger_debug:
-            return
-        Logger.custom_multiline(string, INFO_BADGE, *print_args, **print_kwargs)
-
-    @classmethod
     def print(cls, string: Any, *print_args: Any, **print_kwargs: Any):
         cls.status.clear()
         print(string, *print_args, **print_kwargs)
-
-    @classmethod
-    def json(cls, obj: list[Any] | dict[str, Any], *print_args: Any, **print_kwargs: Any):
-        Logger.print(json.dumps(obj, indent=2), *print_args, **print_kwargs)
-
-    @classmethod
-    def new_line(cls):
-        cls.print("")
-
-    @classmethod
-    def is_debug(cls) -> bool:
-        return _logger_debug

--- a/src/yutto/utils/console/logger.py
+++ b/src/yutto/utils/console/logger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from yutto.utils.console.colorful import colored_string
@@ -105,3 +106,7 @@ class Logger:
     def print(cls, string: Any, *print_args: Any, **print_kwargs: Any):
         cls.status.clear()
         print(string, *print_args, **print_kwargs)
+
+    @classmethod
+    def json(cls, obj: list[Any] | dict[str, Any], *print_args: Any, **print_kwargs: Any):
+        Logger.print(json.dumps(obj, indent=2), *print_args, **print_kwargs)

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -10,8 +10,8 @@ import httpx
 from returns.result import Failure, Result, Success
 from typing_extensions import ParamSpec
 
+from yutto.core.operation import emit_download_report
 from yutto.exceptions import MaxRetryError
-from yutto.utils.console.logger import Logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Mapping
@@ -46,13 +46,13 @@ class MaxRetry:
                 try:
                     return Success(await connect_once(*args, **kwargs))
                 except httpx.TimeoutException:
-                    Logger.warning(f"抓取超时，正在重试，剩余 {retry - 1} 次")
+                    emit_download_report(f"抓取超时，正在重试，剩余 {retry - 1} 次", level="warning")
                 except (httpx.InvalidURL, httpx.UnsupportedProtocol) as e:
                     raise e
                 except httpx.HTTPError as e:
                     await asyncio.sleep(0.5)
                     error_type = e.__class__.__name__
-                    Logger.warning(f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次")
+                    emit_download_report(f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次", level="warning")
                 finally:
                     retry -= 1
             return Failure(MaxRetryError("超出最大重试次数！"))
@@ -115,8 +115,7 @@ class Fetcher:
         encoding: str | None = None,  # TODO(SigureMo): Support this
     ) -> str | None:
         async with scope.fetch_guard():
-            Logger.debug(f"Fetch text: {url}")
-            Logger.status.next_tick()
+            emit_download_report(f"Fetch text: {url}", level="debug")
             resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 return None
@@ -131,8 +130,7 @@ class Fetcher:
         params: Mapping[str, Any] | None = None,
     ) -> bytes | None:
         async with scope.fetch_guard():
-            Logger.debug(f"Fetch bin: {url}")
-            Logger.status.next_tick()
+            emit_download_report(f"Fetch bin: {url}", level="debug")
             resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 return None
@@ -147,8 +145,7 @@ class Fetcher:
         params: Mapping[str, Any] | None = None,
     ) -> Any:
         async with scope.fetch_guard():
-            Logger.debug(f"Fetch json: {url}")
-            Logger.status.next_tick()
+            emit_download_report(f"Fetch json: {url}", level="debug")
             resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 resp.raise_for_status()
@@ -164,10 +161,9 @@ class Fetcher:
             resp = await scope.client.get(url)
             redirected_url = str(resp.url)
             if redirected_url == url:
-                Logger.debug(f"Get redircted url: {url}")
+                emit_download_report(f"Get redircted url: {url}", level="debug")
             else:
-                Logger.debug(f"Get redircted url: {url} -> {redirected_url}")
-            Logger.status.next_tick()
+                emit_download_report(f"Get redircted url: {url} -> {redirected_url}", level="debug")
             return redirected_url
 
     @staticmethod
@@ -182,7 +178,7 @@ class Fetcher:
             )
             if resp.status_code == 206:
                 size = int(resp.headers["Content-Range"].split("/")[-1])
-                Logger.debug(f"Get size: {url} {size}")
+                emit_download_report(f"Get size: {url} {size}", level="debug")
                 return size
             else:
                 return None
@@ -191,10 +187,10 @@ class Fetcher:
     @MaxRetry(2)
     async def touch_url(scope: ExecutionScope, url: str) -> None:
         if url in scope.touched_urls:
-            Logger.debug(f"touch_url cache hit: {url}")
+            emit_download_report(f"touch_url cache hit: {url}", level="debug")
             return
         async with scope.fetch_guard():
-            Logger.debug(f"Touch url: {url}")
+            emit_download_report(f"Touch url: {url}", level="debug")
             await scope.client.get(url)
             scope.touched_urls.add(url)
 
@@ -208,7 +204,10 @@ class Fetcher:
         size: int | None,
     ) -> None:
         async with scope.download_guard():
-            Logger.debug(f"Start download (offset {offset}, number of mirrors {len(mirrors)}) {url}")
+            emit_download_report(
+                f"Start download (offset {offset}, number of mirrors {len(mirrors)}) {url}",
+                level="debug",
+            )
             done = False
             headers = scope.client.headers.copy()
             url_pool = [url] + mirrors
@@ -236,18 +235,24 @@ class Fetcher:
                     done = True
 
                 except httpx.TimeoutException:
-                    Logger.warning(f"文件 {file_buffer.file_path} 下载超时，尝试重新连接...")
-                    Logger.debug(f"超时链接：{url}")
+                    emit_download_report(f"文件 {file_buffer.file_path} 下载超时，尝试重新连接...", level="warning")
+                    emit_download_report(f"超时链接：{url}", level="debug")
                 except (httpx.HTTPError, h2.exceptions.H2Error) as e:
                     await asyncio.sleep(0.5)
                     error_type = e.__class__.__name__
-                    Logger.warning(f"文件 {file_buffer.file_path} 下载出错（{error_type}），尝试重新连接...")
-                    Logger.debug(f"超时链接：{url}")
+                    emit_download_report(
+                        f"文件 {file_buffer.file_path} 下载出错（{error_type}），尝试重新连接...",
+                        level="warning",
+                    )
+                    emit_download_report(f"超时链接：{url}", level="debug")
                 except ValueError as e:
                     # 由于 httpx 经常出现此问题，暂时捕获该问题
                     if "semaphore released too many times" not in str(e):
                         raise e
-                    Logger.warning(f"文件 {file_buffer.file_path} 下载出错（{e}），尝试重新连接...")
+                    emit_download_report(
+                        f"文件 {file_buffer.file_path} 下载出错（{e}），尝试重新连接...",
+                        level="warning",
+                    )
 
 
 def _client_kwargs(

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -10,7 +10,7 @@ import httpx
 from returns.result import Failure, Result, Success
 from typing_extensions import ParamSpec
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import MaxRetryError
 
 if TYPE_CHECKING:
@@ -46,13 +46,19 @@ class MaxRetry:
                 try:
                     return Success(await connect_once(*args, **kwargs))
                 except httpx.TimeoutException:
-                    emit_download_report(f"抓取超时，正在重试，剩余 {retry - 1} 次", level="warning")
+                    emit_download_report(
+                        f"抓取超时，正在重试，剩余 {retry - 1} 次",
+                        level=ReportLevel.WARNING,
+                    )
                 except (httpx.InvalidURL, httpx.UnsupportedProtocol) as e:
                     raise e
                 except httpx.HTTPError as e:
                     await asyncio.sleep(0.5)
                     error_type = e.__class__.__name__
-                    emit_download_report(f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次", level="warning")
+                    emit_download_report(
+                        f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次",
+                        level=ReportLevel.WARNING,
+                    )
                 finally:
                     retry -= 1
             return Failure(MaxRetryError("超出最大重试次数！"))
@@ -115,7 +121,7 @@ class Fetcher:
         encoding: str | None = None,  # TODO(SigureMo): Support this
     ) -> str | None:
         async with scope.fetch_guard():
-            emit_download_report(f"Fetch text: {url}", level="debug")
+            emit_download_report(f"Fetch text: {url}", level=ReportLevel.DEBUG)
             resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 return None
@@ -130,7 +136,7 @@ class Fetcher:
         params: Mapping[str, Any] | None = None,
     ) -> bytes | None:
         async with scope.fetch_guard():
-            emit_download_report(f"Fetch bin: {url}", level="debug")
+            emit_download_report(f"Fetch bin: {url}", level=ReportLevel.DEBUG)
             resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 return None
@@ -145,7 +151,7 @@ class Fetcher:
         params: Mapping[str, Any] | None = None,
     ) -> Any:
         async with scope.fetch_guard():
-            emit_download_report(f"Fetch json: {url}", level="debug")
+            emit_download_report(f"Fetch json: {url}", level=ReportLevel.DEBUG)
             resp = await scope.client.get(url, params=params)
             if not resp.is_success:
                 resp.raise_for_status()
@@ -161,9 +167,12 @@ class Fetcher:
             resp = await scope.client.get(url)
             redirected_url = str(resp.url)
             if redirected_url == url:
-                emit_download_report(f"Get redircted url: {url}", level="debug")
+                emit_download_report(f"Get redircted url: {url}", level=ReportLevel.DEBUG)
             else:
-                emit_download_report(f"Get redircted url: {url} -> {redirected_url}", level="debug")
+                emit_download_report(
+                    f"Get redircted url: {url} -> {redirected_url}",
+                    level=ReportLevel.DEBUG,
+                )
             return redirected_url
 
     @staticmethod
@@ -178,7 +187,7 @@ class Fetcher:
             )
             if resp.status_code == 206:
                 size = int(resp.headers["Content-Range"].split("/")[-1])
-                emit_download_report(f"Get size: {url} {size}", level="debug")
+                emit_download_report(f"Get size: {url} {size}", level=ReportLevel.DEBUG)
                 return size
             else:
                 return None
@@ -187,10 +196,10 @@ class Fetcher:
     @MaxRetry(2)
     async def touch_url(scope: ExecutionScope, url: str) -> None:
         if url in scope.touched_urls:
-            emit_download_report(f"touch_url cache hit: {url}", level="debug")
+            emit_download_report(f"touch_url cache hit: {url}", level=ReportLevel.DEBUG)
             return
         async with scope.fetch_guard():
-            emit_download_report(f"Touch url: {url}", level="debug")
+            emit_download_report(f"Touch url: {url}", level=ReportLevel.DEBUG)
             await scope.client.get(url)
             scope.touched_urls.add(url)
 
@@ -206,7 +215,7 @@ class Fetcher:
         async with scope.download_guard():
             emit_download_report(
                 f"Start download (offset {offset}, number of mirrors {len(mirrors)}) {url}",
-                level="debug",
+                level=ReportLevel.DEBUG,
             )
             done = False
             headers = scope.client.headers.copy()
@@ -235,23 +244,26 @@ class Fetcher:
                     done = True
 
                 except httpx.TimeoutException:
-                    emit_download_report(f"文件 {file_buffer.file_path} 下载超时，尝试重新连接...", level="warning")
-                    emit_download_report(f"超时链接：{url}", level="debug")
+                    emit_download_report(
+                        f"文件 {file_buffer.file_path} 下载超时，尝试重新连接...",
+                        level=ReportLevel.WARNING,
+                    )
+                    emit_download_report(f"超时链接：{url}", level=ReportLevel.DEBUG)
                 except (httpx.HTTPError, h2.exceptions.H2Error) as e:
                     await asyncio.sleep(0.5)
                     error_type = e.__class__.__name__
                     emit_download_report(
                         f"文件 {file_buffer.file_path} 下载出错（{error_type}），尝试重新连接...",
-                        level="warning",
+                        level=ReportLevel.WARNING,
                     )
-                    emit_download_report(f"超时链接：{url}", level="debug")
+                    emit_download_report(f"超时链接：{url}", level=ReportLevel.DEBUG)
                 except ValueError as e:
                     # 由于 httpx 经常出现此问题，暂时捕获该问题
                     if "semaphore released too many times" not in str(e):
                         raise e
                     emit_download_report(
                         f"文件 {file_buffer.file_path} 下载出错（{e}），尝试重新连接...",
-                        level="warning",
+                        level=ReportLevel.WARNING,
                     )
 
 

--- a/src/yutto/utils/ffmpeg.py
+++ b/src/yutto/utils/ffmpeg.py
@@ -8,7 +8,7 @@ import subprocess
 from functools import cached_property, reduce
 from pathlib import Path
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.utils.functional import Singleton
 
 _TERMINATE_TIMEOUT_SECONDS = 3.0
@@ -32,7 +32,7 @@ class FFmpeg(metaclass=Singleton):
     def exec(self, args: list[str]):
         cmd = [self.path]
         cmd.extend(args)
-        emit_download_report(" ".join(cmd), level="debug")
+        emit_download_report(" ".join(cmd), level=ReportLevel.DEBUG)
         # NOTE(aheadlead): FFmpeg 会谜之从 stdin 读取一个字节，这会让调用 yutto 的 shell 脚本踩到坑
         # 这个行为在目前最新的 FFmpeg 6.0 仍然存在
         return subprocess.run(cmd, stdin=subprocess.DEVNULL, capture_output=True)
@@ -40,7 +40,7 @@ class FFmpeg(metaclass=Singleton):
     async def exec_async(self, args: list[str]) -> subprocess.CompletedProcess[bytes]:
         """Run FFmpeg without blocking the event loop and reap it on cancellation."""
         cmd = [self.path, *args]
-        emit_download_report(" ".join(cmd), level="debug")
+        emit_download_report(" ".join(cmd), level=ReportLevel.DEBUG)
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=subprocess.DEVNULL,

--- a/src/yutto/utils/ffmpeg.py
+++ b/src/yutto/utils/ffmpeg.py
@@ -8,7 +8,7 @@ import subprocess
 from functools import cached_property, reduce
 from pathlib import Path
 
-from yutto.utils.console.logger import Logger
+from yutto.core.operation import emit_download_report
 from yutto.utils.functional import Singleton
 
 _TERMINATE_TIMEOUT_SECONDS = 3.0
@@ -32,7 +32,7 @@ class FFmpeg(metaclass=Singleton):
     def exec(self, args: list[str]):
         cmd = [self.path]
         cmd.extend(args)
-        Logger.debug(" ".join(cmd))
+        emit_download_report(" ".join(cmd), level="debug")
         # NOTE(aheadlead): FFmpeg 会谜之从 stdin 读取一个字节，这会让调用 yutto 的 shell 脚本踩到坑
         # 这个行为在目前最新的 FFmpeg 6.0 仍然存在
         return subprocess.run(cmd, stdin=subprocess.DEVNULL, capture_output=True)
@@ -40,7 +40,7 @@ class FFmpeg(metaclass=Singleton):
     async def exec_async(self, args: list[str]) -> subprocess.CompletedProcess[bytes]:
         """Run FFmpeg without blocking the event loop and reap it on cancellation."""
         cmd = [self.path, *args]
-        Logger.debug(" ".join(cmd))
+        emit_download_report(" ".join(cmd), level="debug")
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=subprocess.DEVNULL,

--- a/src/yutto/utils/file_buffer.py
+++ b/src/yutto/utils/file_buffer.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import aiofiles
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -82,7 +82,7 @@ class AsyncFileBuffer:
             if ready_to_write_chunk.offset < self.written_size:
                 emit_download_report(
                     f"交叠的块范围 {ready_to_write_chunk.offset} < {self.written_size}，舍弃！",
-                    level="error",
+                    level=ReportLevel.ERROR,
                 )
                 continue
             await self.file_obj.write(ready_to_write_chunk.data)
@@ -96,7 +96,7 @@ class AsyncFileBuffer:
         if self.file_obj is not None:
             await self.file_obj.close()
         else:
-            emit_download_report("未预期的结果：未曾创建文件对象", level="error")
+            emit_download_report("未预期的结果：未曾创建文件对象", level=ReportLevel.ERROR)
 
     def __enter__(self) -> None:
         raise TypeError("Use async with instead")

--- a/src/yutto/utils/file_buffer.py
+++ b/src/yutto/utils/file_buffer.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import aiofiles
 
-from yutto.utils.console.logger import Logger
+from yutto.core.operation import emit_download_report
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -80,7 +80,10 @@ class AsyncFileBuffer:
             assert self.file_obj is not None
             ready_to_write_chunk = heapq.heappop(self.buffer)
             if ready_to_write_chunk.offset < self.written_size:
-                Logger.error(f"交叠的块范围 {ready_to_write_chunk.offset} < {self.written_size}，舍弃！")
+                emit_download_report(
+                    f"交叠的块范围 {ready_to_write_chunk.offset} < {self.written_size}，舍弃！",
+                    level="error",
+                )
                 continue
             await self.file_obj.write(ready_to_write_chunk.data)
             self.written_size += len(ready_to_write_chunk.data)
@@ -93,7 +96,7 @@ class AsyncFileBuffer:
         if self.file_obj is not None:
             await self.file_obj.close()
         else:
-            Logger.error("未预期的结果：未曾创建文件对象")
+            emit_download_report("未预期的结果：未曾创建文件对象", level="error")
 
     def __enter__(self) -> None:
         raise TypeError("Use async with instead")

--- a/src/yutto/utils/filter.py
+++ b/src/yutto/utils/filter.py
@@ -4,7 +4,7 @@ import datetime
 import re
 from dataclasses import dataclass
 
-from yutto.core.operation import emit_download_report
+from yutto.core.operation import ReportLevel, emit_download_report
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,7 +29,7 @@ class PublicationTimeFilter:
             return datetime.datetime.strptime(user_input, "%Y-%m-%d")
         elif re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$", user_input):
             return datetime.datetime.strptime(user_input, "%Y-%m-%d %H:%M:%S")
-        emit_download_report(f"稿件过滤参数: {user_input} 看不懂呢┭┮﹏┭┮，不会生效哦", "error")
+        emit_download_report(f"稿件过滤参数: {user_input} 看不懂呢┭┮﹏┭┮，不会生效哦", ReportLevel.ERROR)
         return None
 
     def matches(self, timestamp: int) -> bool:

--- a/src/yutto/utils/filter.py
+++ b/src/yutto/utils/filter.py
@@ -4,7 +4,7 @@ import datetime
 import re
 from dataclasses import dataclass
 
-from yutto.utils.console.logger import Logger
+from yutto.core.operation import emit_download_report
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,7 +29,7 @@ class PublicationTimeFilter:
             return datetime.datetime.strptime(user_input, "%Y-%m-%d")
         elif re.match(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$", user_input):
             return datetime.datetime.strptime(user_input, "%Y-%m-%d %H:%M:%S")
-        Logger.error(f"稿件过滤参数: {user_input} 看不懂呢┭┮﹏┭┮，不会生效哦")
+        emit_download_report(f"稿件过滤参数: {user_input} 看不懂呢┭┮﹏┭┮，不会生效哦", "error")
         return None
 
     def matches(self, timestamp: int) -> bool:

--- a/src/yutto/validator.py
+++ b/src/yutto/validator.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 import biliass
 
 from yutto.auth import format_auth_inline, resolve_auth
-from yutto.exceptions import ErrorCode, WrongArgumentError
-from yutto.input_parser import validate_episodes_selection
+from yutto.exceptions import ErrorCode
+from yutto.input_parser import validate_batch_selection
 from yutto.media.codec import audio_codec_priority_default, video_codec_priority_default
 from yutto.utils.console.colorful import set_no_color
 from yutto.utils.console.logger import Logger, set_logger_debug
@@ -37,7 +37,7 @@ def hydrate_auth(args: argparse.Namespace) -> AuthInfo | None:
 def initial_validation(args: argparse.Namespace):
     """初始化检查，仅执行一次"""
 
-    if not args.no_progress:
+    if not args.no_progress and sys.stdout.isatty():
         Logger.enable_statusbar()
 
     # 在使用 --no-color 或者环境变量 NO_COLOR 非空时都应该不显示颜色
@@ -149,11 +149,3 @@ def validate_basic_arguments(args: argparse.Namespace):
 def validate_batch_arguments(args: argparse.Namespace):
     """检查批量下载相关选项"""
     validate_batch_selection(args.episodes)
-
-
-def validate_batch_selection(episodes: str):
-    """检查 Core 请求中的批量选集格式。"""
-    # 检查 episodes 格式（简单的正则检查，后续过滤剧集时还有完整检查）
-    if not validate_episodes_selection(episodes):
-        # TODO: 错误信息链接到相应文档，当然需要先写文档……
-        raise WrongArgumentError(f"选集参数（{episodes}）格式不正确呀～重新检查一下下～")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
 
+import yutto.__main__ as main_module
 import yutto.cli.event_renderer as renderer_module
 import yutto.validator as validator_module
 from yutto.cli.cli import (
@@ -17,6 +19,13 @@ from yutto.cli.cli import (
 )
 from yutto.cli.settings import YuttoSettings
 from yutto.core.events import DownloadProgress
+from yutto.core.execution import RequestExecutionScopeFactory
+from yutto.core.operation import (
+    ReportColor,
+    ReportLevel,
+    bind_download_report_sink,
+    emit_download_report,
+)
 from yutto.exceptions import ErrorCode
 
 if TYPE_CHECKING:
@@ -168,3 +177,35 @@ def test_progress_renderer_respects_no_progress(monkeypatch: pytest.MonkeyPatch)
     assert "1.00 KiB" in rendered[0]
     assert "2.00 KiB" in rendered[0]
     assert debug_messages == ["number blocks in buffer: 2049"]
+
+
+def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):
+    output: list[tuple[str, object]] = []
+
+    async def cancel_download(_application: object, _requests: object) -> None:
+        emit_download_report("warning", ReportLevel.WARNING)
+        emit_download_report("badge", badge="TAG", color=ReportColor.GREEN)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(main_module.YuttoApplication, "download_all", cancel_download)
+    monkeypatch.setattr(renderer_module.Logger, "warning", lambda message: output.append(("warning", message)))
+    monkeypatch.setattr(
+        renderer_module.Logger,
+        "custom",
+        lambda message, badge: output.append(("badge", (message, badge.text))),
+    )
+    monkeypatch.setattr(renderer_module.Logger.status, "clear", lambda: output.append(("cleared", True)))
+    monkeypatch.setattr(renderer_module, "colored_string", lambda message, *, fore, **_: f"{fore}:{message}")
+
+    emit_download_report("unbound")
+    with bind_download_report_sink(lambda message, *_: output.append(("outer", message))):
+        with pytest.raises(asyncio.CancelledError):
+            main_module.run_download(RequestExecutionScopeFactory(), [], renderer_module.CliApplicationEventRenderer())
+        emit_download_report("outer")
+
+    assert output == [
+        ("warning", "warning"),
+        ("badge", ("green:badge", "TAG")),
+        ("cleared", True),
+        ("outer", "outer"),
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import yutto.cli.event_renderer as renderer_module
 import yutto.validator as validator_module
 from yutto.cli.cli import (
     add_auth_logout_arguments,
@@ -15,6 +16,7 @@ from yutto.cli.cli import (
     handle_default_subcommand,
 )
 from yutto.cli.settings import YuttoSettings
+from yutto.core.events import DownloadProgress
 from yutto.exceptions import ErrorCode
 
 if TYPE_CHECKING:
@@ -147,3 +149,18 @@ def test_root_parser_rejects_removed_top_level_login():
         cli().parse_args(handle_default_subcommand(["login"]))
 
     assert exc_info.value.code == 2
+
+
+def test_progress_renderer_respects_no_progress(monkeypatch: pytest.MonkeyPatch):
+    rendered: list[str] = []
+    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (80, 24))
+    monkeypatch.setattr(renderer_module.Logger.status, "set", rendered.append)
+    progress = DownloadProgress(current=1024, total=2048, speed_per_second=1024)
+
+    renderer_module.CliApplicationEventRenderer(progress_enabled=False).emit(progress)
+    assert rendered == []
+
+    renderer_module.CliApplicationEventRenderer().emit(progress)
+    assert len(rendered) == 1
+    assert "1.00 KiB" in rendered[0]
+    assert "2.00 KiB" in rendered[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,13 +170,13 @@ def test_progress_renderer_respects_no_progress(monkeypatch: pytest.MonkeyPatch)
 
     renderer_module.CliApplicationEventRenderer(progress_enabled=False).emit(progress)
     assert rendered == []
-    assert debug_messages == []
+    assert debug_messages == ["number blocks in buffer: 2049"]
 
     renderer_module.CliApplicationEventRenderer().emit(progress)
     assert len(rendered) == 1
     assert "1.00 KiB" in rendered[0]
     assert "2.00 KiB" in rendered[0]
-    assert debug_messages == ["number blocks in buffer: 2049"]
+    assert debug_messages == ["number blocks in buffer: 2049"] * 2
 
 
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,14 +153,18 @@ def test_root_parser_rejects_removed_top_level_login():
 
 def test_progress_renderer_respects_no_progress(monkeypatch: pytest.MonkeyPatch):
     rendered: list[str] = []
+    debug_messages: list[str] = []
     monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (80, 24))
     monkeypatch.setattr(renderer_module.Logger.status, "set", rendered.append)
-    progress = DownloadProgress(current=1024, total=2048, speed_per_second=1024)
+    monkeypatch.setattr(renderer_module.Logger, "debug", debug_messages.append)
+    progress = DownloadProgress(current=1024, total=2048, speed_per_second=1024, buffered_blocks=2049)
 
     renderer_module.CliApplicationEventRenderer(progress_enabled=False).emit(progress)
     assert rendered == []
+    assert debug_messages == []
 
     renderer_module.CliApplicationEventRenderer().emit(progress)
     assert len(rendered) == 1
     assert "1.00 KiB" in rendered[0]
     assert "2.00 KiB" in rendered[0]
+    assert debug_messages == ["number blocks in buffer: 2049"]

--- a/tests/test_core/test_task_service.py
+++ b/tests/test_core/test_task_service.py
@@ -111,7 +111,7 @@ async def test_download_events_are_noop_outside_application_context():
             ("stage", {"name": "preparing", "item": "video"}),
         ),
         (
-            DownloadProgress(current=1, total=2, speed_per_second=3.0),
+            DownloadProgress(current=1, total=2, speed_per_second=3.0, buffered_blocks=2049),
             (
                 "progress",
                 {

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -10,7 +10,7 @@ from returns.result import Success
 
 import yutto.download_manager as download_manager_module
 from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
-from yutto.core.operation import bind_download_report_sink
+from yutto.core.operation import ReportLevel, bind_download_report_sink
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ItemResult, ItemState, ResolvedItem
 from yutto.download_manager import (
@@ -444,7 +444,7 @@ async def test_execute_cancellation_closes_client():
 
 @pytest.mark.processor
 def test_ensure_unique_path_updates_episode_and_only_warns_on_rename():
-    reports: list[tuple[str, str]] = []
+    reports: list[tuple[str, ReportLevel]] = []
     resolved_paths: list[str] = []
 
     def resolve_unique_path(path: str) -> str:
@@ -461,7 +461,7 @@ def test_ensure_unique_path_updates_episode_and_only_warns_on_rename():
     assert result["info"]["path"] == Path("group/video (1).mp4")
     assert result["info"]["listing"].planned_path == Path("group/video.mp4")
     assert resolved_paths == [str(Path("group/video.mp4"))]
-    assert reports == [("文件名重复，已重命名为 video (1).mp4", "warning")]
+    assert reports == [("文件名重复，已重命名为 video (1).mp4", ReportLevel.WARNING)]
 
 
 @pytest.mark.processor

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -10,6 +10,7 @@ from returns.result import Success
 
 import yutto.download_manager as download_manager_module
 from yutto.core.execution import ExecutionScope, RequestExecutionScopeFactory
+from yutto.core.operation import bind_download_report_sink
 from yutto.core.request import DownloadRequest
 from yutto.core.result import DownloadResult, ItemResult, ItemState, ResolvedItem
 from yutto.download_manager import (
@@ -21,7 +22,6 @@ from yutto.download_manager import (
 from yutto.exceptions import NotLoginError, WrongArgumentError
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.types import AId, CId, ResolvableEpisode
-from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.fetcher import Fetcher
 from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
@@ -180,7 +180,6 @@ async def test_process_request_preserves_extractor_and_downloader_option_mapping
     monkeypatch.setattr(Fetcher, "get_redirected_url", fake_get_redirected_url)
     monkeypatch.setattr(download_manager_module, "process_download", fake_process_download)
     monkeypatch.setattr(download_manager_module, "BlockOptions", fake_block_options)
-    monkeypatch.setattr(Logger, "new_line", lambda: None)
 
     manager = DownloadManager()
     client = cast("httpx.AsyncClient", object())
@@ -291,7 +290,6 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
     monkeypatch.setattr(manager, "resolve_request", fake_resolve_request)
     monkeypatch.setattr(download_manager_module, "validate_user_info", fake_validate_user_info)
     monkeypatch.setattr(download_manager_module, "process_download", fake_process_download)
-    monkeypatch.setattr(Logger, "new_line", lambda: None)
 
     with pytest.raises(NotLoginError):
         await manager.process_request(
@@ -445,38 +443,34 @@ async def test_execute_cancellation_closes_client():
 
 
 @pytest.mark.processor
-def test_ensure_unique_path_updates_episode_and_only_warns_on_rename(monkeypatch: pytest.MonkeyPatch):
-    warnings: list[str] = []
+def test_ensure_unique_path_updates_episode_and_only_warns_on_rename():
+    reports: list[tuple[str, str]] = []
     resolved_paths: list[str] = []
 
     def resolve_unique_path(path: str) -> str:
         resolved_paths.append(path)
         return "group/video (1).mp4"
 
-    monkeypatch.setattr(Logger, "warning", lambda message: warnings.append(str(message)))
-
     renamed_episode = make_episode("group/video.mp4")
-    result = ensure_unique_path(renamed_episode, resolve_unique_path)
+    with bind_download_report_sink(lambda message, level, _badge, _color: reports.append((message, level))):
+        result = ensure_unique_path(renamed_episode, resolve_unique_path)
+        unchanged_episode = make_episode("group/another.mp4")
+        ensure_unique_path(unchanged_episode, lambda path: path)
 
     assert result is renamed_episode
     assert result["info"]["path"] == Path("group/video (1).mp4")
     assert result["info"]["listing"].planned_path == Path("group/video.mp4")
     assert resolved_paths == [str(Path("group/video.mp4"))]
-    assert warnings == ["文件名重复，已重命名为 video (1).mp4"]
-
-    unchanged_episode = make_episode("group/another.mp4")
-    ensure_unique_path(unchanged_episode, lambda path: path)
-    assert warnings == ["文件名重复，已重命名为 video (1).mp4"]
+    assert reports == [("文件名重复，已重命名为 video (1).mp4", "warning")]
 
 
 @pytest.mark.processor
-def test_show_batch_episode_title_preserves_order_and_group_state(monkeypatch: pytest.MonkeyPatch):
+def test_show_batch_episode_title_preserves_order_and_group_state():
     output: list[tuple[str, str]] = []
 
-    def capture_output(message: Any, badge: Badge, *args: Any, **kwargs: Any):
-        output.append((str(message), badge.text))
-
-    monkeypatch.setattr(Logger, "custom", capture_output)
+    def capture_output(message: str, _level: Any, badge: str | None, _color: Any) -> None:
+        assert badge is not None
+        output.append((message, badge))
 
     current_group: str | None = None
     group_states: list[str | None] = []
@@ -486,9 +480,10 @@ def test_show_batch_episode_title_preserves_order_and_group_state(monkeypatch: p
         make_episode("单集"),
         make_episode("投稿 B/P1", "投稿 B"),
     ]
-    for index, episode in enumerate(episodes, start=1):
-        current_group = show_batch_episode_title(episode["info"], index, len(episodes), current_group)
-        group_states.append(current_group)
+    with bind_download_report_sink(capture_output):
+        for index, episode in enumerate(episodes, start=1):
+            current_group = show_batch_episode_title(episode["info"], index, len(episodes), current_group)
+            group_states.append(current_group)
 
     assert group_states == ["投稿 A", "投稿 A", None, "投稿 B"]
     assert output == [

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -77,15 +77,11 @@ def test_selection_validation_raises_structured_argument_errors():
 
 @pytest.mark.processor
 @as_sync
-async def test_manager_raises_login_error_without_rendering(monkeypatch: pytest.MonkeyPatch):
-    rendered_errors: list[str] = []
-
+async def test_manager_raises_login_error(monkeypatch: pytest.MonkeyPatch):
     async def reject_login(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return False
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", reject_login)
-    monkeypatch.setattr(download_manager_module.Logger, "error", lambda message: rendered_errors.append(str(message)))
-
     with pytest.raises(NotLoginError) as exc_info:
         await DownloadManager().process_request(
             ExecutionScope(cast("httpx.AsyncClient", object())),
@@ -97,14 +93,11 @@ async def test_manager_raises_login_error_without_rendering(monkeypatch: pytest.
         "启用了严格校验大会员或登录模式，请检查认证信息（--auth）或大会员状态！",
         ErrorCode.NOT_LOGIN_ERROR,
     )
-    assert rendered_errors == []
 
 
 @pytest.mark.processor
 @as_sync
-async def test_manager_raises_url_errors_without_rendering_or_network(monkeypatch: pytest.MonkeyPatch):
-    rendered_errors: list[str] = []
-
+async def test_manager_raises_url_errors_without_network(monkeypatch: pytest.MonkeyPatch):
     async def accept_login(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         return True
 
@@ -113,8 +106,6 @@ async def test_manager_raises_url_errors_without_rendering_or_network(monkeypatc
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", accept_login)
     monkeypatch.setattr(Fetcher, "get_redirected_url", reject_url)
-    monkeypatch.setattr(download_manager_module.Logger, "error", lambda message: rendered_errors.append(str(message)))
-
     with pytest.raises(WrongUrlError) as exc_info:
         await DownloadManager().process_request(
             ExecutionScope(cast("httpx.AsyncClient", object())),
@@ -126,7 +117,6 @@ async def test_manager_raises_url_errors_without_rendering_or_network(monkeypatc
         "无效的 url(not-a-url)～请检查一下链接是否正确～",
         ErrorCode.WRONG_URL_ERROR,
     )
-    assert rendered_errors == []
 
 
 @pytest.mark.processor
@@ -195,7 +185,6 @@ async def test_single_extractors_raise_when_episode_is_missing(
 
     monkeypatch.setattr(module, "get_season_id_by_episode_id", get_season)
     monkeypatch.setattr(module, list_getter_name, get_empty_list)
-    monkeypatch.setattr(module.Logger, "custom", lambda *args, **kwargs: None)
     extractor = extractor_type()
     assert extractor.match(url)
 
@@ -214,11 +203,15 @@ def configure_download_cli(
     *,
     replace_logger: bool = True,
 ) -> tuple[list[str], list[str]]:
-    parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="download"))
+    parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="download", no_progress=True))
     rendered_errors: list[str] = []
     rendered_info: list[str] = []
 
-    def fail_download(scope_factory: object, requests: list[DownloadRequest]):
+    def fail_download(
+        scope_factory: object,
+        requests: list[DownloadRequest],
+        renderer: object,
+    ):
         raise failure
 
     monkeypatch.setattr(main_module, "cli", lambda: parser)

--- a/tests/test_server/test_command.py
+++ b/tests/test_server/test_command.py
@@ -8,6 +8,7 @@ import pytest
 import yutto.__main__ as main_module
 import yutto.server.command as server_command_module
 from yutto.cli.cli import cli, handle_default_subcommand
+from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import ErrorCode
 from yutto.server.command import resolve_server_token
 
@@ -27,6 +28,7 @@ def test_serve_io_error_is_rendered_without_traceback(monkeypatch: pytest.Monkey
     rendered_errors: list[str] = []
 
     def fail_server(args: object) -> None:
+        emit_download_report("server report", ReportLevel.ERROR)
         raise OSError("address already in use")
 
     monkeypatch.setattr(main_module, "cli", lambda: parser)
@@ -38,7 +40,7 @@ def test_serve_io_error_is_rendered_without_traceback(monkeypatch: pytest.Monkey
         main_module.main()
 
     assert exc_info.value.code == ErrorCode.WRONG_ARGUMENT_ERROR.value
-    assert rendered_errors == ["address already in use"]
+    assert rendered_errors == ["server report", "address already in use"]
 
 
 def test_environment_token_takes_precedence(tmp_path):

--- a/tests/test_utils/test_ffmpeg.py
+++ b/tests/test_utils/test_ffmpeg.py
@@ -362,11 +362,8 @@ async def test_ffmpeg_exec_async_kills_after_terminate_timeout(monkeypatch: pyte
 
 @pytest.mark.processor
 @as_sync
-async def test_merge_uses_async_ffmpeg_without_changing_success_logs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+async def test_merge_uses_async_ffmpeg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     commands: list[list[str]] = []
-    infos: list[str] = []
-    errors: list[str] = []
-    debugs: list[str] = []
 
     class FakeFFmpeg:
         async def exec_async(self, args: list[str]) -> subprocess.CompletedProcess[bytes]:
@@ -376,9 +373,6 @@ async def test_merge_uses_async_ffmpeg_without_changing_success_logs(monkeypatch
             return subprocess.CompletedProcess(args, 0, b"", b"ffmpeg detail")
 
     monkeypatch.setattr(downloader_module, "FFmpeg", FakeFFmpeg)
-    monkeypatch.setattr(downloader_module.Logger, "info", lambda message: infos.append(str(message)))
-    monkeypatch.setattr(downloader_module.Logger, "error", lambda message: errors.append(str(message)))
-    monkeypatch.setattr(downloader_module.Logger, "debug", lambda message: debugs.append(str(message)))
 
     output_path = tmp_path / "output.m4a"
     options = make_merge_options()
@@ -389,9 +383,6 @@ async def test_merge_uses_async_ffmpeg_without_changing_success_logs(monkeypatch
     assert commands[0][-1] == str(output_path)
     assert commands[0][commands[0].index("-acodec") + 1] == "copy"
     assert options["audio_save_codec"] == "mp4a"
-    assert infos == ["开始合并……", "合并完成！"]
-    assert errors == []
-    assert debugs == ["ffmpeg detail"]
 
 
 @pytest.mark.processor
@@ -442,9 +433,7 @@ async def test_merge_cancellation_removes_partial_output(monkeypatch: pytest.Mon
             await asyncio.Event().wait()
             raise AssertionError("unreachable")
 
-    infos: list[str] = []
     monkeypatch.setattr(downloader_module, "FFmpeg", BlockingFFmpeg)
-    monkeypatch.setattr(downloader_module.Logger, "info", lambda message: infos.append(str(message)))
     output_path = tmp_path / "output.m4a"
     merging = asyncio.create_task(merge_audio(output_path))
     await started.wait()
@@ -454,4 +443,3 @@ async def test_merge_cancellation_removes_partial_output(monkeypatch: pytest.Mon
         await merging
 
     assert output_path.exists() is False
-    assert infos == ["开始合并……"]


### PR DESCRIPTION
## 动机

核心下载流程此前直接承担终端展示、日志和进度渲染职责，CLI 与 JSON-RPC/server 难以复用同一套工作流。原始重构又把展示语义拆得过细，造成事件、测试和代码量明显膨胀。

本 PR 以 compact 版本建立 presentation boundary：core 不再导入终端展示模块，同时保留既有 CLI 文案、进度和 debug 行为。

## 解决方案

- 保留 7 个稳定领域事件：batch_started、request_queued、stage、progress、item_skipped、artifact_created、item_listed。
- 人类可见文案通过 ContextVar 作用域内的 report sink 交给 CLI renderer；level 与 color 使用 StrEnum，不再传裸字符串。
- CLI renderer 负责 TTY 进度、no-progress/非 TTY 下仍可用的拥塞 debug 诊断和 Logger 映射；server 继续只序列化稳定 v1 事件。
- buffered_blocks 明确为 CLI-only telemetry，并由编码测试固定为不进入 v1 wire payload。
- 移除全局 uncaught-exception hook、旧 sleep/status helper、async_cache 以及 Logger 中未使用的 multiline、new_line、is_debug；保留调试需要的 Logger.json。
- report sink 覆盖默认 no-op、嵌套恢复、CLI 取消清理以及 server 入口传播，不再增加实现细节事件矩阵。

## 类型

- [ ] :sparkles: feat: 添加新功能
- [ ] :bug: fix: 修复 bug
- [ ] :pencil: docs: 对文档进行修改
- [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
- [ ] :zap: perf: 提高性能的代码修改
- [ ] :technologist: dx: 优化开发体验
- [ ] :hammer: workflow: 工作流变动
- [ ] :label: types: 类型声明修改
- [ ] :construction: wip: 工作正在进行中
- [x] :white_check_mark: test: 测试用例添加及修改
- [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
- [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
- [ ] :question: chore: 其它不涉及源码以及测试的修改
- [ ] :arrow_up: deps: 依赖项修改
- [ ] :bookmark: release: 发布新版本

## 验证

- just fmt
- just lint
- report/renderer/server 定向测试：29 passed
- 扩展的 CLI/API/core/manager/server/utils 定向测试：112 passed，1 skipped；4 个 Bilibili 实网 API 用例因重试耗尽失败，均发生在外部请求阶段
- 本地 checkout：python -m yutto --version、--help、serve --help
- GitHub 上一轮 18 项 checks 全部通过；最新 head 的 checks 重新运行中

未运行会清理工作区的 just test。

## 规模

相对 main：528 additions / 439 deletions，净增 89 行；相比原实现的净增 2467 行已删除绝大多数事件和测试膨胀。

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol ultra)</sup>
</div>