### PR TITLE
🐛 fix: reap competing media size probes

### DIFF
--- a/src/yutto/downloader/transfer.py
+++ b/src/yutto/downloader/transfer.py
@@ -7,7 +7,8 @@ from typing import TYPE_CHECKING
 from yutto.core.events import DownloadStage, DownloadStageChanged
 from yutto.core.operation import emit_download_event, emit_download_report
 from yutto.downloader.progressbar import show_progress
-from yutto.utils.asynclib import first_successful_with_check, make_coroutine_factory
+from yutto.exceptions import MaxRetryError
+from yutto.utils.asynclib import NoSuccessfulResultError, make_coroutine_factory, race_for_first_success
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 from yutto.utils.file_buffer import AsyncFileBuffer
 from yutto.utils.functional import filter_none_values, xmerge
@@ -52,6 +53,23 @@ def create_mirrors_filter(banned_mirrors_pattern: str | None) -> Callable[[list[
     return mirrors_filter
 
 
+async def _probe_media_size(scope: ExecutionScope, url: str, mirrors: Iterable[str]) -> int | None:
+    async def probe(candidate: str) -> int | None:
+        return unwrap_fetch_result(await Fetcher.get_size(scope, candidate))
+
+    create_probe = make_coroutine_factory(probe)
+    try:
+        return await race_for_first_success(create_probe(candidate) for candidate in (url, *mirrors))
+    except NoSuccessfulResultError as error:
+        if len(error.exceptions) == 1 and isinstance(error.exceptions[0], MaxRetryError):
+            raise error.exceptions[0] from None
+        if not error.exceptions:
+            raise MaxRetryError("媒体大小探测失败：所有地址均已取消") from error
+        raise MaxRetryError(f"媒体大小探测失败：{len(error.exceptions)} 个地址均不可用") from ExceptionGroup(
+            "all media size probes failed", error.exceptions
+        )
+
+
 async def _run_download_lifecycle(
     coroutine_factories: Iterable[Callable[[], Coroutine[Any, Any, None]]],
     buffers: Iterable[_DownloadBuffer],
@@ -87,9 +105,6 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
     lifecycle_started = False
     mirrors_filter = create_mirrors_filter(plan.banned_mirrors_pattern)
 
-    async def get_size(url: str) -> int | None:
-        return unwrap_fetch_result(await Fetcher.get_size(scope, url))
-
     defer_download_file = make_coroutine_factory(Fetcher.download_file_with_offset)
     defer_progress = make_coroutine_factory(show_progress)
 
@@ -97,8 +112,10 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
     emit_download_report("开始下载……")
     try:
         if plan.video is not None:
-            video_size = await first_successful_with_check(
-                [get_size(url) for url in [plan.video.url, *mirrors_filter(list(plan.video.mirrors))]]
+            video_size = await _probe_media_size(
+                scope,
+                plan.video.url,
+                mirrors_filter(list(plan.video.mirrors)),
             )
             video_buffer = await AsyncFileBuffer.open(
                 plan.paths.video,
@@ -125,8 +142,10 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
             )
 
         if plan.audio is not None:
-            audio_size = await first_successful_with_check(
-                [get_size(url) for url in [plan.audio.url, *mirrors_filter(list(plan.audio.mirrors))]]
+            audio_size = await _probe_media_size(
+                scope,
+                plan.audio.url,
+                mirrors_filter(list(plan.audio.mirrors)),
             )
             audio_buffer = await AsyncFileBuffer.open(
                 plan.paths.audio,

--- a/src/yutto/utils/asynclib.py
+++ b/src/yutto/utils/asynclib.py
@@ -7,10 +7,18 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Iterable
+    from collections.abc import Awaitable, Callable, Coroutine, Iterable
 
 RetT = TypeVar("RetT")
 P = ParamSpec("P")
+
+
+class NoSuccessfulResultError(Exception):
+    """No raced operation completed successfully."""
+
+    def __init__(self, exceptions: Iterable[Exception]):
+        self.exceptions = tuple(exceptions)
+        super().__init__("no raced operation completed successfully")
 
 
 def make_coroutine_factory(
@@ -24,29 +32,38 @@ def make_coroutine_factory(
     return bind
 
 
-async def first_successful(coros: Iterable[Coroutine[Any, Any, RetT]]) -> list[RetT]:
-    tasks = [asyncio.create_task(coro) for coro in coros]
+async def race_for_first_success(factories: Iterable[Callable[[], Awaitable[RetT]]]) -> RetT:
+    """Return the first successful value after reaping every started operation."""
 
-    results: list[RetT] = []
-    try:
-        while not results:
-            done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            results = [task.result() for task in done if task.exception() is None]
-    except asyncio.CancelledError:
+    factory_list = tuple(factories)
+    winner: list[RetT] = []
+    failures: list[Exception] = []
+    remaining = len(factory_list)
+    completed = asyncio.Event()
+
+    async def run(factory: Callable[[], Awaitable[RetT]]) -> None:
+        nonlocal remaining
+        try:
+            value = await factory()
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            failures.append(error)
+        else:
+            if not winner:
+                winner.append(value)
+        finally:
+            remaining -= 1
+            if winner or not remaining:
+                completed.set()
+
+    async with asyncio.TaskGroup() as group:
+        tasks = [group.create_task(run(factory)) for factory in factory_list]
+        if tasks:
+            await completed.wait()
         for task in tasks:
             task.cancel()
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-        raise
-    for task in tasks:
-        task.cancel()
-    return results
 
-
-async def first_successful_with_check(coros: Iterable[Coroutine[Any, Any, RetT]]) -> RetT:
-    results = await first_successful(coros)
-    if not results:
-        raise Exception("All coroutines failed")
-    if len(set(results)) != 1:
-        raise Exception("Multiple coroutines returned different results")
-    return results[0]
+    if winner:
+        return winner[0]
+    raise NoSuccessfulResultError(failures)

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from returns.result import Failure
 
 from tests.test_processor.test_download_result import make_request, make_resource_only_episode
 from yutto.core.execution import ExecutionScope
 from yutto.downloader.planner import DownloadPlanner
-from yutto.downloader.transfer import download_video_and_audio, slice_blocks
+from yutto.downloader.transfer import _probe_media_size, download_video_and_audio, slice_blocks
+from yutto.exceptions import MaxRetryError
+from yutto.utils.fetcher import Fetcher
 from yutto.utils.functional import as_sync
 
+pytestmark = pytest.mark.processor
 
-@pytest.mark.processor
+
 @pytest.mark.parametrize(
     ("start", "total_size", "block_size", "expected"),
     [
@@ -29,7 +33,29 @@ def test_slice_blocks_handles_resume_offsets(
     assert slice_blocks(start, total_size, block_size) == expected
 
 
-@pytest.mark.processor
+@as_sync
+async def test_probe_media_size_preserves_probe_failures(monkeypatch: pytest.MonkeyPatch):
+    failures = {
+        "primary": MaxRetryError("primary failed"),
+        "mirror": MaxRetryError("mirror failed"),
+    }
+
+    async def get_size(_scope: ExecutionScope, url: str) -> Failure[MaxRetryError]:
+        return Failure(failures[url])
+
+    monkeypatch.setattr(Fetcher, "get_size", get_size)
+    async with httpx.AsyncClient() as client:
+        scope = ExecutionScope(client)
+        with pytest.raises(MaxRetryError) as single_failure:
+            await _probe_media_size(scope, "primary", [])
+        with pytest.raises(MaxRetryError) as multiple_failure:
+            await _probe_media_size(scope, "primary", ["mirror"])
+
+    assert single_failure.value is failures["primary"]
+    assert isinstance(multiple_failure.value.__cause__, ExceptionGroup)
+    assert set(multiple_failure.value.__cause__.exceptions) == set(failures.values())
+
+
 @as_sync
 async def test_unknown_size_restarts_fragment_and_http_200_retry(tmp_path):
     payload = b"A" * (64 * 1024) + b"B" * (64 * 1024)

--- a/tests/test_runtime/test_tasks.py
+++ b/tests/test_runtime/test_tasks.py
@@ -15,7 +15,6 @@ from yutto.runtime import (
     TaskState,
     monotonic_seq_allocator,
 )
-from yutto.utils.asynclib import first_successful
 from yutto.utils.functional import as_sync
 
 pytestmark = pytest.mark.processor
@@ -435,32 +434,6 @@ async def test_close_can_cancel_running_and_queued_tasks():
     assert running_snapshot.state is TaskState.CANCELLED
     assert queued_snapshot.state is TaskState.CANCELLED
     assert running_snapshot.error is None and queued_snapshot.error is None
-
-
-@as_sync
-async def test_runtime_cancellation_reaps_nested_first_successful_tasks():
-    child_started = asyncio.Event()
-    child_cancelled = asyncio.Event()
-
-    async def child() -> None:
-        child_started.set()
-        try:
-            await asyncio.Event().wait()
-        finally:
-            child_cancelled.set()
-
-    async def handler(payload: None, context: TaskContext) -> None:
-        await first_successful([child()])
-
-    async with TaskRuntime(handler) as runtime:
-        submitted = await runtime.submit(None)
-        await child_started.wait()
-        await runtime.cancel(submitted.task_id)
-        cancelled = await runtime.wait(submitted.task_id)
-
-    assert cancelled is not None
-    assert cancelled.state is TaskState.CANCELLED
-    assert child_cancelled.is_set()
 
 
 def test_runtime_rejects_invalid_limits():

--- a/tests/test_utils/test_asynclib.py
+++ b/tests/test_utils/test_asynclib.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from yutto.utils.asynclib import race_for_first_success
+from yutto.utils.functional import as_sync
+
+pytestmark = pytest.mark.processor
+
+
+@pytest.mark.parametrize("cancel_race", [False, True])
+@as_sync
+async def test_race_for_first_success_reaps_operations(cancel_race: bool):
+    all_started = asyncio.Event()
+    release_winner = asyncio.Event()
+    started = 0
+    reaped = 0
+
+    async def operation(winner: bool) -> None:
+        nonlocal started, reaped
+        started += 1
+        if started == 2:
+            all_started.set()
+        try:
+            if winner:
+                await release_winner.wait()
+            else:
+                await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            reaped += 1
+            if not cancel_race and not winner:
+                raise ValueError("semaphore released too many times") from None
+            raise
+
+    task = asyncio.create_task(race_for_first_success([lambda: operation(True), lambda: operation(False)]))
+    await all_started.wait()
+    if cancel_race:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert reaped == 2
+    else:
+        release_winner.set()
+        assert await task is None
+        assert reaped == 1


### PR DESCRIPTION
## 动机

媒体大小探测通过 `first_successful_with_check` 并发请求主地址和镜像。旧实现找到首个成功结果后只取消其余 task，却没有等待它们退出；如果某个 loser 在取消清理期间抛出异常（例如 `semaphore released too many times`），异常便无人读取，最终以 `Task exception was never retrieved` 和完整栈泄漏到 CLI。

旧 helper 还接收已经创建的 coroutine、返回成功结果列表，并用同一调度批次偶然完成的结果做一致性检查；这些语义既容易泄漏，也不等于检查所有镜像。

## 解决方案

- 用通用 `race_for_first_success` 替换 `first_successful` / `first_successful_with_check`。
- 新 helper 接收 coroutine factories、返回单个首个成功值；普通失败会继续等待，其余失败原因由 `NoSuccessfulResultError` 聚合。
- 用 `TaskGroup` 持有所有已启动 task；选出 winner 后取消 loser，并在返回或抛错前统一等待回收。
- caller cancellation 原样传播，child self-cancel 不会伪装成 caller cancellation；fatal `BaseException` 使用 `TaskGroup` 的原生传播语义。
- 下载层的 `_probe_media_size` 只负责调用通用 helper，并把单个或多个探测失败翻译成稳定的 `MaxRetryError`。
- 保持 first-success 语义，`None` 仍是合法成功结果；删除受调度时序影响的旧一致性检查。

## 验证

- `just fmt`
- `just lint`
- `uv run pytest -m processor tests/test_utils/test_asynclib.py tests/test_processor/test_downloader.py tests/test_runtime/test_tasks.py -q`：26 passed
- `uv run pytest -m 'not (api or e2e or ci_only or ignore)'`：316 passed, 34 deselected
- `uv run pytest tests/test_e2e.py::test_ugc_video_e2e -q --reruns 2 --reruns-delay 1`：1 passed
- Python 3.11 下 8 类竞态各 300 轮，Python 3.14 eager task factory 下 success/fatal 双顺序各 200 轮：全部零残留 task、零未读取异常

## 类型

-  [x] :bug: fix: 修复 bug
-  [ ] :sparkles: feat: 添加新功能
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol ultra)</sup>
</div>