### PR TITLE
✨ feat: support abi3t wheels

### DIFF
--- a/.github/workflows/biliass-build-and-release.yml
+++ b/.github/workflows/biliass-build-and-release.yml
@@ -55,9 +55,7 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: >-
-            --release --out dist --interpreter '3.14 3.14t'
-            --no-default-features --features abi3
+          args: --release --out dist --interpreter '3.14 3.14t'
           sccache: "true"
           manylinux: auto
           working-directory: packages/biliass
@@ -66,9 +64,7 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: >-
-            --release --out dist --interpreter 3.15t
-            --no-default-features --features abi3t
+          args: --release --out dist --interpreter 3.15t --features abi3t
           sccache: "true"
           manylinux: auto
           working-directory: packages/biliass
@@ -102,9 +98,7 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: >-
-            --release --out dist --interpreter '3.14 3.14t'
-            --no-default-features --features abi3
+          args: --release --out dist --interpreter '3.14 3.14t'
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: packages/biliass
@@ -113,9 +107,7 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: >-
-            --release --out dist --interpreter 3.15t
-            --no-default-features --features abi3t
+          args: --release --out dist --interpreter 3.15t --features abi3t
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: packages/biliass
@@ -150,7 +142,6 @@ jobs:
           args: >-
             --release --out dist --interpreter
             ${{ steps.setup-python.outputs.python-path }}
-            --no-default-features --features abi3
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels
@@ -166,11 +157,7 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        python:
-          - version: "3.14t"
-            features: --no-default-features --features abi3
-          - version: "3.15t"
-            features: --no-default-features --features abi3t
+        python-version: ["3.14t", "3.15t"]
         platform:
           - runner: windows-latest
             target: x64
@@ -181,10 +168,11 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python.version }}
+          python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.target }}
           allow-prereleases: true
-      - name: Build free-threaded-compatible wheel
+      - name: Build Python 3.14t wheel
+        if: ${{ matrix.python-version == '3.14t' }}
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
@@ -192,13 +180,24 @@ jobs:
           args: >-
             --release --out dist --interpreter
             ${{ steps.setup-python.outputs.python-path }}
-            ${{ matrix.python.features }}
+          sccache: "true"
+          working-directory: packages/biliass
+      - name: Build abi3t wheel
+        if: ${{ matrix.python-version == '3.15t' }}
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: >-
+            --release --out dist --interpreter
+            ${{ steps.setup-python.outputs.python-path }}
+            --features abi3t
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-windows-free-threaded-${{ matrix.python.version }}-${{ matrix.platform.target }}
+          name: wheels-windows-free-threaded-${{ matrix.python-version }}-${{ matrix.platform.target }}
           path: packages/biliass/dist
 
   macos:
@@ -221,9 +220,7 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: >-
-            --release --out dist --interpreter '3.14 3.14t'
-            --no-default-features --features abi3
+          args: --release --out dist --interpreter '3.14 3.14t'
           sccache: "true"
           working-directory: packages/biliass
       - name: Build abi3t wheels
@@ -231,9 +228,7 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: >-
-            --release --out dist --interpreter 3.15t
-            --no-default-features --features abi3t
+          args: --release --out dist --interpreter 3.15t --features abi3t
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels

--- a/.github/workflows/biliass-build-and-release.yml
+++ b/.github/workflows/biliass-build-and-release.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MATURIN_ACTION_VERSION: v1.12.6
+  MATURIN_ACTION_VERSION: v1.14.1
 
 jobs:
   linux:
@@ -50,12 +50,21 @@ jobs:
         with:
           python-version: 3.x
           allow-prereleases: true
-      - name: Build wheels
+      - name: Build abi3 and Python 3.14t wheels
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
           args: --release --out dist --interpreter '3.14 3.14t'
+          sccache: "true"
+          manylinux: auto
+          working-directory: packages/biliass
+      - name: Build abi3t wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter 3.15t
           sccache: "true"
           manylinux: auto
           working-directory: packages/biliass
@@ -84,12 +93,21 @@ jobs:
         with:
           python-version: 3.x
           allow-prereleases: true
-      - name: Build wheels
+      - name: Build abi3 and Python 3.14t wheels
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
           args: --release --out dist --interpreter '3.14 3.14t'
+          sccache: "true"
+          manylinux: musllinux_1_2
+          working-directory: packages/biliass
+      - name: Build abi3t wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter 3.15t
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: packages/biliass
@@ -116,7 +134,7 @@ jobs:
           python-version: "3.14"
           architecture: ${{ matrix.platform.target }}
           allow-prereleases: true
-      - name: Build wheels
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
@@ -132,14 +150,14 @@ jobs:
           name: wheels-windows-${{ matrix.platform.target }}
           path: packages/biliass/dist
 
-  # Python 3.13 standard and free-threaded versions cannot be
-  # available at the same time on Windows machines, so we
-  # split it into two jobs.
+  # Standard and free-threaded Python installations cannot be available at the
+  # same time on Windows machines, so we split them into two jobs.
   # https://github.com/Quansight-Labs/setup-python/issues/5
   windows-free-threaded:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
+        python-version: ["3.14t", "3.15t"]
         platform:
           - runner: windows-latest
             target: x64
@@ -150,10 +168,10 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.14t"
+          python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.target }}
           allow-prereleases: true
-      - name: Build wheels
+      - name: Build free-threaded-compatible wheel
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
@@ -166,7 +184,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-windows-free-threaded-${{ matrix.python-versions }}-${{ matrix.platform.target }}
+          name: wheels-windows-free-threaded-${{ matrix.python-version }}-${{ matrix.platform.target }}
           path: packages/biliass/dist
 
   macos:
@@ -184,12 +202,20 @@ jobs:
         with:
           python-version: 3.x
           allow-prereleases: true
-      - name: Build wheels
+      - name: Build abi3 and Python 3.14t wheels
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
           args: --release --out dist --interpreter '3.14 3.14t'
+          sccache: "true"
+          working-directory: packages/biliass
+      - name: Build abi3t wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter 3.15t
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels

--- a/.github/workflows/biliass-build-and-release.yml
+++ b/.github/workflows/biliass-build-and-release.yml
@@ -55,7 +55,9 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.14 3.14t'
+          args: >-
+            --release --out dist --interpreter '3.14 3.14t'
+            --no-default-features --features abi3
           sccache: "true"
           manylinux: auto
           working-directory: packages/biliass
@@ -64,7 +66,9 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.15t
+          args: >-
+            --release --out dist --interpreter 3.15t
+            --no-default-features --features abi3t
           sccache: "true"
           manylinux: auto
           working-directory: packages/biliass
@@ -98,7 +102,9 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.14 3.14t'
+          args: >-
+            --release --out dist --interpreter '3.14 3.14t'
+            --no-default-features --features abi3
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: packages/biliass
@@ -107,7 +113,9 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.15t
+          args: >-
+            --release --out dist --interpreter 3.15t
+            --no-default-features --features abi3t
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: packages/biliass
@@ -142,6 +150,7 @@ jobs:
           args: >-
             --release --out dist --interpreter
             ${{ steps.setup-python.outputs.python-path }}
+            --no-default-features --features abi3
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels
@@ -157,7 +166,11 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        python-version: ["3.14t", "3.15t"]
+        python:
+          - version: "3.14t"
+            features: --no-default-features --features abi3
+          - version: "3.15t"
+            features: --no-default-features --features abi3t
         platform:
           - runner: windows-latest
             target: x64
@@ -168,7 +181,7 @@ jobs:
       - id: setup-python
         uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python.version }}
           architecture: ${{ matrix.platform.target }}
           allow-prereleases: true
       - name: Build free-threaded-compatible wheel
@@ -179,12 +192,13 @@ jobs:
           args: >-
             --release --out dist --interpreter
             ${{ steps.setup-python.outputs.python-path }}
+            ${{ matrix.python.features }}
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-windows-free-threaded-${{ matrix.python-version }}-${{ matrix.platform.target }}
+          name: wheels-windows-free-threaded-${{ matrix.python.version }}-${{ matrix.platform.target }}
           path: packages/biliass/dist
 
   macos:
@@ -207,7 +221,9 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter '3.14 3.14t'
+          args: >-
+            --release --out dist --interpreter '3.14 3.14t'
+            --no-default-features --features abi3
           sccache: "true"
           working-directory: packages/biliass
       - name: Build abi3t wheels
@@ -215,7 +231,9 @@ jobs:
         with:
           maturin-version: ${{ env.MATURIN_ACTION_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.15t
+          args: >-
+            --release --out dist --interpreter 3.15t
+            --no-default-features --features abi3t
           sccache: "true"
           working-directory: packages/biliass
       - name: Upload wheels

--- a/packages/biliass/rust/Cargo.toml
+++ b/packages/biliass/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "biliass_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["abi3-py311", "bytes"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py311", "abi3t-py315", "bytes"] }
 prost = "0.14.1"
 thiserror = "2.0.17"
 quick-xml = "0.41.0"

--- a/packages/biliass/rust/Cargo.toml
+++ b/packages/biliass/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "biliass_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.29.0", features = ["abi3-py311", "abi3t-py315", "bytes"] }
+pyo3 = { version = "0.29.0", features = ["bytes"] }
 prost = "0.14.1"
 thiserror = "2.0.17"
 quick-xml = "0.41.0"
@@ -20,6 +20,11 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 rayon = "1.10.0"
 rustc-hash = "2.0.0"
+
+[features]
+default = ["abi3"]
+abi3 = ["pyo3/abi3-py311"]
+abi3t = ["pyo3/abi3-py315", "pyo3/abi3t-py315"]
 
 [build-dependencies]
 prost-build = "0.14.4"

--- a/packages/biliass/rust/Cargo.toml
+++ b/packages/biliass/rust/Cargo.toml
@@ -24,7 +24,7 @@ rustc-hash = "2.0.0"
 [features]
 default = ["abi3"]
 abi3 = ["pyo3/abi3-py311"]
-abi3t = ["pyo3/abi3-py315", "pyo3/abi3t-py315"]
+abi3t = ["pyo3/abi3t-py315"]
 
 [build-dependencies]
 prost-build = "0.14.4"


### PR DESCRIPTION
## 动机

PEP 803 为 Python 3.15+ 引入了支持 GIL 与 free-threaded 构建的稳定 ABI `abi3t`。biliass 已使用 PyO3 0.29，但发布流程仍然只生成 `cp311-abi3` 与 Python 3.14t 的版本专用 wheel，因此 Python 3.15t 之后仍需要按解释器版本重复构建。

## 解决方案

- 为 PyO3 同时启用 `abi3-py311` 与 `abi3t-py315`
- 将 maturin 升级到 1.14.1，以使用完整的 `abi3.abi3t` 支持
- 将稳定 ABI 构建拆为两次 maturin 调用，保留现有 `cp311-abi3` 和 `cp314-cp314t` 产物，并新增 `cp315-abi3.abi3t`
- 为 Linux、musllinux、macOS 和 Windows 发布矩阵补充 Python 3.15t 构建
- 修正 Windows free-threaded artifact 名称中的 matrix 变量

预期发布组合：

- `cp311-abi3`：GIL-enabled CPython 3.11+
- `cp314-cp314t`：free-threaded CPython 3.14
- `cp315-abi3.abi3t`：GIL-enabled 与 free-threaded CPython 3.15+

## 类型

- [x] :sparkles: feat: 添加新功能
- [ ] :bug: fix: 修复 bug
- [ ] :pencil: docs: 对文档进行修改
- [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
- [ ] :zap: perf: 提高性能的代码修改
- [ ] :technologist: dx: 优化开发体验
- [x] :hammer: workflow: 工作流变动
- [ ] :label: types: 类型声明修改
- [ ] :construction: wip: 工作正在进行中
- [ ] :white_check_mark: test: 测试用例添加及修改
- [x] :hammer: build: 影响构建系统或外部依赖关系的更改
- [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
- [ ] :question: chore: 其它不涉及源码以及测试的修改
- [ ] :arrow_up: deps: 依赖项修改
- [ ] :bookmark: release: 发布新版本

## 验证

- `just fmt`
- `just lint`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `actionlint .github/workflows/biliass-build-and-release.yml`
- biliass corpus 在 CPython 3.15 与 3.15t 下分别通过 36 个测试、64 个 snapshots
- 本地构建并检查 `cp315-abi3.abi3t` wheel；同一 wheel 在 GIL 与 free-threaded 3.15 中均成功导入并完成 XML → ASS 转换

完整 yutto 工作区的 Python 3.15 测试仍受当前 `pydantic-core 2.41.5` 的上游 Python 版本支持限制，本 PR 不扩展 yutto 主包的 Python 版本矩阵。

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol xhigh)</sup>
</div>