### PR TITLE
✨ feat: add Haya HTTP and file adapters

### DIFF
--- a/packages/yutto-core/rust/Cargo.lock
+++ b/packages/yutto-core/rust/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,12 +95,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -123,6 +167,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -547,6 +601,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,12 +1148,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/packages/yutto-core/rust/Cargo.lock
+++ b/packages/yutto-core/rust/Cargo.lock
@@ -14,16 +14,151 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
@@ -55,11 +190,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "rand_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "haya"
@@ -68,10 +258,316 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "haya-http"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "haya",
+ "reqwest",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -80,12 +576,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -98,10 +659,252 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -126,6 +929,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,13 +982,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,12 +1052,402 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/packages/yutto-core/rust/Cargo.toml
+++ b/packages/yutto-core/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/haya"]
+members = ["crates/haya", "crates/haya-http"]
 resolver = "3"
 
 [workspace.package]
@@ -13,6 +13,7 @@ license = "GPL-3.0-only"
 async-trait = "0.1.89"
 bytes = "1.10.1"
 futures-util = "0.3.31"
+reqwest = { version = "0.12.24", default-features = false, features = ["http2", "rustls-tls", "stream"] }
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.48.0", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7.17", features = ["rt"] }

--- a/packages/yutto-core/rust/crates/haya-http/Cargo.toml
+++ b/packages/yutto-core/rust/crates/haya-http/Cargo.toml
@@ -1,23 +1,22 @@
 [package]
-name = "haya"
+name = "haya-http"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 license = "MIT OR Apache-2.0"
-description = "A bounded, resilient, multi-source asynchronous downloader core"
+description = "Reqwest HTTP Range source adapter for Haya"
 readme = "README.md"
-keywords = ["async", "download", "resumable", "http", "multi-source"]
+keywords = ["async", "download", "http", "range", "reqwest"]
 categories = ["asynchronous", "network-programming"]
 publish = ["crates-io"]
 
 [dependencies]
 async-trait.workspace = true
-bytes.workspace = true
 futures-util.workspace = true
-thiserror.workspace = true
-tokio.workspace = true
-tokio-util.workspace = true
+haya = { version = "0.0.1", path = "../haya" }
+reqwest.workspace = true
 
 [dev-dependencies]
 tempfile = "3.23.0"
+tokio.workspace = true

--- a/packages/yutto-core/rust/crates/haya-http/Cargo.toml
+++ b/packages/yutto-core/rust/crates/haya-http/Cargo.toml
@@ -18,5 +18,6 @@ haya = { version = "0.0.1", path = "../haya" }
 reqwest.workspace = true
 
 [dev-dependencies]
+reqwest = { workspace = true, features = ["gzip"] }
 tempfile = "3.23.0"
 tokio.workspace = true

--- a/packages/yutto-core/rust/crates/haya-http/README.md
+++ b/packages/yutto-core/rust/crates/haya-http/README.md
@@ -1,0 +1,14 @@
+# haya-http
+
+`haya-http` provides the reqwest-based HTTP Range source adapter for `haya`.
+
+It sends exact Range requests, validates partial responses, streams
+response bytes, and accepts an externally configured `reqwest::Client` so the
+caller retains control of proxies, TLS, cookies, headers, and connection pools.
+
+The public API is experimental and may change between `0.0.x` releases.
+
+## License
+
+Licensed under either of the Apache License, Version 2.0 or the MIT license at
+your option.

--- a/packages/yutto-core/rust/crates/haya-http/README.md
+++ b/packages/yutto-core/rust/crates/haya-http/README.md
@@ -6,6 +6,8 @@ It sends exact Range requests, validates partial responses, streams response byt
 
 The injected client's default headers must not contain `If-Range`; the adapter deliberately strips any per-source `If-Range` value.
 
+The client must be built with reqwest's `no_gzip`, `no_brotli`, `no_deflate`, and `no_zstd` methods so Cargo feature unification cannot enable automatic response decompression before `haya-http` validates the wire encoding.
+
 The public API is experimental and may change between `0.0.x` releases.
 
 ## License

--- a/packages/yutto-core/rust/crates/haya-http/README.md
+++ b/packages/yutto-core/rust/crates/haya-http/README.md
@@ -2,13 +2,12 @@
 
 `haya-http` provides the reqwest-based HTTP Range source adapter for `haya`.
 
-It sends exact Range requests, validates partial responses, streams
-response bytes, and accepts an externally configured `reqwest::Client` so the
-caller retains control of proxies, TLS, cookies, headers, and connection pools.
+It sends exact Range requests, validates partial responses, streams response bytes, and accepts an externally configured `reqwest::Client` so the caller retains control of proxies, TLS, cookies, headers, and connection pools.
+
+The injected client's default headers must not contain `If-Range`; the adapter deliberately strips any per-source `If-Range` value.
 
 The public API is experimental and may change between `0.0.x` releases.
 
 ## License
 
-Licensed under either of the Apache License, Version 2.0 or the MIT license at
-your option.
+Licensed under either of the Apache License, Version 2.0 or the MIT license at your option.

--- a/packages/yutto-core/rust/crates/haya-http/examples/download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/examples/download.rs
@@ -22,7 +22,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .to_str()
         .ok_or("SIZE must be valid UTF-8")?
         .parse::<u64>()?;
-    let source = Arc::new(HttpRangeSource::new(Client::new(), url, HeaderMap::new()));
+    let source = Arc::new(HttpRangeSource::new(
+        Client::new(),
+        url,
+        HeaderMap::new(),
+        size,
+    ));
     let sink = Arc::new(FileSink::open(output, FileOpenMode::ResumeFromLength).await?);
     let report = Downloader::new(DownloadSpec::new(size), vec![source], sink)?
         .run()

--- a/packages/yutto-core/rust/crates/haya-http/examples/download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/examples/download.rs
@@ -22,12 +22,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .to_str()
         .ok_or("SIZE must be valid UTF-8")?
         .parse::<u64>()?;
-    let source = Arc::new(HttpRangeSource::new(
-        Client::new(),
-        url,
-        HeaderMap::new(),
-        size,
-    ));
+    let client = Client::builder()
+        .no_gzip()
+        .no_brotli()
+        .no_deflate()
+        .no_zstd()
+        .build()?;
+    let source = Arc::new(HttpRangeSource::new(client, url, HeaderMap::new(), size));
     let sink = Arc::new(FileSink::open(output, FileOpenMode::Overwrite).await?);
     let report = Downloader::new(DownloadSpec::new(size), vec![source], sink)?
         .run()

--- a/packages/yutto-core/rust/crates/haya-http/examples/download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/examples/download.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         HeaderMap::new(),
         size,
     ));
-    let sink = Arc::new(FileSink::open(output, FileOpenMode::ResumeFromLength).await?);
+    let sink = Arc::new(FileSink::open(output, FileOpenMode::Overwrite).await?);
     let report = Downloader::new(DownloadSpec::new(size), vec![source], sink)?
         .run()
         .await?;

--- a/packages/yutto-core/rust/crates/haya-http/examples/download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/examples/download.rs
@@ -1,0 +1,32 @@
+use std::{env, sync::Arc};
+
+use haya::{
+    DownloadSpec, Downloader,
+    file::{FileOpenMode, FileSink},
+};
+use haya_http::HttpRangeSource;
+use reqwest::{Client, Url, header::HeaderMap};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut arguments = env::args_os().skip(1);
+    let url = arguments.next().ok_or("usage: download URL OUTPUT SIZE")?;
+    let output = arguments.next().ok_or("usage: download URL OUTPUT SIZE")?;
+    let size = arguments.next().ok_or("usage: download URL OUTPUT SIZE")?;
+    if arguments.next().is_some() {
+        return Err("usage: download URL OUTPUT SIZE".into());
+    }
+
+    let url = Url::parse(url.to_str().ok_or("URL must be valid UTF-8")?)?;
+    let size = size
+        .to_str()
+        .ok_or("SIZE must be valid UTF-8")?
+        .parse::<u64>()?;
+    let source = Arc::new(HttpRangeSource::new(Client::new(), url, HeaderMap::new()));
+    let sink = Arc::new(FileSink::open(output, FileOpenMode::ResumeFromLength).await?);
+    let report = Downloader::new(DownloadSpec::new(size), vec![source], sink)?
+        .run()
+        .await?;
+    println!("downloaded {} bytes", report.committed_bytes);
+    Ok(())
+}

--- a/packages/yutto-core/rust/crates/haya-http/src/lib.rs
+++ b/packages/yutto-core/rust/crates/haya-http/src/lib.rs
@@ -124,18 +124,22 @@ struct ContentRange {
 }
 
 fn satisfied_content_range(headers: &HeaderMap) -> Result<ContentRange, SourceError> {
-    let value = headers
-        .get(CONTENT_RANGE)
-        .ok_or_else(|| {
-            SourceError::new(SourceErrorKind::Protocol, "response has no Content-Range")
-        })?
-        .to_str()
-        .map_err(|error| {
-            SourceError::new(
-                SourceErrorKind::Protocol,
-                format!("Content-Range is not valid ASCII: {error}"),
-            )
-        })?;
+    let mut values = headers.get_all(CONTENT_RANGE).iter();
+    let value = values.next().ok_or_else(|| {
+        SourceError::new(SourceErrorKind::Protocol, "response has no Content-Range")
+    })?;
+    if values.next().is_some() {
+        return Err(SourceError::new(
+            SourceErrorKind::Protocol,
+            "response has multiple Content-Range fields",
+        ));
+    }
+    let value = value.to_str().map_err(|error| {
+        SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("Content-Range is not valid ASCII: {error}"),
+        )
+    })?;
     let (unit, value) = value.split_once(' ').ok_or_else(|| {
         SourceError::new(
             SourceErrorKind::Protocol,
@@ -294,6 +298,9 @@ mod tests {
 
         headers.insert(CONTENT_RANGE, "Bytes 2-5/9".parse().expect("header"));
         assert!(satisfied_content_range(&headers).is_ok());
+
+        headers.append(CONTENT_RANGE, "bytes 2-5/9".parse().expect("header"));
+        assert!(satisfied_content_range(&headers).is_err());
     }
 
     #[test]

--- a/packages/yutto-core/rust/crates/haya-http/src/lib.rs
+++ b/packages/yutto-core/rust/crates/haya-http/src/lib.rs
@@ -3,25 +3,43 @@ use futures_util::StreamExt;
 use haya::{ByteRange, ByteStream, RangeSource, SourceError, SourceErrorKind};
 use reqwest::{
     Client, Request, StatusCode, Url,
-    header::{ACCEPT_ENCODING, CONTENT_RANGE, HeaderMap, HeaderValue, IF_RANGE, RANGE},
+    header::{
+        ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_RANGE, HeaderMap, HeaderValue, IF_RANGE, RANGE,
+    },
 };
 
 pub struct HttpRangeSource {
     client: Client,
     url: Url,
     headers: HeaderMap,
+    expected_size: u64,
 }
 
 impl HttpRangeSource {
-    pub fn new(client: Client, url: Url, headers: HeaderMap) -> Self {
+    /// Creates a source for one known-size resource.
+    ///
+    /// The client's default headers must not contain `If-Range`: reqwest adds
+    /// missing default headers when executing a request, after this adapter has
+    /// deliberately stripped any per-source `If-Range` value.
+    pub fn new(client: Client, url: Url, headers: HeaderMap, expected_size: u64) -> Self {
         Self {
             client,
             url,
             headers,
+            expected_size,
         }
     }
 
     fn request(&self, range: ByteRange) -> Result<Request, SourceError> {
+        if range.start >= range.end || range.end > self.expected_size {
+            return Err(SourceError::new(
+                SourceErrorKind::Protocol,
+                format!(
+                    "range {range:?} is outside resource size {}",
+                    self.expected_size
+                ),
+            ));
+        }
         let mut request = self
             .client
             .get(self.url.clone())
@@ -42,6 +60,8 @@ impl HttpRangeSource {
                 },
             )?,
         );
+        // This removes per-source values. Client defaults are applied later by
+        // reqwest and are therefore excluded by `new`'s documented precondition.
         request.headers_mut().remove(IF_RANGE);
         Ok(request)
     }
@@ -59,6 +79,7 @@ impl RangeSource for HttpRangeSource {
             return Err(status_error(response.status()));
         }
 
+        validate_content_encoding(response.headers())?;
         let content_range = satisfied_content_range(response.headers())?;
         if content_range.start != range.start || content_range.end.checked_add(1) != Some(range.end)
         {
@@ -71,6 +92,18 @@ impl RangeSource for HttpRangeSource {
                     content_range
                         .total
                         .map_or_else(|| "*".into(), |total| total.to_string())
+                ),
+            ));
+        }
+        if let Some(total) = content_range
+            .total
+            .filter(|total| *total != self.expected_size)
+        {
+            return Err(SourceError::new(
+                SourceErrorKind::Protocol,
+                format!(
+                    "expected resource size {}, got Content-Range total {}",
+                    self.expected_size, total
                 ),
             ));
         }
@@ -103,12 +136,19 @@ fn satisfied_content_range(headers: &HeaderMap) -> Result<ContentRange, SourceEr
                 format!("Content-Range is not valid ASCII: {error}"),
             )
         })?;
-    let value = value.strip_prefix("bytes ").ok_or_else(|| {
+    let (unit, value) = value.split_once(' ').ok_or_else(|| {
         SourceError::new(
             SourceErrorKind::Protocol,
             format!("unsupported Content-Range unit: {value}"),
         )
     })?;
+    if !unit.eq_ignore_ascii_case("bytes") {
+        return Err(SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("unsupported Content-Range unit: {unit}"),
+        ));
+    }
+    let value = value.trim_start();
     let (range, total) = value.split_once('/').ok_or_else(|| {
         SourceError::new(
             SourceErrorKind::Protocol,
@@ -133,6 +173,26 @@ fn satisfied_content_range(headers: &HeaderMap) -> Result<ContentRange, SourceEr
         ));
     }
     Ok(ContentRange { start, end, total })
+}
+
+fn validate_content_encoding(headers: &HeaderMap) -> Result<(), SourceError> {
+    for value in headers.get_all(CONTENT_ENCODING) {
+        let value = value.to_str().map_err(|error| {
+            SourceError::new(
+                SourceErrorKind::Protocol,
+                format!("Content-Encoding is not valid ASCII: {error}"),
+            )
+        })?;
+        for coding in value.split(',').map(str::trim) {
+            if !coding.eq_ignore_ascii_case("identity") {
+                return Err(SourceError::new(
+                    SourceErrorKind::Protocol,
+                    format!("unsupported Content-Encoding: {coding}"),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn parse_number(value: &str, field: &str) -> Result<u64, SourceError> {
@@ -171,10 +231,10 @@ fn status_error(status: StatusCode) -> SourceError {
 mod tests {
     use reqwest::{
         Client, Url,
-        header::{ACCEPT_ENCODING, CONTENT_RANGE, HeaderMap, IF_RANGE, RANGE},
+        header::{ACCEPT_ENCODING, CONTENT_ENCODING, CONTENT_RANGE, HeaderMap, IF_RANGE, RANGE},
     };
 
-    use super::{HttpRangeSource, satisfied_content_range};
+    use super::{HttpRangeSource, satisfied_content_range, validate_content_encoding};
     use haya::ByteRange;
 
     #[test]
@@ -182,7 +242,6 @@ mod tests {
         let mut default_headers = HeaderMap::new();
         default_headers.append(ACCEPT_ENCODING, "gzip".parse().expect("header"));
         default_headers.append(RANGE, "bytes=7-".parse().expect("header"));
-        default_headers.append(IF_RANGE, "stale-default".parse().expect("header"));
         let client = Client::builder()
             .default_headers(default_headers)
             .build()
@@ -195,6 +254,7 @@ mod tests {
             client,
             Url::parse("https://example.test/media").expect("URL"),
             source_headers,
+            9,
         );
 
         let request = source
@@ -213,10 +273,36 @@ mod tests {
     }
 
     #[test]
+    fn rejects_ranges_outside_the_known_resource() {
+        let source = HttpRangeSource::new(
+            Client::new(),
+            Url::parse("https://example.test/media").expect("URL"),
+            HeaderMap::new(),
+            9,
+        );
+
+        assert!(source.request(ByteRange { start: 0, end: 0 }).is_err());
+        assert!(source.request(ByteRange { start: 8, end: 10 }).is_err());
+    }
+
+    #[test]
     fn parses_satisfied_content_ranges() {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_RANGE, "bytes 2-5/9".parse().expect("header"));
         let parsed = satisfied_content_range(&headers).expect("valid range");
         assert_eq!((parsed.start, parsed.end, parsed.total), (2, 5, Some(9)));
+
+        headers.insert(CONTENT_RANGE, "Bytes 2-5/9".parse().expect("header"));
+        assert!(satisfied_content_range(&headers).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_identity_content_encoding() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_ENCODING, "gzip".parse().expect("header"));
+        assert!(validate_content_encoding(&headers).is_err());
+
+        headers.insert(CONTENT_ENCODING, "identity".parse().expect("header"));
+        assert!(validate_content_encoding(&headers).is_ok());
     }
 }

--- a/packages/yutto-core/rust/crates/haya-http/src/lib.rs
+++ b/packages/yutto-core/rust/crates/haya-http/src/lib.rs
@@ -1,0 +1,222 @@
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use haya::{ByteRange, ByteStream, RangeSource, SourceError, SourceErrorKind};
+use reqwest::{
+    Client, Request, StatusCode, Url,
+    header::{ACCEPT_ENCODING, CONTENT_RANGE, HeaderMap, HeaderValue, IF_RANGE, RANGE},
+};
+
+pub struct HttpRangeSource {
+    client: Client,
+    url: Url,
+    headers: HeaderMap,
+}
+
+impl HttpRangeSource {
+    pub fn new(client: Client, url: Url, headers: HeaderMap) -> Self {
+        Self {
+            client,
+            url,
+            headers,
+        }
+    }
+
+    fn request(&self, range: ByteRange) -> Result<Request, SourceError> {
+        let mut request = self
+            .client
+            .get(self.url.clone())
+            .headers(self.headers.clone())
+            .build()
+            .map_err(classify_reqwest_error)?;
+        request
+            .headers_mut()
+            .insert(ACCEPT_ENCODING, HeaderValue::from_static("identity"));
+        request.headers_mut().insert(
+            RANGE,
+            HeaderValue::from_str(&format!("bytes={}-{}", range.start, range.end - 1)).map_err(
+                |error| {
+                    SourceError::new(
+                        SourceErrorKind::Protocol,
+                        format!("invalid generated Range header: {error}"),
+                    )
+                },
+            )?,
+        );
+        request.headers_mut().remove(IF_RANGE);
+        Ok(request)
+    }
+}
+
+#[async_trait]
+impl RangeSource for HttpRangeSource {
+    async fn open(&self, range: ByteRange) -> Result<ByteStream, SourceError> {
+        let response = self
+            .client
+            .execute(self.request(range)?)
+            .await
+            .map_err(classify_reqwest_error)?;
+        if response.status() != StatusCode::PARTIAL_CONTENT {
+            return Err(status_error(response.status()));
+        }
+
+        let content_range = satisfied_content_range(response.headers())?;
+        if content_range.start != range.start || content_range.end.checked_add(1) != Some(range.end)
+        {
+            return Err(SourceError::new(
+                SourceErrorKind::Protocol,
+                format!(
+                    "requested {range:?}, got Content-Range {}-{}/{}",
+                    content_range.start,
+                    content_range.end,
+                    content_range
+                        .total
+                        .map_or_else(|| "*".into(), |total| total.to_string())
+                ),
+            ));
+        }
+
+        Ok(Box::pin(
+            response
+                .bytes_stream()
+                .map(|chunk| chunk.map_err(classify_reqwest_error)),
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ContentRange {
+    start: u64,
+    end: u64,
+    total: Option<u64>,
+}
+
+fn satisfied_content_range(headers: &HeaderMap) -> Result<ContentRange, SourceError> {
+    let value = headers
+        .get(CONTENT_RANGE)
+        .ok_or_else(|| {
+            SourceError::new(SourceErrorKind::Protocol, "response has no Content-Range")
+        })?
+        .to_str()
+        .map_err(|error| {
+            SourceError::new(
+                SourceErrorKind::Protocol,
+                format!("Content-Range is not valid ASCII: {error}"),
+            )
+        })?;
+    let value = value.strip_prefix("bytes ").ok_or_else(|| {
+        SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("unsupported Content-Range unit: {value}"),
+        )
+    })?;
+    let (range, total) = value.split_once('/').ok_or_else(|| {
+        SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("malformed Content-Range: {value}"),
+        )
+    })?;
+    let (start, end) = range.split_once('-').ok_or_else(|| {
+        SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("malformed Content-Range: {value}"),
+        )
+    })?;
+    let start = parse_number(start, "Content-Range start")?;
+    let end = parse_number(end, "Content-Range end")?;
+    let total = (total != "*")
+        .then(|| parse_number(total, "Content-Range total"))
+        .transpose()?;
+    if end < start || total.is_some_and(|total| end >= total) {
+        return Err(SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("invalid Content-Range bounds: {value}"),
+        ));
+    }
+    Ok(ContentRange { start, end, total })
+}
+
+fn parse_number(value: &str, field: &str) -> Result<u64, SourceError> {
+    value.parse().map_err(|error| {
+        SourceError::new(
+            SourceErrorKind::Protocol,
+            format!("invalid {field} {value:?}: {error}"),
+        )
+    })
+}
+
+fn classify_reqwest_error(error: reqwest::Error) -> SourceError {
+    let kind = if error.is_timeout() {
+        SourceErrorKind::Timeout
+    } else if error.is_connect() || error.is_body() {
+        SourceErrorKind::Transport
+    } else {
+        SourceErrorKind::Other
+    };
+    SourceError::new(kind, error.to_string())
+}
+
+fn status_error(status: StatusCode) -> SourceError {
+    let kind = if status.is_server_error()
+        || status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+    {
+        SourceErrorKind::Other
+    } else {
+        SourceErrorKind::Protocol
+    };
+    SourceError::new(kind, format!("expected HTTP 206, got {status}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::{
+        Client, Url,
+        header::{ACCEPT_ENCODING, CONTENT_RANGE, HeaderMap, IF_RANGE, RANGE},
+    };
+
+    use super::{HttpRangeSource, satisfied_content_range};
+    use haya::ByteRange;
+
+    #[test]
+    fn range_requests_replace_conflicting_headers() {
+        let mut default_headers = HeaderMap::new();
+        default_headers.append(ACCEPT_ENCODING, "gzip".parse().expect("header"));
+        default_headers.append(RANGE, "bytes=7-".parse().expect("header"));
+        default_headers.append(IF_RANGE, "stale-default".parse().expect("header"));
+        let client = Client::builder()
+            .default_headers(default_headers)
+            .build()
+            .expect("client");
+        let mut source_headers = HeaderMap::new();
+        source_headers.append(ACCEPT_ENCODING, "br".parse().expect("header"));
+        source_headers.append(RANGE, "bytes=9-".parse().expect("header"));
+        source_headers.append(IF_RANGE, "stale-source".parse().expect("header"));
+        let source = HttpRangeSource::new(
+            client,
+            Url::parse("https://example.test/media").expect("URL"),
+            source_headers,
+        );
+
+        let request = source
+            .request(ByteRange::new(2, 6).expect("range"))
+            .expect("request");
+
+        assert_eq!(
+            request.headers().get(ACCEPT_ENCODING),
+            Some(&"identity".parse().unwrap())
+        );
+        assert_eq!(
+            request.headers().get(RANGE),
+            Some(&"bytes=2-5".parse().unwrap())
+        );
+        assert!(request.headers().get(IF_RANGE).is_none());
+    }
+
+    #[test]
+    fn parses_satisfied_content_ranges() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_RANGE, "bytes 2-5/9".parse().expect("header"));
+        let parsed = satisfied_content_range(&headers).expect("valid range");
+        assert_eq!((parsed.start, parsed.end, parsed.total), (2, 5, Some(9)));
+    }
+}

--- a/packages/yutto-core/rust/crates/haya-http/src/lib.rs
+++ b/packages/yutto-core/rust/crates/haya-http/src/lib.rs
@@ -21,6 +21,11 @@ impl HttpRangeSource {
     /// The client's default headers must not contain `If-Range`: reqwest adds
     /// missing default headers when executing a request, after this adapter has
     /// deliberately stripped any per-source `If-Range` value.
+    ///
+    /// The client must also be built with `no_gzip`, `no_brotli`, `no_deflate`,
+    /// and `no_zstd`. Cargo feature unification can otherwise enable reqwest's
+    /// automatic response decompression before this adapter validates the wire
+    /// encoding.
     pub fn new(client: Client, url: Url, headers: HeaderMap, expected_size: u64) -> Self {
         Self {
             client,

--- a/packages/yutto-core/rust/crates/haya-http/src/lib.rs
+++ b/packages/yutto-core/rust/crates/haya-http/src/lib.rs
@@ -212,7 +212,7 @@ fn classify_reqwest_error(error: reqwest::Error) -> SourceError {
     } else {
         SourceErrorKind::Other
     };
-    SourceError::new(kind, error.to_string())
+    SourceError::new(kind, error.without_url().to_string())
 }
 
 fn status_error(status: StatusCode) -> SourceError {

--- a/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
@@ -20,6 +20,7 @@ enum Behavior {
     Normal,
     IgnoreRange,
     WrongRange,
+    Disconnect,
 }
 
 struct FaultServer {
@@ -107,6 +108,10 @@ async fn serve_connection(
         .lock()
         .expect("request lock poisoned")
         .push(range.unwrap_or("<none>").to_owned());
+
+    if matches!(behavior, Behavior::Disconnect) {
+        return;
+    }
 
     if matches!(behavior, Behavior::IgnoreRange) {
         write_response(&mut socket, "200 OK", &[], &payload).await;
@@ -276,4 +281,22 @@ async fn rejects_a_conflicting_content_range_total() {
         result,
         Err(error) if error.kind == SourceErrorKind::Protocol
     ));
+}
+
+#[tokio::test]
+async fn redacts_the_url_from_transport_errors() {
+    let server = FaultServer::spawn(payload(4096), Behavior::Disconnect).await;
+    let mut url = server.url.clone();
+    url.set_query(Some("token=secret"));
+    let source = HttpRangeSource::new(Client::new(), url, HeaderMap::new(), 4096);
+    let error = match source
+        .open(haya::ByteRange::new(0, 1024).expect("range"))
+        .await
+    {
+        Ok(_) => panic!("disconnected response must fail"),
+        Err(error) => error,
+    };
+
+    assert!(!error.message.contains("secret"));
+    assert!(!error.message.contains(server.url.as_str()));
 }

--- a/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
@@ -21,6 +21,7 @@ enum Behavior {
     IgnoreRange,
     WrongRange,
     Disconnect,
+    GzipEncoding,
 }
 
 struct FaultServer {
@@ -129,6 +130,25 @@ async fn serve_connection(
         start
     };
     let content_range = format!("bytes {content_start}-{}/{}", end - 1, payload.len());
+    if matches!(behavior, Behavior::GzipEncoding) {
+        const GZIP_1024_ZEROS: &[u8] = &[
+            0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x63, 0x60, 0x18, 0x05,
+            0xa3, 0x60, 0x14, 0x8c, 0x54, 0x00, 0x00, 0x2e, 0xaf, 0xb5, 0xef, 0x00, 0x04, 0x00,
+            0x00,
+        ];
+        assert_eq!(payload.len(), 1024);
+        write_response(
+            &mut socket,
+            "206 Partial Content",
+            &[
+                ("Content-Range", content_range),
+                ("Content-Encoding", "gzip".to_owned()),
+            ],
+            GZIP_1024_ZEROS,
+        )
+        .await;
+        return;
+    }
     write_response(
         &mut socket,
         "206 Partial Content",
@@ -274,6 +294,28 @@ async fn rejects_a_conflicting_content_range_total() {
     let server = FaultServer::spawn(payload(4096), Behavior::Normal).await;
     let result = server
         .source(8192)
+        .open(haya::ByteRange::new(0, 1024).expect("range"))
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(error) if error.kind == SourceErrorKind::Protocol
+    ));
+}
+
+#[tokio::test]
+async fn rejects_encoded_ranges_when_reqwest_decoders_are_available() {
+    let server = FaultServer::spawn(vec![0; 1024], Behavior::GzipEncoding).await;
+    let client = Client::builder()
+        .no_gzip()
+        .no_brotli()
+        .no_deflate()
+        .no_zstd()
+        .build()
+        .expect("range client");
+    let source = HttpRangeSource::new(client, server.url.clone(), HeaderMap::new(), 1024);
+
+    let result = source
         .open(haya::ByteRange::new(0, 1024).expect("range"))
         .await;
 

--- a/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
@@ -172,6 +172,7 @@ fn spec(expected_size: u64) -> DownloadSpec {
         workers: 3,
         max_attempts: 2,
         source_cooldown: Duration::from_millis(1),
+        attempt_timeout: Duration::from_secs(1),
     }
 }
 

--- a/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
@@ -1,0 +1,260 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use haya::{
+    CommitSink, DownloadSpec, Downloader, RangeSource, SourceErrorKind,
+    file::{FileOpenMode, FileSink},
+};
+use haya_http::HttpRangeSource;
+use reqwest::{Client, Url, header::HeaderMap};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    task::JoinHandle,
+};
+
+#[derive(Clone, Copy)]
+enum Behavior {
+    Normal,
+    IgnoreRange,
+    WrongRange,
+}
+
+struct FaultServer {
+    url: Url,
+    requests: Arc<Mutex<Vec<String>>>,
+    task: JoinHandle<()>,
+}
+
+impl FaultServer {
+    async fn spawn(payload: Vec<u8>, behavior: Behavior) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fault server");
+        let address = listener.local_addr().expect("local address");
+        let payload = Arc::new(payload);
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let task_requests = requests.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                let Ok((socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let payload = payload.clone();
+                let requests = task_requests.clone();
+                tokio::spawn(async move {
+                    serve_connection(socket, payload, behavior, requests).await;
+                });
+            }
+        });
+        Self {
+            url: Url::parse(&format!("http://{address}/asset")).expect("server URL"),
+            requests,
+            task,
+        }
+    }
+
+    fn source(&self) -> Arc<HttpRangeSource> {
+        Arc::new(HttpRangeSource::new(
+            Client::new(),
+            self.url.clone(),
+            HeaderMap::new(),
+        ))
+    }
+
+    fn requested_ranges(&self) -> Vec<String> {
+        self.requests.lock().expect("request lock poisoned").clone()
+    }
+}
+
+impl Drop for FaultServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn serve_connection(
+    mut socket: TcpStream,
+    payload: Arc<Vec<u8>>,
+    behavior: Behavior,
+    requests: Arc<Mutex<Vec<String>>>,
+) {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 2048];
+    loop {
+        let Ok(read) = socket.read(&mut buffer).await else {
+            return;
+        };
+        if read == 0 {
+            return;
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let request = String::from_utf8_lossy(&request);
+    let range = request.lines().find_map(|line| {
+        line.strip_prefix("Range: ")
+            .or_else(|| line.strip_prefix("range: "))
+            .map(str::trim)
+    });
+    requests
+        .lock()
+        .expect("request lock poisoned")
+        .push(range.unwrap_or("<none>").to_owned());
+
+    if matches!(behavior, Behavior::IgnoreRange) {
+        write_response(&mut socket, "200 OK", &[], &payload).await;
+        return;
+    }
+
+    let Some((start, end)) = range.and_then(parse_range) else {
+        write_response(&mut socket, "400 Bad Request", &[], b"").await;
+        return;
+    };
+    let end = end.min(payload.len());
+    let content_start = if matches!(behavior, Behavior::WrongRange) {
+        start + 1
+    } else {
+        start
+    };
+    let content_range = format!("bytes {content_start}-{}/{}", end - 1, payload.len());
+    write_response(
+        &mut socket,
+        "206 Partial Content",
+        &[("Content-Range", content_range)],
+        &payload[start..end],
+    )
+    .await;
+}
+
+fn parse_range(value: &str) -> Option<(usize, usize)> {
+    let value = value.strip_prefix("bytes=")?;
+    let (start, end) = value.split_once('-')?;
+    Some((
+        start.parse().ok()?,
+        end.parse::<usize>().ok()?.checked_add(1)?,
+    ))
+}
+
+async fn write_response(
+    socket: &mut TcpStream,
+    status: &str,
+    headers: &[(&str, String)],
+    body: &[u8],
+) {
+    let mut head = format!(
+        "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        body.len()
+    );
+    for (name, value) in headers {
+        head.push_str(&format!("{name}: {value}\r\n"));
+    }
+    head.push_str("\r\n");
+    socket
+        .write_all(head.as_bytes())
+        .await
+        .expect("write response headers");
+    socket.write_all(body).await.expect("write response body");
+    socket.shutdown().await.expect("close response");
+}
+
+fn spec(expected_size: u64) -> DownloadSpec {
+    DownloadSpec {
+        expected_size,
+        page_size: 1024,
+        block_size: 4 * 1024,
+        window_pages: 8,
+        workers: 3,
+        max_attempts: 2,
+        source_cooldown: Duration::from_millis(1),
+    }
+}
+
+fn payload(size: usize) -> Vec<u8> {
+    (0..size).map(|index| (index % 251) as u8).collect()
+}
+
+#[tokio::test]
+async fn downloads_to_a_file_and_resumes_from_an_unaligned_length() {
+    let expected = payload(20 * 1024 + 17);
+    let server = FaultServer::spawn(expected.clone(), Behavior::Normal).await;
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    let prefix = 1237;
+    tokio::fs::write(&path, &expected[..prefix])
+        .await
+        .expect("write prefix");
+    let sink = Arc::new(
+        FileSink::open(&path, FileOpenMode::ResumeFromLength)
+            .await
+            .expect("open file sink"),
+    );
+
+    let report = Downloader::new(
+        spec(expected.len() as u64),
+        vec![server.source()],
+        sink.clone(),
+    )
+    .expect("valid downloader")
+    .run()
+    .await
+    .expect("download succeeds");
+    sink.close().await.expect("close output");
+
+    assert_eq!(report.committed_bytes, expected.len() as u64);
+    assert_eq!(tokio::fs::read(path).await.expect("read output"), expected);
+    assert!(
+        server
+            .requested_ranges()
+            .iter()
+            .all(|range| range.starts_with("bytes=") && !range.ends_with('-'))
+    );
+}
+
+#[tokio::test]
+async fn switches_to_a_mirror_after_wrong_content_range() {
+    let expected = payload(12 * 1024 + 3);
+    let bad = FaultServer::spawn(expected.clone(), Behavior::WrongRange).await;
+    let good = FaultServer::spawn(expected.clone(), Behavior::Normal).await;
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    let sink = Arc::new(
+        FileSink::open(&path, FileOpenMode::Overwrite)
+            .await
+            .expect("open file sink"),
+    );
+
+    Downloader::new(
+        spec(expected.len() as u64),
+        vec![bad.source(), good.source()],
+        sink.clone(),
+    )
+    .expect("valid downloader")
+    .run()
+    .await
+    .expect("healthy mirror finishes download");
+    sink.close().await.expect("close output");
+
+    assert_eq!(tokio::fs::read(path).await.expect("read output"), expected);
+    assert!(!bad.requested_ranges().is_empty());
+    assert!(!good.requested_ranges().is_empty());
+}
+
+#[tokio::test]
+async fn rejects_servers_that_ignore_range_requests() {
+    let server = FaultServer::spawn(payload(4096), Behavior::IgnoreRange).await;
+    let result = server
+        .source()
+        .open(haya::ByteRange::new(0, 1024).expect("range"))
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(error) if error.kind == SourceErrorKind::Protocol
+    ));
+}

--- a/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
+++ b/packages/yutto-core/rust/crates/haya-http/tests/http_download.rs
@@ -56,11 +56,12 @@ impl FaultServer {
         }
     }
 
-    fn source(&self) -> Arc<HttpRangeSource> {
+    fn source(&self, expected_size: u64) -> Arc<HttpRangeSource> {
         Arc::new(HttpRangeSource::new(
             Client::new(),
             self.url.clone(),
             HeaderMap::new(),
+            expected_size,
         ))
     }
 
@@ -198,7 +199,7 @@ async fn downloads_to_a_file_and_resumes_from_an_unaligned_length() {
 
     let report = Downloader::new(
         spec(expected.len() as u64),
-        vec![server.source()],
+        vec![server.source(expected.len() as u64)],
         sink.clone(),
     )
     .expect("valid downloader")
@@ -232,7 +233,10 @@ async fn switches_to_a_mirror_after_wrong_content_range() {
 
     Downloader::new(
         spec(expected.len() as u64),
-        vec![bad.source(), good.source()],
+        vec![
+            bad.source(expected.len() as u64),
+            good.source(expected.len() as u64),
+        ],
         sink.clone(),
     )
     .expect("valid downloader")
@@ -250,7 +254,21 @@ async fn switches_to_a_mirror_after_wrong_content_range() {
 async fn rejects_servers_that_ignore_range_requests() {
     let server = FaultServer::spawn(payload(4096), Behavior::IgnoreRange).await;
     let result = server
-        .source()
+        .source(4096)
+        .open(haya::ByteRange::new(0, 1024).expect("range"))
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(error) if error.kind == SourceErrorKind::Protocol
+    ));
+}
+
+#[tokio::test]
+async fn rejects_a_conflicting_content_range_total() {
+    let server = FaultServer::spawn(payload(4096), Behavior::Normal).await;
+    let result = server
+        .source(8192)
         .open(haya::ByteRange::new(0, 1024).expect("range"))
         .await;
 

--- a/packages/yutto-core/rust/crates/haya/src/file.rs
+++ b/packages/yutto-core/rust/crates/haya/src/file.rs
@@ -1,0 +1,166 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tokio::{
+    fs::{File, OpenOptions},
+    io::{AsyncSeekExt, AsyncWriteExt, SeekFrom},
+    sync::Mutex,
+};
+
+use crate::{CommitSink, SinkError};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FileOpenMode {
+    Overwrite,
+    /// Continue from the existing file length.
+    ///
+    /// The caller must ensure that the existing bytes are a prefix of the same
+    /// resource identity. Length alone cannot detect a different resource with
+    /// the same size.
+    ResumeFromLength,
+}
+
+pub struct FileSink {
+    state: Mutex<FileState>,
+}
+
+struct FileState {
+    file: File,
+    committed: u64,
+    closed: bool,
+}
+
+impl FileSink {
+    pub async fn open(path: impl AsRef<Path>, mode: FileOpenMode) -> Result<Self, SinkError> {
+        let mut options = OpenOptions::new();
+        options.create(true).write(true);
+        match mode {
+            FileOpenMode::Overwrite => {
+                options.truncate(true);
+            }
+            FileOpenMode::ResumeFromLength => {}
+        }
+
+        let mut file = options.open(path.as_ref()).await.map_err(|error| {
+            SinkError::new(format!(
+                "failed to open {}: {error}",
+                path.as_ref().display()
+            ))
+        })?;
+        let committed = match mode {
+            FileOpenMode::Overwrite => 0,
+            FileOpenMode::ResumeFromLength => file
+                .seek(SeekFrom::End(0))
+                .await
+                .map_err(|error| SinkError::new(format!("failed to seek output file: {error}")))?,
+        };
+
+        Ok(Self {
+            state: Mutex::new(FileState {
+                file,
+                committed,
+                closed: false,
+            }),
+        })
+    }
+}
+
+#[async_trait]
+impl CommitSink for FileSink {
+    async fn committed_offset(&self) -> Result<u64, SinkError> {
+        Ok(self.state.lock().await.committed)
+    }
+
+    async fn append(&self, offset: u64, data: Bytes) -> Result<(), SinkError> {
+        let mut state = self.state.lock().await;
+        if state.closed {
+            return Err(SinkError::new("cannot append to a closed file sink"));
+        }
+        if offset != state.committed {
+            return Err(SinkError::new(format!(
+                "append at {offset}, committed offset is {}",
+                state.committed
+            )));
+        }
+        let write_result = async {
+            state.file.write_all(&data).await?;
+            // Tokio may report the buffered write's OS error only when the
+            // in-flight blocking operation is polled again.
+            state.file.flush().await
+        }
+        .await;
+        if let Err(write_error) = write_result {
+            let committed = state.committed;
+            let rollback = async {
+                state.file.set_len(committed).await?;
+                state.file.seek(SeekFrom::Start(committed)).await?;
+                Ok::<_, std::io::Error>(())
+            }
+            .await;
+            if let Err(rollback_error) = rollback {
+                state.closed = true;
+                return Err(SinkError::new(format!(
+                    "failed to write output file: {write_error}; failed to restore committed offset {committed}, so the sink was closed: {rollback_error}"
+                )));
+            }
+            return Err(SinkError::new(format!(
+                "failed to write output file: {write_error}"
+            )));
+        }
+        state.committed += data.len() as u64;
+        Ok(())
+    }
+
+    async fn flush(&self) -> Result<(), SinkError> {
+        let mut state = self.state.lock().await;
+        state
+            .file
+            .flush()
+            .await
+            .map_err(|error| SinkError::new(format!("failed to flush output file: {error}")))
+    }
+
+    async fn close(&self) -> Result<(), SinkError> {
+        let mut state = self.state.lock().await;
+        state
+            .file
+            .flush()
+            .await
+            .map_err(|error| SinkError::new(format!("failed to flush output file: {error}")))?;
+        state.closed = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn poisons_the_sink_when_a_failed_write_cannot_be_rolled_back() {
+        let temporary = tempfile::NamedTempFile::new().expect("temporary file");
+        let read_only = std::fs::OpenOptions::new()
+            .read(true)
+            .open(temporary.path())
+            .expect("open read-only file");
+        let sink = FileSink {
+            state: Mutex::new(FileState {
+                file: File::from_std(read_only),
+                committed: 0,
+                closed: false,
+            }),
+        };
+
+        let first = sink
+            .append(0, Bytes::from_static(b"data"))
+            .await
+            .expect_err("read-only file rejects writes");
+        assert!(first.message.contains("sink was closed"));
+        let second = sink
+            .append(0, Bytes::from_static(b"data"))
+            .await
+            .expect_err("poisoned sink rejects reuse");
+        assert_eq!(second.message, "cannot append to a closed file sink");
+    }
+}

--- a/packages/yutto-core/rust/crates/haya/src/file.rs
+++ b/packages/yutto-core/rust/crates/haya/src/file.rs
@@ -26,7 +26,7 @@ pub struct FileSink {
 }
 
 struct FileState {
-    file: File,
+    file: Option<File>,
     committed: u64,
     closed: bool,
 }
@@ -58,7 +58,7 @@ impl FileSink {
 
         Ok(Self {
             state: Mutex::new(FileState {
-                file,
+                file: Some(file),
                 committed,
                 closed: false,
             }),
@@ -83,23 +83,32 @@ impl CommitSink for FileSink {
                 state.committed
             )));
         }
+        let file = state
+            .file
+            .as_mut()
+            .ok_or_else(|| SinkError::new("cannot append to a closed file sink"))?;
         let write_result = async {
-            state.file.write_all(&data).await?;
+            file.write_all(&data).await?;
             // Tokio may report the buffered write's OS error only when the
             // in-flight blocking operation is polled again.
-            state.file.flush().await
+            file.flush().await
         }
         .await;
         if let Err(write_error) = write_result {
             let committed = state.committed;
+            let file = state
+                .file
+                .as_mut()
+                .expect("an open sink retains its file until close");
             let rollback = async {
-                state.file.set_len(committed).await?;
-                state.file.seek(SeekFrom::Start(committed)).await?;
+                file.set_len(committed).await?;
+                file.seek(SeekFrom::Start(committed)).await?;
                 Ok::<_, std::io::Error>(())
             }
             .await;
             if let Err(rollback_error) = rollback {
                 state.closed = true;
+                state.file.take();
                 return Err(SinkError::new(format!(
                     "failed to write output file: {write_error}; failed to restore committed offset {committed}, so the sink was closed: {rollback_error}"
                 )));
@@ -114,21 +123,25 @@ impl CommitSink for FileSink {
 
     async fn flush(&self) -> Result<(), SinkError> {
         let mut state = self.state.lock().await;
-        state
-            .file
-            .flush()
+        let Some(file) = state.file.as_mut() else {
+            return Ok(());
+        };
+        file.flush()
             .await
             .map_err(|error| SinkError::new(format!("failed to flush output file: {error}")))
     }
 
     async fn close(&self) -> Result<(), SinkError> {
         let mut state = self.state.lock().await;
-        state
-            .file
-            .flush()
+        let Some(file) = state.file.as_mut() else {
+            state.closed = true;
+            return Ok(());
+        };
+        file.flush()
             .await
             .map_err(|error| SinkError::new(format!("failed to flush output file: {error}")))?;
         state.closed = true;
+        state.file.take();
         Ok(())
     }
 }
@@ -146,7 +159,7 @@ mod tests {
             .expect("open read-only file");
         let sink = FileSink {
             state: Mutex::new(FileState {
-                file: File::from_std(read_only),
+                file: Some(File::from_std(read_only)),
                 committed: 0,
                 closed: false,
             }),
@@ -162,5 +175,19 @@ mod tests {
             .await
             .expect_err("poisoned sink rejects reuse");
         assert_eq!(second.message, "cannot append to a closed file sink");
+    }
+
+    #[tokio::test]
+    async fn close_releases_the_file_handle() {
+        let temporary = tempfile::NamedTempFile::new().expect("temporary file");
+        let sink = FileSink::open(temporary.path(), FileOpenMode::Overwrite)
+            .await
+            .expect("open file sink");
+
+        sink.close().await.expect("close file sink");
+
+        let state = sink.state.lock().await;
+        assert!(state.closed);
+        assert!(state.file.is_none());
     }
 }

--- a/packages/yutto-core/rust/crates/haya/src/file.rs
+++ b/packages/yutto-core/rust/crates/haya/src/file.rs
@@ -29,6 +29,7 @@ struct FileState {
     file: Option<File>,
     committed: u64,
     closed: bool,
+    poisoned: bool,
 }
 
 impl FileSink {
@@ -61,6 +62,7 @@ impl FileSink {
                 file: Some(file),
                 committed,
                 closed: false,
+                poisoned: false,
             }),
         })
     }
@@ -69,7 +71,11 @@ impl FileSink {
 #[async_trait]
 impl CommitSink for FileSink {
     async fn committed_offset(&self) -> Result<u64, SinkError> {
-        Ok(self.state.lock().await.committed)
+        let state = self.state.lock().await;
+        if state.poisoned {
+            return Err(cancelled_append_error());
+        }
+        Ok(state.committed)
     }
 
     async fn append(&self, offset: u64, data: Bytes) -> Result<(), SinkError> {
@@ -77,16 +83,17 @@ impl CommitSink for FileSink {
         if state.closed {
             return Err(SinkError::new("cannot append to a closed file sink"));
         }
+        if state.poisoned {
+            return Err(cancelled_append_error());
+        }
         if offset != state.committed {
             return Err(SinkError::new(format!(
                 "append at {offset}, committed offset is {}",
                 state.committed
             )));
         }
-        let file = state
-            .file
-            .as_mut()
-            .ok_or_else(|| SinkError::new("cannot append to a closed file sink"))?;
+        state.poisoned = true;
+        let file = state.file.as_mut().expect("an open sink retains its file");
         let write_result = async {
             file.write_all(&data).await?;
             // Tokio may report the buffered write's OS error only when the
@@ -113,16 +120,21 @@ impl CommitSink for FileSink {
                     "failed to write output file: {write_error}; failed to restore committed offset {committed}, so the sink was closed: {rollback_error}"
                 )));
             }
+            state.poisoned = false;
             return Err(SinkError::new(format!(
                 "failed to write output file: {write_error}"
             )));
         }
         state.committed += data.len() as u64;
+        state.poisoned = false;
         Ok(())
     }
 
     async fn flush(&self) -> Result<(), SinkError> {
         let mut state = self.state.lock().await;
+        if state.poisoned {
+            return Err(cancelled_append_error());
+        }
         let Some(file) = state.file.as_mut() else {
             return Ok(());
         };
@@ -133,6 +145,11 @@ impl CommitSink for FileSink {
 
     async fn close(&self) -> Result<(), SinkError> {
         let mut state = self.state.lock().await;
+        if state.poisoned {
+            state.closed = true;
+            state.file.take();
+            return Err(cancelled_append_error());
+        }
         let Some(file) = state.file.as_mut() else {
             state.closed = true;
             return Ok(());
@@ -144,6 +161,10 @@ impl CommitSink for FileSink {
         state.file.take();
         Ok(())
     }
+}
+
+fn cancelled_append_error() -> SinkError {
+    SinkError::new("file sink is unusable because an append was cancelled")
 }
 
 #[cfg(test)]
@@ -162,6 +183,7 @@ mod tests {
                 file: Some(File::from_std(read_only)),
                 committed: 0,
                 closed: false,
+                poisoned: false,
             }),
         };
 
@@ -189,5 +211,27 @@ mod tests {
         let state = sink.state.lock().await;
         assert!(state.closed);
         assert!(state.file.is_none());
+    }
+
+    #[tokio::test]
+    async fn rejects_reuse_after_an_append_future_is_dropped() {
+        use std::{future::Future, task::Context};
+
+        use futures_util::task::noop_waker_ref;
+
+        let temporary = tempfile::NamedTempFile::new().expect("temporary file");
+        let sink = FileSink::open(temporary.path(), FileOpenMode::Overwrite)
+            .await
+            .expect("open file sink");
+        let mut append = Box::pin(sink.append(0, Bytes::from(vec![0; 16 * 1024 * 1024])));
+        let mut context = Context::from_waker(noop_waker_ref());
+
+        assert!(append.as_mut().poll(&mut context).is_pending());
+        drop(append);
+
+        assert!(sink.committed_offset().await.is_err());
+        assert!(sink.append(0, Bytes::from_static(b"tail")).await.is_err());
+        assert!(sink.close().await.is_err());
+        assert!(sink.state.lock().await.file.is_none());
     }
 }

--- a/packages/yutto-core/rust/crates/haya/src/lib.rs
+++ b/packages/yutto-core/rust/crates/haya/src/lib.rs
@@ -2,6 +2,7 @@ mod buffer;
 mod downloader;
 mod error;
 mod event;
+pub mod file;
 mod model;
 mod sink;
 mod source;

--- a/packages/yutto-core/rust/crates/haya/tests/file_sink.rs
+++ b/packages/yutto-core/rust/crates/haya/tests/file_sink.rs
@@ -1,0 +1,60 @@
+use bytes::Bytes;
+use haya::{
+    CommitSink,
+    file::{FileOpenMode, FileSink},
+};
+
+#[tokio::test]
+async fn overwrites_and_appends_contiguously() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    tokio::fs::write(&path, b"old bytes")
+        .await
+        .expect("seed output");
+
+    let sink = FileSink::open(&path, FileOpenMode::Overwrite)
+        .await
+        .expect("open sink");
+    sink.append(0, Bytes::from_static(b"new"))
+        .await
+        .expect("append bytes");
+    sink.close().await.expect("close sink");
+
+    assert_eq!(tokio::fs::read(path).await.expect("read output"), b"new");
+}
+
+#[tokio::test]
+async fn resumes_from_the_existing_contiguous_length() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    tokio::fs::write(&path, b"prefix")
+        .await
+        .expect("seed output");
+
+    let sink = FileSink::open(&path, FileOpenMode::ResumeFromLength)
+        .await
+        .expect("open sink");
+    assert_eq!(sink.committed_offset().await.expect("read offset"), 6);
+    sink.append(6, Bytes::from_static(b"-suffix"))
+        .await
+        .expect("append bytes");
+    sink.flush().await.expect("flush sink");
+
+    assert_eq!(
+        tokio::fs::read(path).await.expect("read output"),
+        b"prefix-suffix"
+    );
+}
+
+#[tokio::test]
+async fn rejects_non_contiguous_writes_and_writes_after_close() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    let sink = FileSink::open(&path, FileOpenMode::Overwrite)
+        .await
+        .expect("open sink");
+
+    assert!(sink.append(1, Bytes::from_static(b"gap")).await.is_err());
+    sink.close().await.expect("close sink");
+    assert!(sink.append(0, Bytes::from_static(b"late")).await.is_err());
+}


### PR DESCRIPTION
## 动机

在通用核心之外提供真实 HTTP Range source 和默认顺序文件 sink，形成不依赖 yutto 的完整多源文件下载能力。本 PR 是 Haya 迁移 stack 的 Phase 2/5，依赖 Phase 1。

## 解决方案

- 新增 `haya-http` reqwest adapter，支持注入外部 client、构造精确 Range 请求并流式返回响应；
- 严格校验 HTTP 206、唯一的 `Content-Range`、请求区间、资源总大小和 wire encoding，并从传输错误中移除 URL；
- 明确注入 client 不得携带默认 `If-Range`，且必须通过 `no_gzip`、`no_brotli`、`no_deflate`、`no_zstd` 关闭自动解压；
- 分类 timeout、transport、protocol 等错误，供 Haya 的有限重试、源冷却和递归拆块策略使用；
- 在 `haya::file` 增加 `Overwrite` / `ResumeFromLength` 顺序 `FileSink`，普通写入失败时回滚到 committed offset；
- 若 `append` future 在文件 I/O 中途被取消，则 poison 当前 sink，拒绝继续伪装一致；`close` 会释放文件句柄；
- 增加本地 TCP fault server，覆盖镜像切换、错误/重复 Range 元数据、忽略 Range、非 identity encoding、Cargo feature 合并、URL 脱敏、取消写入和非对齐续传；
- 提供使用 `Overwrite` 且显式关闭 reqwest 自动解压的小型 Rust download example；
- crate README 保持一段一行，不做 Markdown 源码硬换行。

验证：stable 与 Rust 1.85 下 fmt/clippy/test 43 passed；仓库 `just fmt`、`just lint` 通过；GitHub 20/20 checks passed。

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [x] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [x] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
