### PR TITLE
♻️ refactor: move fetches to native sessions

### DIFF
--- a/packages/yutto-core/rust/Cargo.lock
+++ b/packages/yutto-core/rust/Cargo.lock
@@ -1675,6 +1675,7 @@ name = "yutto"
 version = "0.0.1"
 dependencies = [
  "bytes",
+ "flate2",
  "haya",
  "haya-http",
  "pyo3",

--- a/packages/yutto-core/rust/Cargo.toml
+++ b/packages/yutto-core/rust/Cargo.toml
@@ -12,6 +12,7 @@ license = "GPL-3.0-only"
 [workspace.dependencies]
 async-trait = "0.1.89"
 bytes = "1.10.1"
+flate2 = "1.1.9"
 futures-util = "0.3.31"
 reqwest = { version = "0.12.24", default-features = false, features = ["cookies", "http2", "rustls-tls", "socks", "stream"] }
 thiserror = "2.0.17"

--- a/packages/yutto-core/rust/crates/yutto/Cargo.toml
+++ b/packages/yutto-core/rust/crates/yutto/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bytes.workspace = true
+flate2.workspace = true
 haya = { version = "0.0.1", path = "../haya" }
 haya-http = { version = "0.0.1", path = "../haya-http" }
 pyo3 = "0.29.0"

--- a/packages/yutto-core/rust/crates/yutto/src/lib.rs
+++ b/packages/yutto-core/rust/crates/yutto/src/lib.rs
@@ -19,7 +19,7 @@ use pyo3::{
 use reqwest::{Client, Url};
 use tokio_util::sync::CancellationToken;
 
-use crate::session::{Response, Session, SessionConfig, SessionError, build_headers};
+use crate::session::{Response, Session, SessionConfig, SessionError};
 
 pub mod session;
 
@@ -181,7 +181,6 @@ impl NativeSession {
             target,
             expected_size,
             overwrite,
-            None,
             workers,
             block_size,
         )
@@ -253,51 +252,12 @@ impl ProgressSink for StateProgress {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-#[pyfunction]
-#[pyo3(signature = (sources, target, expected_size, *, overwrite=false, headers=None, source_headers=None, proxy=None, use_system_proxy=true, accept_invalid_certs=false, workers=8, block_size=524288))]
-fn start_transfer(
-    sources: Vec<String>,
-    target: PathBuf,
-    expected_size: u64,
-    overwrite: bool,
-    headers: Option<HashMap<String, String>>,
-    source_headers: Option<Vec<HashMap<String, String>>>,
-    proxy: Option<String>,
-    use_system_proxy: bool,
-    accept_invalid_certs: bool,
-    workers: usize,
-    block_size: usize,
-) -> PyResult<TransferHandle> {
-    let session = Session::new(SessionConfig {
-        headers: headers.unwrap_or_default(),
-        proxy,
-        use_system_proxy,
-        accept_invalid_certs,
-        connect_timeout: Duration::from_secs(3),
-        ..SessionConfig::default()
-    })
-    .map_err(session_error_to_py)?;
-    start_transfer_with_session(
-        &session,
-        sources,
-        target,
-        expected_size,
-        overwrite,
-        source_headers,
-        workers,
-        block_size,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
 fn start_transfer_with_session(
     session: &Session,
     sources: Vec<String>,
     target: PathBuf,
     expected_size: u64,
     overwrite: bool,
-    source_headers: Option<Vec<HashMap<String, String>>>,
     workers: usize,
     block_size: usize,
 ) -> PyResult<TransferHandle> {
@@ -309,12 +269,6 @@ fn start_transfer_with_session(
     }
     if block_size == 0 {
         return Err(PyValueError::new_err("block_size must be at least 1"));
-    }
-    let source_headers = source_headers.unwrap_or_else(|| vec![HashMap::new(); sources.len()]);
-    if source_headers.len() != sources.len() {
-        return Err(PyValueError::new_err(
-            "source_headers must contain one entry per source",
-        ));
     }
     let spec = transfer_spec(expected_size, workers, block_size);
     let client = session.client().map_err(session_error_to_py)?;
@@ -338,7 +292,6 @@ fn start_transfer_with_session(
             sources,
             target,
             overwrite,
-            source_headers,
             spec,
             cancellation: task_cancellation.clone(),
             state: task_state.clone(),
@@ -366,7 +319,6 @@ struct TransferArgs {
     sources: Vec<String>,
     target: PathBuf,
     overwrite: bool,
-    source_headers: Vec<HashMap<String, String>>,
     spec: DownloadSpec,
     cancellation: CancellationToken,
     state: Arc<Mutex<TransferState>>,
@@ -376,14 +328,13 @@ async fn run_transfer(args: TransferArgs) -> Result<u64, String> {
     let sources = args
         .sources
         .into_iter()
-        .zip(args.source_headers)
-        .map(|(source, headers)| {
+        .map(|source| {
             let url =
                 Url::parse(&source).map_err(|error| format!("invalid source URL: {error}"))?;
             Ok(Arc::new(HttpRangeSource::new(
                 args.client.clone(),
                 url,
-                build_headers(headers).map_err(|error| error.to_string())?,
+                Default::default(),
                 args.spec.expected_size,
             )) as Arc<dyn haya::RangeSource>)
         })
@@ -481,7 +432,6 @@ fn yutto(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "SessionClosedError",
         module.py().get_type::<SessionClosedError>(),
     )?;
-    module.add_function(wrap_pyfunction!(start_transfer, module)?)?;
     Ok(())
 }
 

--- a/packages/yutto-core/rust/crates/yutto/src/session.rs
+++ b/packages/yutto-core/rust/crates/yutto/src/session.rs
@@ -1,14 +1,16 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    io::Read,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use bytes::Bytes;
+use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use reqwest::{
     Client, Proxy, StatusCode, Url,
     cookie::{CookieStore, Jar},
-    header::{HeaderMap, HeaderName, HeaderValue},
+    header::{ACCEPT_ENCODING, CONTENT_ENCODING, HeaderMap, HeaderName, HeaderValue},
 };
 use thiserror::Error;
 
@@ -114,7 +116,10 @@ impl Session {
             ));
         }
 
-        let default_headers = build_headers(config.headers)?;
+        let mut default_headers = build_headers(config.headers)?;
+        default_headers
+            .entry(ACCEPT_ENCODING)
+            .or_insert(HeaderValue::from_static("gzip, deflate"));
         let cookies = Arc::new(SessionCookieStore::new(config.cookies)?);
         let mut builder = Client::builder()
             .no_gzip()
@@ -164,6 +169,7 @@ impl Session {
         let url = response.url().clone();
         let headers = response.headers().clone();
         let body = response.bytes().await.map_err(classify_reqwest_error)?;
+        let body = decode_response_body(&headers, body)?;
         Ok(Response {
             status,
             url,
@@ -243,6 +249,43 @@ fn classify_reqwest_error(error: reqwest::Error) -> SessionError {
     }
 }
 
+fn decode_response_body(headers: &HeaderMap, body: Bytes) -> Result<Bytes, SessionError> {
+    let Some(encoding) = headers.get(CONTENT_ENCODING) else {
+        return Ok(body);
+    };
+    let encoding = encoding.to_str().map_err(|error| {
+        SessionError::Transport(format!("invalid Content-Encoding header: {error}"))
+    })?;
+    let mut decoded = None;
+    for encoding in encoding.split(',').rev().map(str::trim) {
+        let input = decoded.as_deref().unwrap_or(body.as_ref());
+        let next = if encoding.eq_ignore_ascii_case("gzip") {
+            decode_reader(GzDecoder::new(input), "gzip")?
+        } else if encoding.eq_ignore_ascii_case("deflate") {
+            decode_deflate(input)?
+        } else {
+            continue;
+        };
+        decoded = Some(next);
+    }
+    Ok(decoded.map_or(body, Bytes::from))
+}
+
+fn decode_deflate(body: &[u8]) -> Result<Vec<u8>, SessionError> {
+    decode_reader(ZlibDecoder::new(body), "deflate")
+        .or_else(|_| decode_reader(DeflateDecoder::new(body), "deflate"))
+}
+
+fn decode_reader(mut decoder: impl Read, encoding: &str) -> Result<Vec<u8>, SessionError> {
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).map_err(|error| {
+        SessionError::Transport(format!(
+            "failed to decode {encoding} response body: {error}"
+        ))
+    })?;
+    Ok(decoded)
+}
+
 #[derive(Debug)]
 struct SessionCookieStore {
     jar: Jar,
@@ -296,31 +339,40 @@ impl CookieStore for SessionCookieStore {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, time::Duration};
+    use std::{collections::HashMap, io::Write, time::Duration};
 
-    use reqwest::{Url, cookie::CookieStore, header::HeaderValue};
+    use flate2::{
+        Compression,
+        write::{DeflateEncoder, GzEncoder, ZlibEncoder},
+    };
+    use reqwest::{
+        Url,
+        cookie::CookieStore,
+        header::{CONTENT_ENCODING, HeaderMap, HeaderValue},
+    };
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
         sync::oneshot,
     };
 
-    use super::{Session, SessionConfig, SessionCookieStore, SessionError};
+    use super::{Session, SessionConfig, SessionCookieStore, SessionError, decode_response_body};
 
     async fn serve_once(
-        response: &'static str,
+        response: impl AsRef<[u8]>,
         delay: Duration,
     ) -> (String, oneshot::Receiver<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
         let address = listener.local_addr().expect("address");
         let (request_sender, request_receiver) = oneshot::channel();
+        let response = response.as_ref().to_vec();
         tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("connection");
             let mut request = vec![0; 8192];
             let length = stream.read(&mut request).await.expect("request");
             let _ = request_sender.send(String::from_utf8_lossy(&request[..length]).into_owned());
             tokio::time::sleep(delay).await;
-            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.write_all(&response).await;
         });
         (format!("http://{address}/resource"), request_receiver)
     }
@@ -390,6 +442,73 @@ mod tests {
         assert!(matches!(session.client(), Err(SessionError::Closed)));
     }
 
+    #[test]
+    fn response_body_decodes_httpx_builtin_encodings() {
+        let payload = b"<i><d>danmaku</d></i>";
+        let mut gzip = GzEncoder::new(Vec::new(), Compression::default());
+        gzip.write_all(payload).expect("gzip input");
+        let mut zlib = ZlibEncoder::new(Vec::new(), Compression::default());
+        zlib.write_all(payload).expect("zlib input");
+        let mut deflate = DeflateEncoder::new(Vec::new(), Compression::default());
+        deflate.write_all(payload).expect("deflate input");
+
+        for (encoding, body) in [
+            ("gzip", gzip.finish().expect("gzip body")),
+            ("deflate", zlib.finish().expect("zlib body")),
+            ("deflate", deflate.finish().expect("deflate body")),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(CONTENT_ENCODING, HeaderValue::from_static(encoding));
+
+            assert_eq!(
+                decode_response_body(&headers, body.into()).expect("decoded body"),
+                payload.as_slice()
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_compressed_body_is_a_transport_error() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+
+        assert!(matches!(
+            decode_response_body(&headers, b"not gzip".as_slice().into()),
+            Err(SessionError::Transport(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_decodes_compressed_response_body() {
+        let payload = b"<i><d>danmaku</d></i>";
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(payload).expect("gzip input");
+        let body = encoder.finish().expect("gzip body");
+        let mut wire_response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        )
+        .into_bytes();
+        wire_response.extend(body);
+        let (url, _) = serve_once(wire_response, Duration::ZERO).await;
+        let session = Session::new(SessionConfig {
+            use_system_proxy: false,
+            ..SessionConfig::default()
+        })
+        .expect("session");
+
+        let response = session
+            .get(url, vec![], HashMap::new())
+            .await
+            .expect("response");
+
+        assert_eq!(response.body, payload.as_slice());
+        assert_eq!(
+            response.header("content-encoding").expect("header"),
+            Some("gzip")
+        );
+    }
+
     #[tokio::test]
     async fn get_returns_response_and_updates_the_shared_cookie_store() {
         let (url, request) = serve_once(
@@ -421,6 +540,7 @@ mod tests {
         assert!(request.starts_with("GET /resource?query=a+b HTTP/1.1\r\n"));
         assert!(request.contains("x-default: default\r\n"));
         assert!(request.contains("x-request: request\r\n"));
+        assert!(request.contains("accept-encoding: gzip, deflate\r\n"));
         assert!(request.contains("cookie: token=initial\r\n"));
         assert_eq!(
             session.cookie("token", &url).expect("cookie"),

--- a/packages/yutto-core/rust/crates/yutto/src/session.rs
+++ b/packages/yutto-core/rust/crates/yutto/src/session.rs
@@ -126,6 +126,7 @@ impl Session {
             .no_brotli()
             .no_deflate()
             .no_zstd()
+            .referer(false)
             .default_headers(default_headers)
             .cookie_provider(cookies.clone())
             .danger_accept_invalid_certs(config.accept_invalid_certs)
@@ -250,23 +251,31 @@ fn classify_reqwest_error(error: reqwest::Error) -> SessionError {
 }
 
 fn decode_response_body(headers: &HeaderMap, body: Bytes) -> Result<Bytes, SessionError> {
-    let Some(encoding) = headers.get(CONTENT_ENCODING) else {
+    let encodings = headers
+        .get_all(CONTENT_ENCODING)
+        .iter()
+        .map(|encoding| {
+            encoding.to_str().map_err(|error| {
+                SessionError::Transport(format!("invalid Content-Encoding header: {error}"))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if encodings.is_empty() {
         return Ok(body);
-    };
-    let encoding = encoding.to_str().map_err(|error| {
-        SessionError::Transport(format!("invalid Content-Encoding header: {error}"))
-    })?;
+    }
     let mut decoded = None;
-    for encoding in encoding.split(',').rev().map(str::trim) {
-        let input = decoded.as_deref().unwrap_or(body.as_ref());
-        let next = if encoding.eq_ignore_ascii_case("gzip") {
-            decode_reader(GzDecoder::new(input), "gzip")?
-        } else if encoding.eq_ignore_ascii_case("deflate") {
-            decode_deflate(input)?
-        } else {
-            continue;
-        };
-        decoded = Some(next);
+    for encodings in encodings.into_iter().rev() {
+        for encoding in encodings.split(',').rev().map(str::trim) {
+            let input = decoded.as_deref().unwrap_or(body.as_ref());
+            let next = if encoding.eq_ignore_ascii_case("gzip") {
+                decode_reader(GzDecoder::new(input), "gzip")?
+            } else if encoding.eq_ignore_ascii_case("deflate") {
+                decode_deflate(input)?
+            } else {
+                continue;
+            };
+            decoded = Some(next);
+        }
     }
     Ok(decoded.map_or(body, Bytes::from))
 }
@@ -396,6 +405,40 @@ mod tests {
         format!("http://{address}/resource")
     }
 
+    async fn serve_redirect_once() -> (String, oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+        let address = listener.local_addr().expect("address");
+        let (request_sender, request_receiver) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut source, _) = listener.accept().await.expect("source connection");
+            let mut request = vec![0; 8192];
+            let _ = source.read(&mut request).await.expect("source request");
+            source
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: /destination\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .expect("redirect response");
+
+            let (mut destination, _) = listener.accept().await.expect("destination connection");
+            let length = destination
+                .read(&mut request)
+                .await
+                .expect("destination request");
+            let _ = request_sender.send(String::from_utf8_lossy(&request[..length]).into_owned());
+            destination
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\npayload",
+                )
+                .await
+                .expect("destination response");
+        });
+        (
+            format!("http://{address}/source?token=secret"),
+            request_receiver,
+        )
+    }
+
     #[test]
     fn initial_cookies_are_available_across_hosts() {
         let store = SessionCookieStore::new(HashMap::from([("SESSDATA".into(), "secret".into())]))
@@ -465,6 +508,25 @@ mod tests {
                 payload.as_slice()
             );
         }
+    }
+
+    #[test]
+    fn response_body_decodes_repeated_content_encoding_fields() {
+        let payload = b"<i><d>danmaku</d></i>";
+        let mut deflate = ZlibEncoder::new(Vec::new(), Compression::default());
+        deflate.write_all(payload).expect("deflate input");
+        let mut gzip = GzEncoder::new(Vec::new(), Compression::default());
+        gzip.write_all(&deflate.finish().expect("deflate body"))
+            .expect("gzip input");
+        let mut headers = HeaderMap::new();
+        headers.append(CONTENT_ENCODING, HeaderValue::from_static("deflate"));
+        headers.append(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+
+        assert_eq!(
+            decode_response_body(&headers, gzip.finish().expect("gzip body").into())
+                .expect("decoded body"),
+            payload.as_slice()
+        );
     }
 
     #[test]
@@ -546,6 +608,27 @@ mod tests {
             session.cookie("token", &url).expect("cookie"),
             Some("updated".into())
         );
+    }
+
+    #[tokio::test]
+    async fn redirects_preserve_the_configured_referer() {
+        let (url, redirected_request) = serve_redirect_once().await;
+        let session = Session::new(SessionConfig {
+            headers: HashMap::from([("Referer".into(), "https://www.bilibili.com".into())]),
+            use_system_proxy: false,
+            ..SessionConfig::default()
+        })
+        .expect("session");
+
+        let response = session
+            .get(url, vec![], HashMap::new())
+            .await
+            .expect("redirected response");
+        let redirected_request = redirected_request.await.expect("redirected request");
+
+        assert_eq!(response.body, "payload");
+        assert!(redirected_request.contains("referer: https://www.bilibili.com\r\n"));
+        assert!(!redirected_request.contains("token=secret"));
     }
 
     #[tokio::test]

--- a/packages/yutto-core/src/yutto_core/__init__.py
+++ b/packages/yutto-core/src/yutto_core/__init__.py
@@ -15,7 +15,6 @@ from yutto_core._core import (
     TransferHandle,
     TransferSnapshot,
     UnsupportedProtocolError,
-    start_transfer,
 )
 
 if TYPE_CHECKING:
@@ -33,7 +32,6 @@ __all__ = [
     "TransferHandle",
     "TransferSnapshot",
     "UnsupportedProtocolError",
-    "start_transfer",
     "wait_for_transfer",
 ]
 

--- a/packages/yutto-core/src/yutto_core/_core.pyi
+++ b/packages/yutto-core/src/yutto_core/_core.pyi
@@ -76,18 +76,3 @@ class NativeSession:
         workers: int = ...,
         block_size: int = ...,
     ) -> TransferHandle: ...
-
-def start_transfer(
-    sources: list[str],
-    target: str | Path,
-    expected_size: int,
-    *,
-    overwrite: bool = ...,
-    headers: dict[str, str] | None = ...,
-    source_headers: list[dict[str, str]] | None = ...,
-    proxy: str | None = ...,
-    use_system_proxy: bool = ...,
-    accept_invalid_certs: bool = ...,
-    workers: int = ...,
-    block_size: int = ...,
-) -> TransferHandle: ...

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -44,8 +44,8 @@ class _CliAuthAnnouncer:
 
     async def __call__(self, scope: ExecutionScope, request: DownloadRequest) -> None:
         credentials = (
-            scope.client.cookies.get("SESSDATA"),
-            scope.client.cookies.get("bili_jct"),
+            scope.session.cookie("SESSDATA"),
+            scope.session.cookie("bili_jct"),
         )
         if credentials in self._announced_credentials:
             return
@@ -129,7 +129,7 @@ async def run_download(
 
 
 async def announce_cli_auth(scope: ExecutionScope, _request: DownloadRequest) -> None:
-    if scope.client.cookies.get("SESSDATA") is None:
+    if scope.session.cookie("SESSDATA") is None:
         Logger.info(
             "未提供登录认证信息，无法下载高清视频、字幕等资源哦～请通过 `--auth` 参数提供认证信息，或者先使用 `yutto auth login` 登录存储认证信息后再下载～"
         )

--- a/src/yutto/core/execution.py
+++ b/src/yutto/core/execution.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
     from contextlib import AbstractAsyncContextManager
 
-    from httpx import AsyncClient
+    from yutto_core import NativeSession
 
     from yutto.auth import AuthInfo
     from yutto.core.request import DownloadRequest
@@ -25,33 +25,27 @@ if TYPE_CHECKING:
 class ExecutionScope:
     """Runtime resources owned by one request execution."""
 
-    client: AsyncClient
+    session: NativeSession
     fetch_limiter: asyncio.Semaphore
     download_workers: int
-    proxy: str | None
-    trust_env: bool
     user_info_cache: UserInfo | None
     wbi_img_cache: Mapping[str, str] | None
     touched_urls: set[str]
 
     def __init__(
         self,
-        client: AsyncClient,
+        session: NativeSession,
         *,
         fetch_workers: int = DEFAULT_FETCH_WORKERS,
         download_workers: int = DEFAULT_FETCH_WORKERS,
-        proxy: str | None = None,
-        trust_env: bool = True,
     ):
         if fetch_workers < 1:
             raise ValueError("fetch_workers must be at least 1")
         if download_workers < 1:
             raise ValueError("download_workers must be at least 1")
-        self.client = client
+        self.session = session
         self.fetch_limiter = asyncio.Semaphore(fetch_workers)
         self.download_workers = download_workers
-        self.proxy = proxy
-        self.trust_env = trust_env
         self.user_info_cache = None
         self.wbi_img_cache = None
         self.touched_urls = set()
@@ -90,13 +84,11 @@ class RequestExecutionScopeFactory:
             cookies=cookies,
             trust_env=trust_env,
             proxy=proxy,
-        ) as client:
+        ) as session:
             scope = ExecutionScope(
-                client,
+                session,
                 fetch_workers=request.network.fetch_workers,
                 download_workers=request.network.download_workers,
-                proxy=proxy,
-                trust_env=trust_env,
             )
             if self._on_open is not None:
                 await self._on_open(scope, request)

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import httpx
+from yutto_core import InvalidUrlError, UnsupportedProtocolError
 
 from yutto.api.user_info import validate_user_info
 from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageChanged
@@ -309,9 +309,9 @@ class DownloadManager:
         # 重定向到可识别的 url
         try:
             url = unwrap_fetch_result(await Fetcher.get_redirected_url(scope, url))
-        except httpx.InvalidURL:
+        except InvalidUrlError:
             raise WrongUrlError(f"无效的 url({url})～请检查一下链接是否正确～") from None
-        except httpx.UnsupportedProtocol:
+        except UnsupportedProtocolError:
             error_text = f"无效的 url 协议（{url}）～请检查一下链接协议是否正确"
             if not request.scope.batch:
                 error_text += (

--- a/src/yutto/downloader/transfer.py
+++ b/src/yutto/downloader/transfer.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 from typing import TYPE_CHECKING
 
-from yutto_core import start_transfer, wait_for_transfer
+from yutto_core import wait_for_transfer
 
 from yutto.core.events import DownloadStage, DownloadStageChanged
 from yutto.core.operation import emit_download_event, emit_download_report
@@ -83,17 +83,11 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
             for workers in worker_batch:
                 sources, target, size = prepared_transfers[completed_transfers]
                 completed_transfers += 1
-                handle = start_transfer(
+                handle = scope.session.start_transfer(
                     sources,
                     target,
                     size,
                     overwrite=plan.overwrite,
-                    headers=_native_http_headers(scope),
-                    source_headers=_native_source_headers(scope, sources),
-                    proxy=scope.proxy,
-                    use_system_proxy=scope.trust_env,
-                    # The existing request client disables certificate verification.
-                    accept_invalid_certs=True,
                     workers=workers,
                     block_size=plan.block_size,
                 )
@@ -143,20 +137,6 @@ async def _cancel_and_reap_native_transfers(handles: Iterable[Any], wait_tasks: 
         if not handle.done():
             handle.cancel()
     await asyncio.gather(*wait_tasks, return_exceptions=True)
-
-
-def _native_http_headers(scope: ExecutionScope) -> dict[str, str]:
-    headers = dict(scope.client.headers.multi_items())
-    headers.pop("cookie", None)
-    return headers
-
-
-def _native_source_headers(scope: ExecutionScope, sources: Iterable[str]) -> list[dict[str, str]]:
-    source_headers = []
-    for source in sources:
-        cookie = scope.client.build_request("GET", source).headers.get("cookie")
-        source_headers.append({"cookie": cookie} if cookie is not None else {})
-    return source_headers
 
 
 def cleanup_temporary_media(plan: DownloadPlan) -> None:

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import quote, unquote, urlparse
 
 import httpx
 from returns.result import Failure, Result, Success
 from typing_extensions import ParamSpec
+from yutto_core import (
+    HttpError,
+    HttpTimeoutError,
+    InvalidUrlError,
+    NativeSession,
+    SessionClosedError,
+    UnsupportedProtocolError,
+)
 
 from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import MaxRetryError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Mapping
-
-    from httpx import AsyncClient
+    from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
 
     from yutto.auth import AuthInfo
     from yutto.core.execution import ExecutionScope
@@ -42,14 +50,16 @@ class MaxRetry:
             while retry:
                 try:
                     return Success(await connect_once(*args, **kwargs))
-                except httpx.TimeoutException:
+                except SessionClosedError:
+                    raise
+                except HttpTimeoutError:
                     emit_download_report(
                         f"抓取超时，正在重试，剩余 {retry - 1} 次",
                         level=ReportLevel.WARNING,
                     )
-                except (httpx.InvalidURL, httpx.UnsupportedProtocol) as e:
+                except (InvalidUrlError, UnsupportedProtocolError) as e:
                     raise e
-                except httpx.HTTPError as e:
+                except HttpError as e:
                     await asyncio.sleep(0.5)
                     error_type = e.__class__.__name__
                     emit_download_report(
@@ -115,14 +125,14 @@ class Fetcher:
         url: str,
         *,
         params: Mapping[str, Any] | None = None,
-        encoding: str | None = None,  # TODO(SigureMo): Support this
+        encoding: str | None = None,
     ) -> str | None:
         async with scope.fetch_guard():
             emit_download_report(f"Fetch text: {url}", level=ReportLevel.DEBUG)
-            resp = await scope.client.get(url, params=params)
+            resp = await scope.session.get(url, params=_query_params(params))
             if not resp.is_success:
                 return None
-            return resp.text
+            return resp.body.decode(encoding or "utf-8", errors="replace")
 
     @staticmethod
     @MaxRetry(2)
@@ -134,10 +144,10 @@ class Fetcher:
     ) -> bytes | None:
         async with scope.fetch_guard():
             emit_download_report(f"Fetch bin: {url}", level=ReportLevel.DEBUG)
-            resp = await scope.client.get(url, params=params)
+            resp = await scope.session.get(url, params=_query_params(params))
             if not resp.is_success:
                 return None
-            return resp.read()
+            return resp.body
 
     @staticmethod
     @MaxRetry(2)
@@ -149,10 +159,10 @@ class Fetcher:
     ) -> Any:
         async with scope.fetch_guard():
             emit_download_report(f"Fetch json: {url}", level=ReportLevel.DEBUG)
-            resp = await scope.client.get(url, params=params)
+            resp = await scope.session.get(url, params=_query_params(params))
             if not resp.is_success:
                 resp.raise_for_status()
-            return resp.json()
+            return json.loads(resp.body)
 
     @staticmethod
     @MaxRetry(2)
@@ -161,8 +171,8 @@ class Fetcher:
         # 为 SEO 的搜索引擎链接、甚至有的 av、BV 链接实际上是番剧页面，一一列举实在太麻烦，而且最后一种
         # 情况需要在 av、BV 解析一部分信息后才能知道是否是番剧页面，处理起来非常麻烦（bilili 就是这么做的）
         async with scope.fetch_guard():
-            resp = await scope.client.get(url)
-            redirected_url = str(resp.url)
+            resp = await scope.session.get(url)
+            redirected_url = resp.url
             if redirected_url == url:
                 emit_download_report(f"Get redircted url: {url}", level=ReportLevel.DEBUG)
             else:
@@ -176,14 +186,15 @@ class Fetcher:
     @MaxRetry(2)
     async def get_size(scope: ExecutionScope, url: str) -> int | None:
         async with scope.fetch_guard():
-            headers = scope.client.headers.copy()
-            headers["Range"] = "bytes=0-1"
-            resp = await scope.client.get(
+            resp = await scope.session.get(
                 url,
-                headers=headers,
+                headers={"Range": "bytes=0-1"},
             )
             if resp.status_code == 206:
-                size = int(resp.headers["Content-Range"].split("/")[-1])
+                content_range = resp.header("Content-Range")
+                if content_range is None:
+                    return None
+                size = int(content_range.split("/")[-1])
                 emit_download_report(f"Get size: {url} {size}", level=ReportLevel.DEBUG)
                 return size
             else:
@@ -197,11 +208,29 @@ class Fetcher:
             return
         async with scope.fetch_guard():
             emit_download_report(f"Touch url: {url}", level=ReportLevel.DEBUG)
-            await scope.client.get(url)
+            await scope.session.get(url)
             scope.touched_urls.add(url)
 
 
-def _client_kwargs(
+def _query_params(params: Mapping[str, Any] | None) -> list[tuple[str, str]] | None:
+    if params is None:
+        return None
+    result = []
+    for key, value in params.items():
+        values = value if isinstance(value, (list, tuple)) else (value,)
+        result.extend((str(key), _query_value(item)) for item in values)
+    return result
+
+
+def _query_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _sync_client_kwargs(
     *,
     headers: dict[str, str],
     cookies: httpx.Cookies,
@@ -223,28 +252,29 @@ def _client_kwargs(
     }
 
 
-def create_client(
+@asynccontextmanager
+async def create_client(
     headers: dict[str, str] = DEFAULT_HEADERS,
     cookies: httpx.Cookies = DEFAULT_COOKIES,
     trust_env: bool = DEFAULT_TRUST_ENV,
     proxy: str | None = DEFAULT_PROXY,
-    timeout: int | httpx.Timeout = 5,
+    timeout: float = 5,
     *,
-    http2: bool = True,
     verify: bool = False,
-) -> AsyncClient:
-    client = httpx.AsyncClient(
-        **_client_kwargs(
-            headers=headers,
-            cookies=cookies,
-            trust_env=trust_env,
-            proxy=proxy,
-            timeout=timeout,
-            http2=http2,
-            verify=verify,
-        )
+) -> AsyncIterator[NativeSession]:
+    session = NativeSession(
+        headers=dict(headers),
+        cookies=dict(cookies),
+        proxy=proxy,
+        use_system_proxy=trust_env,
+        accept_invalid_certs=not verify,
+        read_timeout=timeout,
+        connect_timeout=timeout,
     )
-    return client
+    try:
+        yield session
+    finally:
+        session.close()
 
 
 def create_sync_client(
@@ -258,7 +288,7 @@ def create_sync_client(
     verify: bool = False,
 ) -> httpx.Client:
     client = httpx.Client(
-        **_client_kwargs(
+        **_sync_client_kwargs(
             headers=headers,
             cookies=cookies,
             trust_env=trust_env,

--- a/tests/test_api/test_user_info.py
+++ b/tests/test_api/test_user_info.py
@@ -60,13 +60,13 @@ async def test_user_info_cache_is_scoped_to_execution_scope(monkeypatch: pytest.
 
 @pytest.mark.processor
 @as_sync
-async def test_validate_user_info_reuses_execution_scope_client_and_cache(monkeypatch: pytest.MonkeyPatch):
-    client = cast("Any", object())
-    scope = ExecutionScope(client)
-    clients: list[Any] = []
+async def test_validate_user_info_reuses_execution_scope_session_and_cache(monkeypatch: pytest.MonkeyPatch):
+    session = cast("Any", object())
+    scope = ExecutionScope(session)
+    sessions: list[Any] = []
 
     async def fake_fetch_json(active_scope, url):
-        clients.append(active_scope.client)
+        sessions.append(active_scope.session)
         return Success({"data": {"vipStatus": 1, "isLogin": True}})
 
     monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
@@ -74,7 +74,7 @@ async def test_validate_user_info_reuses_execution_scope_client_and_cache(monkey
     requirements = UserInfo(vip_status=True, is_login=True)
     assert await validate_user_info(scope, requirements)
     assert await validate_user_info(scope, requirements)
-    assert clients == [client]
+    assert sessions == [session]
 
 
 @pytest.mark.processor

--- a/tests/test_core/test_execution.py
+++ b/tests/test_core/test_execution.py
@@ -39,22 +39,22 @@ def test_execution_scope_rejects_non_positive_workers(
 
 
 @as_sync
-async def test_scope_factory_opens_fresh_clients_limiters_and_caches():
+async def test_scope_factory_opens_fresh_sessions_limiters_and_caches():
     factory = RequestExecutionScopeFactory()
     request = make_request()
 
     async with factory.open(request) as first_scope:
-        first_client = first_scope.client
+        first_session = first_scope.session
         first_fetch_limiter = first_scope.fetch_limiter
         assert first_scope.download_workers == 8
         first_scope.user_info_cache = UserInfo(vip_status=True, is_login=True)
         first_scope.wbi_img_cache = {"img_key": "img", "sub_key": "sub"}
         first_scope.touched_urls.add("https://example.com")
 
-    assert first_client.is_closed
+    assert first_session.is_closed
 
     async with factory.open(request) as second_scope:
-        assert second_scope.client is not first_client
+        assert second_scope.session is not first_session
         assert second_scope.fetch_limiter is not first_fetch_limiter
         assert second_scope.download_workers == 8
         assert second_scope.user_info_cache is None
@@ -63,11 +63,11 @@ async def test_scope_factory_opens_fresh_clients_limiters_and_caches():
 
 
 @as_sync
-async def test_scope_factory_closes_client_when_on_open_fails():
-    clients: list[Any] = []
+async def test_scope_factory_closes_session_when_on_open_fails():
+    sessions: list[Any] = []
 
     async def fail_on_open(scope: ExecutionScope, request: DownloadRequest) -> None:
-        clients.append(scope.client)
+        sessions.append(scope.session)
         raise RuntimeError("on_open failed")
 
     factory = RequestExecutionScopeFactory(on_open=fail_on_open)
@@ -76,8 +76,8 @@ async def test_scope_factory_closes_client_when_on_open_fails():
         async with factory.open(make_request()):
             pytest.fail("scope should not be yielded")
 
-    assert len(clients) == 1
-    assert clients[0].is_closed
+    assert len(sessions) == 1
+    assert sessions[0].is_closed
 
 
 @as_sync
@@ -99,8 +99,8 @@ async def test_cli_auth_announcer_deduplicates_effective_credentials(
     async def validate(scope: ExecutionScope, requirements: dict[str, bool]) -> bool:
         assert requirements == {"vip_status": True, "is_login": True}
         credentials = (
-            scope.client.cookies.get("SESSDATA"),
-            scope.client.cookies.get("bili_jct"),
+            scope.session.cookie("SESSDATA"),
+            scope.session.cookie("bili_jct"),
         )
         validation_calls.append(credentials)
         is_vip = credentials[0] == "member"

--- a/tests/test_processor/test_batch_resolve.py
+++ b/tests/test_processor/test_batch_resolve.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from returns.result import Failure, Success
@@ -15,7 +15,6 @@ from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
-    import httpx
     from returns.result import Result
 
     from yutto.api.ugc_video import UgcVideoList
@@ -31,8 +30,8 @@ def make_ugc_video_list(avid: AvId, pubdate: int = 1_600_000_000) -> UgcVideoLis
     }
 
 
-def make_fake_client() -> httpx.AsyncClient:
-    return cast("httpx.AsyncClient", object())
+def make_fake_session() -> Any:
+    return cast("Any", object())
 
 
 async def touch_url_ok(scope: ExecutionScope, url: str) -> Result[None, MaxRetryError]:
@@ -56,7 +55,7 @@ async def test_resolve_ugc_video_lists_preserves_order(monkeypatch: pytest.Monke
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", touch_url_ok)
 
-    scope = ExecutionScope(make_fake_client())
+    scope = ExecutionScope(make_fake_session())
     outcome = await resolve_ugc_video_lists(
         scope,
         avids,
@@ -94,7 +93,7 @@ async def test_resolve_ugc_video_lists_isolates_failures(monkeypatch: pytest.Mon
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
-    scope = ExecutionScope(make_fake_client())
+    scope = ExecutionScope(make_fake_session())
     outcome = await resolve_ugc_video_lists(
         scope,
         avids,
@@ -115,7 +114,7 @@ async def test_resolve_ugc_video_lists_bounded_by_fetch_semaphore(monkeypatch: p
     running = 0
     max_running = 0
 
-    scope = ExecutionScope(make_fake_client(), fetch_workers=fetch_workers)
+    scope = ExecutionScope(make_fake_session(), fetch_workers=fetch_workers)
 
     async def occupy_fetch_guard(active_scope: ExecutionScope) -> None:
         nonlocal running, max_running

--- a/tests/test_processor/test_download_result.py
+++ b/tests/test_processor/test_download_result.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -19,8 +19,6 @@ from yutto.utils.danmaku import write_danmaku
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.downloader.planner import DownloadPlan
     from yutto.media.codec import AudioCodec
     from yutto.types import AudioUrlMeta, EpisodeData
@@ -148,7 +146,7 @@ async def test_interrupted_mux_keeps_resume_inputs(
     monkeypatch.setattr(executor_module, "MediaMuxer", lambda: muxer)
     execution = asyncio.create_task(
         process_download(
-            ExecutionScope(cast("httpx.AsyncClient", object())),
+            ExecutionScope(cast("Any", object())),
             make_media_episode(),
             make_request(tmp_path, audio=True),
         )
@@ -175,7 +173,7 @@ async def test_interrupted_mux_keeps_resume_inputs(
 @as_sync
 async def test_resource_only_download_returns_final_artifacts_without_temporary_files(tmp_path: Path):
     result = await process_download(
-        ExecutionScope(cast("httpx.AsyncClient", object())),
+        ExecutionScope(cast("Any", object())),
         make_resource_only_episode(),
         make_request(tmp_path),
     )
@@ -207,7 +205,7 @@ async def test_existing_media_returns_artifacts_and_cleans_temporary_resources(t
     subtitle_path.write_text("stale subtitle")
 
     result = await process_download(
-        ExecutionScope(cast("httpx.AsyncClient", object())),
+        ExecutionScope(cast("Any", object())),
         episode,
         make_request(tmp_path, audio=True),
     )
@@ -246,7 +244,7 @@ async def test_missing_requested_audio_does_not_clean_uncreated_video_file(tmp_p
     episode["cover_data"] = None
 
     result = await process_download(
-        ExecutionScope(cast("httpx.AsyncClient", object())),
+        ExecutionScope(cast("Any", object())),
         episode,
         make_request(tmp_path, audio=True, save_cover=False),
     )

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
-import httpx
 import pytest
 from returns.result import Failure, Success
 
@@ -22,12 +21,11 @@ from yutto.downloader.transfer import (
     download_video_and_audio,
 )
 from yutto.exceptions import MaxRetryError
-from yutto.utils.fetcher import Fetcher
+from yutto.utils.fetcher import Fetcher, create_client
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Any
 
 pytestmark = pytest.mark.processor
 
@@ -35,14 +33,14 @@ pytestmark = pytest.mark.processor
 @as_sync
 async def test_local_range_server_targets_faults_and_closes_connections():
     with LocalRangeServer(b"payload", faults=[((2, 3), RangeFault.IGNORE)]) as server:
-        async with httpx.AsyncClient(http2=False) as client:
-            probe = await client.get(server.url, headers={"Range": "bytes=0-1"})
-            faulted = await client.get(server.url, headers={"Range": "bytes=2-3"})
+        async with create_client(trust_env=False) as session:
+            probe = await session.get(server.url, headers={"Range": "bytes=0-1"})
+            faulted = await session.get(server.url, headers={"Range": "bytes=2-3"})
 
     assert probe.status_code == 206
     assert faulted.status_code == 200
-    assert probe.headers["Connection"] == "close"
-    assert faulted.headers["Connection"] == "close"
+    assert probe.header("Connection") == "close"
+    assert faulted.header("Connection") == "close"
 
 
 class RecordingEventSink:
@@ -135,12 +133,11 @@ async def test_probe_media_size_preserves_probe_failures(monkeypatch: pytest.Mon
         return Failure(failures[url])
 
     monkeypatch.setattr(Fetcher, "get_size", get_size)
-    async with httpx.AsyncClient() as client:
-        scope = ExecutionScope(client)
-        with pytest.raises(MaxRetryError) as single_failure:
-            await _probe_media_size(scope, "primary", [])
-        with pytest.raises(MaxRetryError) as multiple_failure:
-            await _probe_media_size(scope, "primary", ["mirror"])
+    scope = ExecutionScope(cast("Any", object()))
+    with pytest.raises(MaxRetryError) as single_failure:
+        await _probe_media_size(scope, "primary", [])
+    with pytest.raises(MaxRetryError) as multiple_failure:
+        await _probe_media_size(scope, "primary", ["mirror"])
 
     assert single_failure.value is failures["primary"]
     assert isinstance(multiple_failure.value.__cause__, ExceptionGroup)
@@ -153,9 +150,8 @@ async def test_probe_media_size_rejects_a_source_without_a_known_length(monkeypa
         return Success(None)
 
     monkeypatch.setattr(Fetcher, "get_size", get_size)
-    async with httpx.AsyncClient() as client:
-        with pytest.raises(MaxRetryError, match="未返回长度"):
-            await _probe_media_size(ExecutionScope(client), "primary", [])
+    with pytest.raises(MaxRetryError, match="未返回长度"):
+        await _probe_media_size(ExecutionScope(cast("Any", object())), "primary", [])
 
 
 @pytest.mark.parametrize(
@@ -205,8 +201,8 @@ async def test_known_size_resume_uses_existing_contiguous_prefix(tmp_path):
         plan.paths.temporary_dir.mkdir(parents=True)
         plan.paths.audio.write_bytes(payload[:resume_offset])
 
-        async with httpx.AsyncClient(http2=False) as client:
-            await download_video_and_audio(ExecutionScope(client), plan)
+        async with create_client(trust_env=False) as session:
+            await download_video_and_audio(ExecutionScope(session), plan)
 
     assert [request.range_header for request in server.requests] == [
         "bytes=0-1",
@@ -242,8 +238,8 @@ async def test_out_of_order_ranges_commit_an_exact_contiguous_file(tmp_path):
         plan = DownloadPlanner().plan(episode, request)
         plan.paths.temporary_dir.mkdir(parents=True)
 
-        async with httpx.AsyncClient(http2=False) as client:
-            await download_video_and_audio(ExecutionScope(client), plan)
+        async with create_client(trust_env=False) as session:
+            await download_video_and_audio(ExecutionScope(session), plan)
 
     assert plan.paths.audio.read_bytes() == payload
     assert plan.paths.audio.stat().st_size == len(payload)
@@ -279,8 +275,8 @@ async def test_native_transfer_resumes_by_default(tmp_path):
         plan.paths.temporary_dir.mkdir(parents=True)
         plan.paths.audio.write_bytes(payload[:page_size])
 
-        async with httpx.AsyncClient(http2=False) as client:
-            await download_video_and_audio(ExecutionScope(client), plan)
+        async with create_client(trust_env=False) as session:
+            await download_video_and_audio(ExecutionScope(session), plan)
 
     assert plan.paths.audio.read_bytes() == payload
     range_headers = [request.range_header for request in server.requests]
@@ -314,8 +310,8 @@ async def test_cancelling_rust_backend_stops_the_native_transfer(tmp_path):
         plan.paths.temporary_dir.mkdir(parents=True)
         plan.paths.audio.write_bytes(payload[:page_size])
 
-        async with httpx.AsyncClient(http2=False) as client:
-            task = asyncio.create_task(download_video_and_audio(ExecutionScope(client), plan))
+        async with create_client(trust_env=False) as session:
+            task = asyncio.create_task(download_video_and_audio(ExecutionScope(session), plan))
             async with asyncio.timeout(2):
                 while not any(request.range_header == later_range for request in server.completed_requests):
                     await asyncio.sleep(0.01)
@@ -330,7 +326,7 @@ async def test_cancelling_rust_backend_stops_the_native_transfer(tmp_path):
 
 
 @as_sync
-async def test_native_transfer_maps_mirrors_headers_cookies_proxy_and_workers(
+async def test_native_transfer_reuses_the_scope_session_and_maps_workers(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
@@ -358,13 +354,13 @@ async def test_native_transfer_maps_mirrors_headers_cookies_proxy_and_workers(
     async def get_size(_scope: ExecutionScope, _url: str) -> Success[int]:
         return Success(123)
 
-    def start_transfer(*args: object, **kwargs: object) -> Handle:
-        captured["args"] = args
-        captured["kwargs"] = kwargs
-        return Handle()
+    class FakeSession:
+        def start_transfer(self, *args: object, **kwargs: object) -> Handle:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return Handle()
 
     monkeypatch.setattr(Fetcher, "get_size", get_size)
-    monkeypatch.setattr(transfer_module, "start_transfer", start_transfer)
 
     episode = make_resource_only_episode()
     episode["audios"] = [
@@ -390,20 +386,11 @@ async def test_native_transfer_maps_mirrors_headers_cookies_proxy_and_workers(
     )
     plan = DownloadPlanner().plan(episode, type(base_request).model_validate(request_data))
 
-    cookies = httpx.Cookies()
-    cookies.set("PRIMARY", "primary-secret", domain="primary.example", path="/media")
-    cookies.set("MIRROR", "mirror-secret", domain="mirror.example", path="/media")
-    cookies.set("WRONG_PATH", "wrong-secret", domain="primary.example", path="/private")
-    async with httpx.AsyncClient(headers={"X-Test": "value"}, cookies=cookies) as client:
-        await download_video_and_audio(
-            ExecutionScope(
-                client,
-                download_workers=3,
-                proxy="socks5://127.0.0.1:1080",
-                trust_env=False,
-            ),
-            plan,
-        )
+    session = FakeSession()
+    await download_video_and_audio(
+        ExecutionScope(cast("Any", session), download_workers=3),
+        plan,
+    )
 
     args = captured["args"]
     kwargs = captured["kwargs"]
@@ -411,14 +398,6 @@ async def test_native_transfer_maps_mirrors_headers_cookies_proxy_and_workers(
     assert isinstance(kwargs, dict)
     assert args[0] == ["https://primary.example/media", "https://mirror.example/media"]
     assert args[2] == 123
-    assert kwargs["headers"]["x-test"] == "value"
-    assert "cookie" not in kwargs["headers"]
-    assert kwargs["source_headers"] == [
-        {"cookie": "PRIMARY=primary-secret"},
-        {"cookie": "MIRROR=mirror-secret"},
-    ]
-    assert kwargs["proxy"] == "socks5://127.0.0.1:1080"
-    assert kwargs["use_system_proxy"] is False
     assert kwargs["workers"] == 3
     assert kwargs["block_size"] == 64 * 1024
 
@@ -452,15 +431,15 @@ async def test_rust_backend_reaps_a_started_handle_when_later_setup_fails(
         started_handle.reaped = True
         raise RuntimeError("cancelled")
 
-    def start_transfer(*_args: object, **_kwargs: object) -> Handle:
-        nonlocal starts
-        starts += 1
-        if starts == 2:
-            raise RuntimeError("second setup failed")
-        return handle
+    class FakeSession:
+        def start_transfer(self, *_args: object, **_kwargs: object) -> Handle:
+            nonlocal starts
+            starts += 1
+            if starts == 2:
+                raise RuntimeError("second setup failed")
+            return handle
 
     monkeypatch.setattr(Fetcher, "get_size", get_size)
-    monkeypatch.setattr(transfer_module, "start_transfer", start_transfer)
     monkeypatch.setattr(transfer_module, "wait_for_transfer", wait_for_transfer)
 
     episode = make_resource_only_episode()
@@ -488,9 +467,11 @@ async def test_rust_backend_reaps_a_started_handle_when_later_setup_fails(
     request_data = base_request.model_dump()
     plan = DownloadPlanner().plan(episode, type(base_request).model_validate(request_data))
 
-    async with httpx.AsyncClient() as client:
-        with pytest.raises(RuntimeError, match="second setup failed"):
-            await download_video_and_audio(ExecutionScope(client, download_workers=2), plan)
+    with pytest.raises(RuntimeError, match="second setup failed"):
+        await download_video_and_audio(
+            ExecutionScope(cast("Any", FakeSession()), download_workers=2),
+            plan,
+        )
 
     assert handle.cancelled
     assert handle.reaped

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -27,8 +27,6 @@ from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.auth import AuthInfo
     from yutto.extractor._abc import ExtractorResolveOutcome
     from yutto.types import EpisodeData, ExtractorOptions
@@ -178,9 +176,9 @@ async def test_process_request_preserves_extractor_mapping_and_passes_download_r
     monkeypatch.setattr(download_manager_module, "process_download", fake_process_download)
 
     manager = DownloadManager()
-    client = cast("httpx.AsyncClient", object())
+    session = cast("Any", object())
     request = make_request(tmp_dir)
-    result = await manager.process_request(ExecutionScope(client), request)
+    result = await manager.process_request(ExecutionScope(session), request)
 
     assert validation_requirements == [
         {"is_login": False, "vip_status": False},
@@ -254,7 +252,7 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
 
     with pytest.raises(NotLoginError):
         await manager.process_request(
-            ExecutionScope(cast("httpx.AsyncClient", object())),
+            ExecutionScope(cast("Any", object())),
             make_request(None),
         )
 
@@ -323,15 +321,15 @@ async def test_execute_uses_request_scopes_and_keeps_path_resolver_order():
     ]
     first_scope, second_scope = (scope for scope, _, _ in manager.calls)
     assert first_scope is not second_scope
-    assert first_scope.client is not second_scope.client
-    assert first_scope.client.is_closed and second_scope.client.is_closed
+    assert first_scope.session is not second_scope.session
+    assert first_scope.session.is_closed and second_scope.session.is_closed
     assert first_scope.fetch_limiter._value == 2
     assert first_scope.download_workers == 3
     assert second_scope.fetch_limiter._value == 5
     assert second_scope.download_workers == 7
     assert first_scope.fetch_limiter is not second_scope.fetch_limiter
-    assert first_scope.client.cookies.get("SESSDATA") == "first%2Csession"
-    assert second_scope.client.cookies.get("SESSDATA") == "second%2Csession"
+    assert first_scope.session.cookie("SESSDATA") == "first%2Csession"
+    assert second_scope.session.cookie("SESSDATA") == "second%2Csession"
     assert result == DownloadResult(
         items=(
             ItemResult(state=ItemState.DONE, output_path=Path("same/video.mp4")),
@@ -341,7 +339,7 @@ async def test_execute_uses_request_scopes_and_keeps_path_resolver_order():
 
 
 @as_sync
-async def test_execute_stops_on_failure_and_closes_client():
+async def test_execute_stops_on_failure_and_closes_session():
     requests = [
         DownloadRequest.model_validate({"source": {"url": "BV1first"}}),
         DownloadRequest.model_validate({"source": {"url": "BV1second"}}),
@@ -351,14 +349,14 @@ async def test_execute_stops_on_failure_and_closes_client():
         def __init__(self) -> None:
             super().__init__()
             self.calls: list[str] = []
-            self.client: httpx.AsyncClient | None = None
+            self.session: Any = None
 
         async def process_request(
             self,
             scope: ExecutionScope,
             request: DownloadRequest,
         ) -> tuple[ItemResult, ...]:
-            self.client = scope.client
+            self.session = scope.session
             self.calls.append(request.source.url)
             raise WrongArgumentError("request failed")
 
@@ -367,11 +365,11 @@ async def test_execute_stops_on_failure_and_closes_client():
         await manager.execute(RequestExecutionScopeFactory(), requests)
 
     assert manager.calls == ["BV1first"]
-    assert manager.client is not None and manager.client.is_closed
+    assert manager.session is not None and manager.session.is_closed
 
 
 @as_sync
-async def test_execute_cancellation_closes_client():
+async def test_execute_cancellation_closes_session():
     started = asyncio.Event()
     release = asyncio.Event()
     request = DownloadRequest.model_validate({"source": {"url": "BV1cancel"}})
@@ -379,14 +377,14 @@ async def test_execute_cancellation_closes_client():
     class BlockingManager(DownloadManager):
         def __init__(self) -> None:
             super().__init__()
-            self.client: httpx.AsyncClient | None = None
+            self.session: Any = None
 
         async def process_request(
             self,
             scope: ExecutionScope,
             request: DownloadRequest,
         ) -> tuple[ItemResult, ...]:
-            self.client = scope.client
+            self.session = scope.session
             started.set()
             await release.wait()
             return ()
@@ -399,7 +397,7 @@ async def test_execute_cancellation_closes_client():
     with pytest.raises(asyncio.CancelledError):
         await execution
 
-    assert manager.client is not None and manager.client.is_closed
+    assert manager.session is not None and manager.session.is_closed
 
 
 @pytest.mark.processor

--- a/tests/test_processor/test_resolve.py
+++ b/tests/test_processor/test_resolve.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from returns.result import Success
@@ -25,8 +25,6 @@ from yutto.utils.filter import PublicationTimeFilter
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
-    import httpx
-
     from yutto.api.ugc_video import UgcVideoList
     from yutto.core.events import DownloadEvent
     from yutto.extractor._abc import EpisodeListedCallback, ExtractorResolveOutcome
@@ -114,7 +112,7 @@ async def test_resolve_items_lists_stable_info_without_resolving_data(monkeypatc
 
     manager = DownloadManager()
     sink = RecordingEventSink()
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     request = DownloadRequest.model_validate({"source": {"url": "BV1baseline"}})
 
     with bind_download_event_sink(sink):
@@ -204,7 +202,7 @@ async def test_resolve_items_streams_explicit_items_without_duplicates(monkeypat
 
     manager = DownloadManager()
     sink = RecordingEventSink()
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     request = DownloadRequest.model_validate({"source": {"url": "BV1stream"}})
 
     with bind_download_event_sink(sink):
@@ -269,7 +267,7 @@ async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.Mon
 
     manager = DownloadManager()
     sink = RecordingEventSink()
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     request = DownloadRequest.model_validate({"source": {"url": "BV1equal"}})
 
     with bind_download_event_sink(sink):
@@ -286,8 +284,8 @@ async def test_resolve_items_emits_each_equal_occurrence(monkeypatch: pytest.Mon
 
 
 class _FakeClientContext:
-    async def __aenter__(self) -> httpx.AsyncClient:
-        return cast("httpx.AsyncClient", object())
+    async def __aenter__(self) -> Any:
+        return cast("Any", object())
 
     async def __aexit__(self, *args: object) -> bool:
         return False
@@ -452,7 +450,7 @@ async def test_resolve_ugc_video_lists_reports_expected_failures(monkeypatch: py
     monkeypatch.setattr("yutto.extractor.utils.batch.get_ugc_video_list", fake_get_ugc_video_list)
     monkeypatch.setattr(Fetcher, "touch_url", fake_touch_url)
 
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     scope = ExecutionScope(client)
     outcome = await resolve_ugc_video_lists(
         scope,
@@ -485,7 +483,7 @@ async def test_resolve_ugc_video_lists_awaits_async_on_resolved(monkeypatch: pyt
         # 契约：回调是异步的，逐分集的让出由回调自身负责（内置提取器均如此）
         await asyncio.sleep(0)
 
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     scope = ExecutionScope(client)
     outcome = await resolve_ugc_video_lists(
         scope,
@@ -521,7 +519,7 @@ async def test_resolve_ugc_video_lists_cancels_siblings_on_fatal_error(monkeypat
     async def on_resolved(resolved: IndexedResolveItem[UgcVideoList]) -> None:
         calls.append(resolved.index)
 
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     scope = ExecutionScope(client)
     # 单个未预期异常直接抛原始异常（而非 ExceptionGroup），wire 错误类型保持稳定
     with pytest.raises(RuntimeError, match="boom"):
@@ -558,7 +556,7 @@ async def test_resolve_ugc_video_lists_cancels_workers_when_callback_fails(monke
     async def on_resolved(resolved: IndexedResolveItem[UgcVideoList]) -> None:
         raise RuntimeError("callback boom")
 
-    client = cast("httpx.AsyncClient", object())
+    client = cast("Any", object())
     scope = ExecutionScope(client)
     with pytest.raises(RuntimeError, match="callback boom"):
         await resolve_ugc_video_lists(

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -4,9 +4,9 @@ import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
-import httpx
 import pytest
 from returns.result import Success
+from yutto_core import InvalidUrlError
 
 import yutto.__main__ as main_module
 import yutto.download_manager as download_manager_module
@@ -84,7 +84,7 @@ async def test_manager_raises_login_error(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(download_manager_module, "validate_user_info", reject_login)
     with pytest.raises(NotLoginError) as exc_info:
         await DownloadManager().process_request(
-            ExecutionScope(cast("httpx.AsyncClient", object())),
+            ExecutionScope(cast("Any", object())),
             make_request(),
         )
 
@@ -102,13 +102,13 @@ async def test_manager_raises_url_errors_without_network(monkeypatch: pytest.Mon
         return True
 
     async def reject_url(scope: ExecutionScope, url: str):
-        raise httpx.InvalidURL("invalid")
+        raise InvalidUrlError("invalid")
 
     monkeypatch.setattr(download_manager_module, "validate_user_info", accept_login)
     monkeypatch.setattr(Fetcher, "get_redirected_url", reject_url)
     with pytest.raises(WrongUrlError) as exc_info:
         await DownloadManager().process_request(
-            ExecutionScope(cast("httpx.AsyncClient", object())),
+            ExecutionScope(cast("Any", object())),
             make_request("not-a-url"),
         )
 
@@ -133,7 +133,7 @@ async def test_manager_reports_unmatched_url_as_structured_error(monkeypatch: py
 
     with pytest.raises(WrongUrlError) as exc_info:
         await DownloadManager().process_request(
-            ExecutionScope(cast("httpx.AsyncClient", object())),
+            ExecutionScope(cast("Any", object())),
             make_request("https://example.com/unsupported"),
         )
 
@@ -190,7 +190,7 @@ async def test_single_extractors_raise_when_episode_is_missing(
 
     with pytest.raises(EpisodeNotFoundError) as exc_info:
         await extractor.extract(
-            ExecutionScope(cast("httpx.AsyncClient", object())),
+            ExecutionScope(cast("Any", object())),
             EMPTY_EXTRACTOR_OPTIONS,
         )
 

--- a/tests/test_server/test_service.py
+++ b/tests/test_server/test_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
@@ -8,6 +9,7 @@ from typing import cast
 import pytest
 from pydantic import BaseModel
 
+import yutto.core.execution as execution_module
 from yutto.auth import load_auth
 from yutto.core.events import DownloadItemListed
 from yutto.core.execution import RequestExecutionScopeFactory
@@ -203,7 +205,10 @@ def test_options_reject_non_positive_worker_limits(tmp_path: Path, field: str):
 
 
 @as_sync
-async def test_scope_factory_applies_request_network_and_selected_auth_profile(tmp_path: Path):
+async def test_scope_factory_applies_request_network_and_selected_auth_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
     policy = make_policy(tmp_path, max_fetch_workers=4)
     policy.options.auth_file.write_text(
         """
@@ -220,12 +225,22 @@ bili_jct = "csrf-value"
         access={"auth_profile": "work"},
         network={"proxy": "no", "fetch_workers": 3},
     )
+    captured: dict[str, object] = {}
+    create_client = execution_module.create_client
+
+    @asynccontextmanager
+    async def capture_client(**kwargs):
+        captured.update(kwargs)
+        async with create_client(**kwargs) as session:
+            yield session
+
+    monkeypatch.setattr(execution_module, "create_client", capture_client)
 
     async with policy.build_scope_factory().open(request) as scope:
-        assert scope.client.trust_env is False
+        assert captured["trust_env"] is False
         assert scope.fetch_limiter._value == 3
-        assert scope.client.cookies.get("SESSDATA") == "session%2Cvalue"
-        assert scope.client.cookies.get("bili_jct") == "csrf-value"
+        assert scope.session.cookie("SESSDATA") == "session%2Cvalue"
+        assert scope.session.cookie("bili_jct") == "csrf-value"
 
 
 @as_sync
@@ -259,17 +274,15 @@ bili_jct = "csrf-value"
         policy.build_scope_factory().open(request) as server_scope,
     ):
         assert (
-            cli_scope.client.trust_env,
             cli_scope.fetch_limiter._value,
             cli_scope.download_workers,
-            cli_scope.client.cookies.get("SESSDATA"),
-            cli_scope.client.cookies.get("bili_jct"),
+            cli_scope.session.cookie("SESSDATA"),
+            cli_scope.session.cookie("bili_jct"),
         ) == (
-            server_scope.client.trust_env,
             server_scope.fetch_limiter._value,
             server_scope.download_workers,
-            server_scope.client.cookies.get("SESSDATA"),
-            server_scope.client.cookies.get("bili_jct"),
+            server_scope.session.cookie("SESSDATA"),
+            server_scope.session.cookie("bili_jct"),
         )
 
 

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import asyncio
 import ssl
 from typing import Any, Protocol, cast
 
-import httpx
 import pytest
 from returns.result import Failure, Success
+from yutto_core import HttpStatusError, SessionClosedError
 
+import yutto.utils.fetcher as fetcher_module
 from yutto.core.execution import ExecutionScope
 from yutto.utils.fetcher import Fetcher, create_client, create_sync_client, resolve_proxy
 from yutto.utils.functional import as_sync
@@ -40,15 +40,31 @@ def test_resolve_proxy_rejects_invalid_scheme():
         resolve_proxy("ftp://127.0.0.1:21")
 
 
-def test_create_client_keeps_download_tls_verification_disabled():
-    client = create_client()
-    try:
-        transport: Any = client._transport
-        ssl_context = _transport_ssl_context(transport)
-        assert ssl_context.verify_mode == ssl.CERT_NONE
-        assert not ssl_context.check_hostname
-    finally:
-        asyncio.run(client.aclose())
+@as_sync
+async def test_create_client_keeps_download_tls_verification_disabled_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, Any] = {}
+
+    class FakeNativeSession:
+        is_closed = False
+
+        def __init__(self, **kwargs: Any):
+            captured.update(kwargs)
+
+        def close(self) -> None:
+            self.is_closed = True
+
+    monkeypatch.setattr(fetcher_module, "NativeSession", FakeNativeSession)
+
+    async with create_client() as session:
+        assert not session.is_closed
+
+    assert session.is_closed
+    assert captured["accept_invalid_certs"] is True
+    assert captured["use_system_proxy"] is True
+    assert captured["read_timeout"] == 5
+    assert captured["connect_timeout"] == 5
 
 
 def test_create_sync_client_follows_default_download_tls_policy():
@@ -73,17 +89,68 @@ def test_create_sync_client_can_enable_tls_verification():
         client.close()
 
 
-class _StatusClient:
+class _StatusResponse:
+    def __init__(self, status_code: int, url: str):
+        self.status_code = status_code
+        self.url = url
+        self.body = b"failed"
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def raise_for_status(self) -> None:
+        if not self.is_success:
+            raise HttpStatusError(f"HTTP status {self.status_code}")
+
+
+class _StatusSession:
     def __init__(self, status_code: int):
         self.status_code = status_code
 
-    async def get(self, url: str, **kwargs: Any) -> httpx.Response:
-        return httpx.Response(self.status_code, request=httpx.Request("GET", url), content=b"failed")
+    async def get(self, url: str, **kwargs: Any) -> _StatusResponse:
+        return _StatusResponse(self.status_code, url)
+
+
+@as_sync
+async def test_fetcher_preserves_httpx_query_parameter_encoding():
+    class QuerySession(_StatusSession):
+        params: list[tuple[str, str]] | None = None
+
+        async def get(self, url: str, **kwargs: Any) -> _StatusResponse:
+            self.params = kwargs["params"]
+            return await super().get(url, **kwargs)
+
+    session = QuerySession(200)
+    scope = ExecutionScope(cast("Any", session))
+
+    assert await Fetcher.fetch_bin(
+        scope,
+        "https://example.com",
+        params={
+            "none": None,
+            "true": True,
+            "false": False,
+            "list": [1, 2],
+            "tuple": ("x", "y"),
+            "scalar": 3,
+        },
+    ) == Success(b"failed")
+    assert session.params == [
+        ("none", ""),
+        ("true", "true"),
+        ("false", "false"),
+        ("list", "1"),
+        ("list", "2"),
+        ("tuple", "x"),
+        ("tuple", "y"),
+        ("scalar", "3"),
+    ]
 
 
 @as_sync
 async def test_fetch_bin_keeps_non_success_status_as_success_none():
-    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    scope = ExecutionScope(cast("Any", _StatusSession(404)))
     match await Fetcher.fetch_bin(scope, "https://example.com"):
         case Success(None):
             pass
@@ -93,7 +160,7 @@ async def test_fetch_bin_keeps_non_success_status_as_success_none():
 
 @as_sync
 async def test_fetch_json_retries_non_success_status():
-    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    scope = ExecutionScope(cast("Any", _StatusSession(404)))
     match await Fetcher.fetch_json(scope, "https://example.com"):
         case Failure(error):
             assert error.message == "超出最大重试次数！"
@@ -103,7 +170,7 @@ async def test_fetch_json_retries_non_success_status():
 
 @as_sync
 async def test_get_redirected_url_keeps_non_success_status_as_url():
-    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    scope = ExecutionScope(cast("Any", _StatusSession(404)))
     match await Fetcher.get_redirected_url(scope, "https://example.com"):
         case Success(url):
             assert url == "https://example.com"
@@ -113,7 +180,7 @@ async def test_get_redirected_url_keeps_non_success_status_as_url():
 
 @as_sync
 async def test_touch_url_keeps_non_success_status_as_success_none():
-    scope = ExecutionScope(cast("Any", _StatusClient(404)))
+    scope = ExecutionScope(cast("Any", _StatusSession(404)))
     match await Fetcher.touch_url(scope, "https://example.com"):
         case Success(None):
             pass
@@ -124,22 +191,33 @@ async def test_touch_url_keeps_non_success_status_as_success_none():
 @pytest.mark.processor
 @as_sync
 async def test_touch_url_cache_is_scoped_to_execution_scope():
-    class CountingClient(_StatusClient):
+    class CountingSession(_StatusSession):
         def __init__(self):
             super().__init__(204)
             self.calls = 0
 
-        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        async def get(self, url: str, **kwargs: Any) -> _StatusResponse:
             self.calls += 1
             return await super().get(url, **kwargs)
 
-    first_client = CountingClient()
-    second_client = CountingClient()
-    first_scope = ExecutionScope(cast("Any", first_client))
-    second_scope = ExecutionScope(cast("Any", second_client))
+    first_session = CountingSession()
+    second_session = CountingSession()
+    first_scope = ExecutionScope(cast("Any", first_session))
+    second_scope = ExecutionScope(cast("Any", second_session))
 
     assert isinstance(await Fetcher.touch_url(first_scope, "https://example.com"), Success)
     assert isinstance(await Fetcher.touch_url(first_scope, "https://example.com"), Success)
     assert isinstance(await Fetcher.touch_url(second_scope, "https://example.com"), Success)
-    assert first_client.calls == 1
-    assert second_client.calls == 1
+    assert first_session.calls == 1
+    assert second_session.calls == 1
+
+
+@as_sync
+async def test_fetcher_does_not_retry_a_closed_session():
+    class ClosedSession:
+        async def get(self, url: str, **kwargs: Any) -> None:
+            raise SessionClosedError("closed")
+
+    scope = ExecutionScope(cast("Any", ClosedSession()))
+    with pytest.raises(SessionClosedError, match="closed"):
+        await Fetcher.touch_url(scope, "https://example.com")


### PR DESCRIPTION
## 动机

在 NativeSession 边界就绪后，主下载请求链仍需要从 HTTPX client 切换到同一个原生 session，才能避免元数据请求和媒体下载各自维护网络状态。

本 PR 是三层迁移栈的第 2 层，基于 #788；只迁移 Fetcher、ExecutionScope 和下载调用侧，登录链留给第 3 层 #790。

## 解决方案

- 让每个 `ExecutionScope` 只持有一个 `NativeSession`，统一元数据请求、媒体探测与 Haya transfer。
- 保留 Fetcher 作为 Python 侧重试、Result、JSON 与文本解码门面，不增加新的通用层。
- 将 query 参数保持为原 HTTPX 语义：`None`、布尔值以及 list/tuple 重复键均有回归覆盖。
- 仅为普通 `Session.get()` 恢复 HTTPX 内置的 gzip/deflate 响应解码；按所有 `Content-Encoding` 字段的 wire 顺序逆序解码，共享 Client 继续关闭自动解压，Haya Range 请求仍强制 `identity`。
- 禁用 reqwest 自动生成 `Referer`，使 redirect 后继续使用配置的 Bilibili Referer，并避免来源 URL query 泄漏。
- 通过 session 方法启动 transfer，并移除模块级 `start_transfer` 与 `source_headers` 过渡入口。
- 将下载管理器切到原生类型化 URL 错误，并更新相关执行域、CLI、processor 与 server 测试替身。

验证：

- `just fmt`
- `just lint`
- 聚焦 Python 测试 95 项通过
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Rust workspace 55 项通过
- Rust 1.85 MSRV check 通过
- 真实 Bilibili deflate 弹幕响应可解析，原失败 e2e 用例通过

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [x] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [x] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
