### PR TITLE
♻️ refactor: remove HTTPX

### DIFF
--- a/docs/guide/thanks.md
+++ b/docs/guide/thanks.md
@@ -8,7 +8,7 @@
 
 我的正常运作离不开以下项目的支持
 
-- [HTTPX](https://github.com/encode/httpx) 用于 HTTP 请求发送
+- [Reqwest](https://github.com/seanmonstar/reqwest) 用于 HTTP 请求发送
 - [FFmpeg](https://github.com/FFmpeg/FFmpeg) 用于视频的合并
 - [biliass](https://github.com/yutto-dev/yutto/tree/main/packages/biliass) 用于 Bilibili XML/Protobuf 格式弹幕转换为 ASS 弹幕
 - [Pydantic](https://github.com/pydantic/pydantic) 用于配置格式校验

--- a/packages/yutto-core/rust/crates/yutto/src/lib.rs
+++ b/packages/yutto-core/rust/crates/yutto/src/lib.rs
@@ -109,7 +109,7 @@ struct YuttoSession {
 #[pymethods]
 impl YuttoSession {
     #[new]
-    #[pyo3(signature = (*, headers=None, cookies=None, proxy=None, use_system_proxy=true, accept_invalid_certs=false, read_timeout=5.0, connect_timeout=5.0))]
+    #[pyo3(signature = (*, headers=None, cookies=None, proxy=None, use_system_proxy=true, accept_invalid_certs=false, ca_cert_file=None, ca_cert_dir=None, read_timeout=5.0, connect_timeout=5.0))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         headers: Option<HashMap<String, String>>,
@@ -117,6 +117,8 @@ impl YuttoSession {
         proxy: Option<String>,
         use_system_proxy: bool,
         accept_invalid_certs: bool,
+        ca_cert_file: Option<PathBuf>,
+        ca_cert_dir: Option<PathBuf>,
         read_timeout: f64,
         connect_timeout: f64,
     ) -> PyResult<Self> {
@@ -126,6 +128,8 @@ impl YuttoSession {
             proxy,
             use_system_proxy,
             accept_invalid_certs,
+            ca_cert_file,
+            ca_cert_dir,
             read_timeout: duration_from_seconds(read_timeout, "read_timeout")?,
             connect_timeout: duration_from_seconds(connect_timeout, "connect_timeout")?,
         })

--- a/packages/yutto-core/rust/crates/yutto/src/lib.rs
+++ b/packages/yutto-core/rust/crates/yutto/src/lib.rs
@@ -102,12 +102,12 @@ impl NativeResponse {
 }
 
 #[pyclass(frozen, module = "yutto_core._core")]
-struct NativeSession {
+struct YuttoSession {
     session: Session,
 }
 
 #[pymethods]
-impl NativeSession {
+impl YuttoSession {
     #[new]
     #[pyo3(signature = (*, headers=None, cookies=None, proxy=None, use_system_proxy=true, accept_invalid_certs=false, read_timeout=5.0, connect_timeout=5.0))]
     #[allow(clippy::too_many_arguments)]
@@ -409,7 +409,7 @@ fn session_error_to_py(error: SessionError) -> PyErr {
 #[pymodule(gil_used = false)]
 #[pyo3(name = "_core")]
 fn yutto(module: &Bound<'_, PyModule>) -> PyResult<()> {
-    module.add_class::<NativeSession>()?;
+    module.add_class::<YuttoSession>()?;
     module.add_class::<NativeResponse>()?;
     module.add_class::<TransferHandle>()?;
     module.add_class::<TransferSnapshot>()?;

--- a/packages/yutto-core/rust/crates/yutto/src/session.rs
+++ b/packages/yutto-core/rust/crates/yutto/src/session.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    fs,
     io::Read,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -8,7 +10,7 @@ use std::{
 use bytes::Bytes;
 use flate2::read::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use reqwest::{
-    Client, Proxy, StatusCode, Url,
+    Certificate, Client, ClientBuilder, Proxy, StatusCode, Url,
     cookie::{CookieStore, Jar},
     header::{ACCEPT_ENCODING, CONTENT_ENCODING, HeaderMap, HeaderName, HeaderValue},
 };
@@ -41,6 +43,8 @@ pub struct SessionConfig {
     pub proxy: Option<String>,
     pub use_system_proxy: bool,
     pub accept_invalid_certs: bool,
+    pub ca_cert_file: Option<PathBuf>,
+    pub ca_cert_dir: Option<PathBuf>,
     pub read_timeout: Duration,
     pub connect_timeout: Duration,
 }
@@ -53,6 +57,8 @@ impl Default for SessionConfig {
             proxy: None,
             use_system_proxy: true,
             accept_invalid_certs: false,
+            ca_cert_file: None,
+            ca_cert_dir: None,
             read_timeout: DEFAULT_READ_TIMEOUT,
             connect_timeout: DEFAULT_CONNECT_TIMEOUT,
         }
@@ -132,6 +138,21 @@ impl Session {
             .danger_accept_invalid_certs(config.accept_invalid_certs)
             .read_timeout(config.read_timeout)
             .connect_timeout(config.connect_timeout);
+        if let Some(path) = config.ca_cert_file {
+            builder = add_root_certificates(builder, &path, true)?;
+        } else if let Some(path) = config.ca_cert_dir {
+            let entries = fs::read_dir(&path).map_err(|error| {
+                SessionError::Configuration(format!(
+                    "failed to read CA certificate directory {}: {error}",
+                    path.display()
+                ))
+            })?;
+            for entry in entries.flatten() {
+                if entry.path().is_file() {
+                    builder = add_root_certificates(builder, &entry.path(), false)?;
+                }
+            }
+        }
         if !config.use_system_proxy {
             builder = builder.no_proxy();
         }
@@ -217,6 +238,43 @@ impl Session {
             .clone()
             .ok_or(SessionError::Closed)
     }
+}
+
+fn add_root_certificates(
+    mut builder: ClientBuilder,
+    path: &Path,
+    required: bool,
+) -> Result<ClientBuilder, SessionError> {
+    let data = match fs::read(path) {
+        Ok(data) => data,
+        Err(_) if !required => return Ok(builder),
+        Err(error) => {
+            return Err(SessionError::Configuration(format!(
+                "failed to read CA certificate file {}: {error}",
+                path.display()
+            )));
+        }
+    };
+    let certificates = match Certificate::from_pem_bundle(&data) {
+        Ok(certificates) if !certificates.is_empty() => certificates,
+        Ok(_) | Err(_) if !required => return Ok(builder),
+        Ok(_) => {
+            return Err(SessionError::Configuration(format!(
+                "CA certificate file {} contains no certificates",
+                path.display()
+            )));
+        }
+        Err(error) => {
+            return Err(SessionError::Configuration(format!(
+                "failed to parse CA certificate file {}: {error}",
+                path.display()
+            )));
+        }
+    };
+    for certificate in certificates {
+        builder = builder.add_root_certificate(certificate);
+    }
+    Ok(builder)
 }
 
 pub(crate) fn build_headers(headers: HashMap<String, String>) -> Result<HeaderMap, SessionError> {
@@ -483,6 +541,26 @@ mod tests {
 
         assert!(session.is_closed());
         assert!(matches!(session.client(), Err(SessionError::Closed)));
+    }
+
+    #[test]
+    fn missing_custom_ca_paths_are_configuration_errors() {
+        let path = std::env::temp_dir().join(format!("missing-yutto-ca-{}", std::process::id()));
+        for config in [
+            SessionConfig {
+                ca_cert_file: Some(path.clone()),
+                ..SessionConfig::default()
+            },
+            SessionConfig {
+                ca_cert_dir: Some(path.clone()),
+                ..SessionConfig::default()
+            },
+        ] {
+            assert!(matches!(
+                Session::new(config),
+                Err(SessionError::Configuration(_))
+            ));
+        }
     }
 
     #[test]

--- a/packages/yutto-core/src/yutto_core/__init__.py
+++ b/packages/yutto-core/src/yutto_core/__init__.py
@@ -10,11 +10,11 @@ from yutto_core._core import (
     HttpTransportError,
     InvalidUrlError,
     NativeResponse,
-    NativeSession,
     SessionClosedError,
     TransferHandle,
     TransferSnapshot,
     UnsupportedProtocolError,
+    YuttoSession,
 )
 
 if TYPE_CHECKING:
@@ -27,11 +27,11 @@ __all__ = [
     "HttpTransportError",
     "InvalidUrlError",
     "NativeResponse",
-    "NativeSession",
     "SessionClosedError",
     "TransferHandle",
     "TransferSnapshot",
     "UnsupportedProtocolError",
+    "YuttoSession",
     "wait_for_transfer",
 ]
 

--- a/packages/yutto-core/src/yutto_core/_core.pyi
+++ b/packages/yutto-core/src/yutto_core/_core.pyi
@@ -43,7 +43,7 @@ class TransferHandle:
     def snapshot(self) -> TransferSnapshot: ...
     def result(self) -> int: ...
 
-class NativeSession:
+class YuttoSession:
     def __init__(
         self,
         *,

--- a/packages/yutto-core/src/yutto_core/_core.pyi
+++ b/packages/yutto-core/src/yutto_core/_core.pyi
@@ -52,6 +52,8 @@ class YuttoSession:
         proxy: str | None = ...,
         use_system_proxy: bool = ...,
         accept_invalid_certs: bool = ...,
+        ca_cert_file: str | Path | None = ...,
+        ca_cert_dir: str | Path | None = ...,
         read_timeout: float = ...,
         connect_timeout: float = ...,
     ) -> None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "colorama>=0.4.6; sys_platform == 'win32'",
   "typing-extensions>=4.15.0",
   "dict2xml>=1.7.8",
-  "httpx[http2,socks]>=0.28.1",
   "pydantic>=2.12.5",
   "returns>=0.26.0",
   "segno>=1.6.6",

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -18,7 +18,7 @@ from yutto.core.operation import bind_download_report_sink
 from yutto.download_manager import DownloadManager
 from yutto.exceptions import ErrorCode, YuttoBaseException
 from yutto.input_parser import file_scheme_parser
-from yutto.login import run_auth_logout, run_auth_status, run_login
+from yutto.login import run_auth
 from yutto.utils.console.logger import Badge, Logger
 from yutto.utils.ffmpeg import FFmpegNotFoundError
 from yutto.utils.functional import as_sync
@@ -86,15 +86,7 @@ def main():
                     Logger.info("已终止下载，再次运行即可继续下载～")
                     sys.exit(ErrorCode.PAUSED_DOWNLOAD.value)
         case "auth":
-            match args.auth_command:
-                case "login":
-                    run_login(args)
-                case "logout":
-                    run_auth_logout(args)
-                case "status":
-                    run_auth_status(args)
-                case _:
-                    raise ValueError("Invalid auth command")
+            run_auth(args)
 
         case "serve":
             from yutto.server.command import run_server_command

--- a/src/yutto/core/execution.py
+++ b/src/yutto/core/execution.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
     from contextlib import AbstractAsyncContextManager
 
-    from yutto_core import NativeSession
+    from yutto_core import YuttoSession
 
     from yutto.auth import AuthInfo
     from yutto.core.request import DownloadRequest
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 class ExecutionScope:
     """Runtime resources owned by one request execution."""
 
-    session: NativeSession
+    session: YuttoSession
     fetch_limiter: asyncio.Semaphore
     download_workers: int
     user_info_cache: UserInfo | None
@@ -34,7 +34,7 @@ class ExecutionScope:
 
     def __init__(
         self,
-        session: NativeSession,
+        session: YuttoSession,
         *,
         fetch_workers: int = DEFAULT_FETCH_WORKERS,
         download_workers: int = DEFAULT_FETCH_WORKERS,

--- a/src/yutto/login.py
+++ b/src/yutto/login.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
+import asyncio
+import json
 import sys
 import time
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
-import httpx
 import segno
+from yutto_core import HttpError
 
 from yutto.api.user_info import USER_INFO_API, parse_user_info, user_info_matches
 from yutto.auth import AuthInfo, remove_auth, resolve_auth, resolve_auth_file, save_auth, validate_profile
 from yutto.exceptions import ErrorCode
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.fetcher import cookies_from_auth, create_sync_client, resolve_proxy
+from yutto.utils.fetcher import cookies_from_auth, create_client, resolve_proxy
+from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
+    from yutto_core import NativeSession
+
     from yutto.types import UserInfo
 
 QR_GENERATE_API = "https://passport.bilibili.com/x/passport-login/web/qrcode/generate"
@@ -25,9 +30,29 @@ QR_STATUS_NOT_SCANNED = 86101
 QR_STATUS_SCANNED = 86090
 QR_STATUS_EXPIRED = 86038
 QR_STATUS_CONFIRMED = 0
+COOKIE_PROBE_URLS = (
+    "https://yutto.bilibili.com/",
+    "https://bilibili.com/",
+    "https://yutto.passport.bilibili.com/",
+    "https://passport.bilibili.com/",
+    "https://www.bilibili.com/",
+)
 
 
-def run_login(args: Any):
+@as_sync
+async def run_auth(args: Any) -> None:
+    match args.auth_command:
+        case "login":
+            await run_login(args)
+        case "logout":
+            run_auth_logout(args)
+        case "status":
+            await run_auth_status(args)
+        case _:
+            raise ValueError("Invalid auth command")
+
+
+async def run_login(args: Any) -> None:
     try:
         proxy, trust_env = resolve_proxy(args.proxy)
         validate_profile(args.auth_profile)
@@ -35,12 +60,17 @@ def run_login(args: Any):
         Logger.error(str(e))
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 
-    with create_sync_client(proxy=proxy, trust_env=trust_env, timeout=10, verify=True) as client:
-        qr_login_url, qr_key = generate_qr_login(client)
+    async with create_client(proxy=proxy, trust_env=trust_env, timeout=10, verify=True) as session:
+        qr_login_url, qr_key = await generate_qr_login(session)
         show_qr_code(qr_login_url, args.mode)
         Logger.info("请使用哔哩哔哩 App 扫码并确认登录")
-        redirect_url = poll_qr_login(client, qr_key, timeout=args.timeout, poll_interval=args.poll_interval)
-        result_url, sessdata, bili_jct = complete_login(client, redirect_url)
+        redirect_url = await poll_qr_login(
+            session,
+            qr_key,
+            timeout=args.timeout,
+            poll_interval=args.poll_interval,
+        )
+        result_url, sessdata, bili_jct = await complete_login(session, redirect_url)
 
     if sessdata is None:
         raise ValueError("登录成功但未提取到 SESSDATA")
@@ -48,7 +78,7 @@ def run_login(args: Any):
     auth_file = resolve_auth_file(args)
     save_auth(auth_file, args.auth_profile, sessdata, bili_jct)
     auth = AuthInfo(SESSDATA=sessdata, bili_jct=bili_jct)
-    if validate_saved_auth(auth, proxy=proxy, trust_env=trust_env):
+    if await validate_saved_auth(auth, proxy=proxy, trust_env=trust_env):
         Logger.info(
             f"登录成功，已写入认证文件：{auth_file}（profile: {args.auth_profile}，url: {sanitize_url_for_log(result_url)}）"
         )
@@ -58,7 +88,7 @@ def run_login(args: Any):
         )
 
 
-def run_auth_status(args: Any):
+async def run_auth_status(args: Any) -> None:
     try:
         proxy, trust_env = resolve_proxy(args.proxy)
         auth = resolve_auth(args)
@@ -71,7 +101,7 @@ def run_auth_status(args: Any):
         sys.exit(ErrorCode.NOT_LOGIN_ERROR.value)
 
     try:
-        user_info = fetch_authenticated_user_info(auth, proxy=proxy, trust_env=trust_env)
+        user_info = await fetch_authenticated_user_info(auth, proxy=proxy, trust_env=trust_env)
     except Exception as e:
         Logger.error(f"登录状态检查失败：{e}")
         sys.exit(ErrorCode.HTTP_STATUS_ERROR.value)
@@ -88,7 +118,7 @@ def run_auth_status(args: Any):
     sys.exit(ErrorCode.NOT_LOGIN_ERROR.value)
 
 
-def run_auth_logout(args: Any):
+def run_auth_logout(args: Any) -> None:
     if getattr(args, "auth", ""):
         Logger.error("当前认证来源于 inline auth，请删除 `--auth` 参数或配置项 `auth.auth` 后再试。")
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
@@ -119,8 +149,8 @@ def sanitize_url_for_log(url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}{path}"
 
 
-def generate_qr_login(client: httpx.Client) -> tuple[str, str]:
-    payload = request_json(client, QR_GENERATE_API, params={"source": "main-fe-header"})
+async def generate_qr_login(session: NativeSession) -> tuple[str, str]:
+    payload = await request_json(session, QR_GENERATE_API, params={"source": "main-fe-header"})
     code = payload.get("code")
     if not isinstance(code, int) or code != 0:
         raise ValueError(f"获取登录二维码失败：{payload}")
@@ -135,7 +165,7 @@ def generate_qr_login(client: httpx.Client) -> tuple[str, str]:
     return login_url, qrcode_key
 
 
-def show_qr_code(url: str, mode: str):
+def show_qr_code(url: str, mode: str) -> None:
     qr = segno.make(url)
     if mode == "web":
         try:
@@ -146,11 +176,21 @@ def show_qr_code(url: str, mode: str):
     qr.terminal(compact=True)
 
 
-def poll_qr_login(client: httpx.Client, qrcode_key: str, *, timeout: int, poll_interval: float) -> str:
+async def poll_qr_login(
+    session: NativeSession,
+    qrcode_key: str,
+    *,
+    timeout: int,
+    poll_interval: float,
+) -> str:
     deadline = time.monotonic() + timeout
     last_status: int | None = None
     while time.monotonic() < deadline:
-        payload = request_json(client, QR_POLL_API, params={"qrcode_key": qrcode_key, "source": "main-fe-header"})
+        payload = await request_json(
+            session,
+            QR_POLL_API,
+            params={"qrcode_key": qrcode_key, "source": "main-fe-header"},
+        )
         code = payload.get("code")
         if not isinstance(code, int) or code != 0:
             raise ValueError(f"轮询登录状态失败：{payload}")
@@ -178,14 +218,16 @@ def poll_qr_login(client: httpx.Client, qrcode_key: str, *, timeout: int, poll_i
                 raise ValueError(f"登录成功但未返回跳转链接：{payload}")
             return redirect_url
 
-        time.sleep(poll_interval)
+        if poll_interval < 0:
+            raise ValueError("poll_interval must be non-negative")
+        await asyncio.sleep(poll_interval)
     raise TimeoutError(f"登录超时（>{timeout} 秒），请重试")
 
 
-def request_json(client: httpx.Client, url: str, *, params: dict[str, str]) -> dict[str, Any]:
-    resp = client.get(url, params=params)
+async def request_json(session: NativeSession, url: str, *, params: dict[str, str]) -> dict[str, Any]:
+    resp = await session.get(url, params=list(params.items()))
     resp.raise_for_status()
-    payload_any = resp.json()
+    payload_any = json.loads(resp.body)
     if not isinstance(payload_any, dict):
         raise ValueError(f"接口返回 JSON 结构异常：{url}")
     return cast("dict[str, Any]", payload_any)
@@ -207,17 +249,17 @@ def extract_bili_jct(redirect_url: str) -> str | None:
     return unquote(values[0])
 
 
-def complete_login(client: httpx.Client, redirect_url: str) -> tuple[str, str | None, str | None]:
+async def complete_login(session: NativeSession, redirect_url: str) -> tuple[str, str | None, str | None]:
     # 登录成功后返回的 URL 需要真正请求一次，才能让 cookie jar 更新到最新值
     final_url = redirect_url
     try:
-        resp = client.get(redirect_url)
-        final_url = str(resp.url)
-    except httpx.HTTPError as e:
+        resp = await session.get(redirect_url)
+        final_url = resp.url
+    except HttpError as e:
         Logger.warning(f"请求登录确认 URL 失败，将尝试从返回 URL 提取 cookies：{e}")
 
-    sessdata = get_cookie_value(client.cookies, "SESSDATA")
-    bili_jct = get_cookie_value(client.cookies, "bili_jct")
+    sessdata = get_cookie_value(session, "SESSDATA")
+    bili_jct = get_cookie_value(session, "bili_jct")
 
     if not sessdata:
         sessdata = extract_sessdata(final_url) or extract_sessdata(redirect_url)
@@ -227,34 +269,35 @@ def complete_login(client: httpx.Client, redirect_url: str) -> tuple[str, str | 
     return final_url, sessdata, bili_jct
 
 
-def get_cookie_value(cookies: httpx.Cookies, name: str) -> str | None:
-    try:
-        return cookies.get(name)
-    except httpx.CookieConflict:
-        # 同名 cookie 可能存在于多个域名，优先取 bilibili 主域下的值
-        candidates: list[tuple[str, str]] = []
-        for cookie in cookies.jar:
-            if cookie.name == name and cookie.value is not None:
-                candidates.append((cookie.domain, cookie.value))
-        domain_priority = [".bilibili.com", "bilibili.com", ".passport.bilibili.com", "passport.bilibili.com"]
-        for target_domain in domain_priority:
-            for domain, value in candidates:
-                if domain == target_domain:
-                    return value
-        if candidates:
-            return candidates[0][1]
-        return None
+def get_cookie_value(session: NativeSession, name: str) -> str | None:
+    # 用只匹配目标 Domain/host-only cookie 的 URL 按旧优先级探测，
+    # 避免 NativeSession 需要暴露整个 cookie jar。
+    for url in COOKIE_PROBE_URLS:
+        if value := session.cookie(name, url=url):
+            return value
+    return None
 
 
-def fetch_authenticated_user_info(auth: AuthInfo, *, proxy: str | None, trust_env: bool) -> UserInfo:
+async def fetch_authenticated_user_info(
+    auth: AuthInfo,
+    *,
+    proxy: str | None,
+    trust_env: bool,
+) -> UserInfo:
     cookies = cookies_from_auth(auth)
-    with create_sync_client(cookies=cookies, proxy=proxy, trust_env=trust_env, verify=True) as client:
-        return parse_user_info(request_json(client, USER_INFO_API, params={}))
+    async with create_client(
+        cookies=cookies,
+        proxy=proxy,
+        trust_env=trust_env,
+        timeout=5,
+        verify=True,
+    ) as session:
+        return parse_user_info(await request_json(session, USER_INFO_API, params={}))
 
 
-def validate_saved_auth(auth: AuthInfo, *, proxy: str | None, trust_env: bool) -> bool:
+async def validate_saved_auth(auth: AuthInfo, *, proxy: str | None, trust_env: bool) -> bool:
     try:
-        user_info = fetch_authenticated_user_info(auth, proxy=proxy, trust_env=trust_env)
+        user_info = await fetch_authenticated_user_info(auth, proxy=proxy, trust_env=trust_env)
         return user_info_matches(user_info, {"vip_status": False, "is_login": True})
     except Exception as e:
         Logger.warning(f"登录状态校验失败，将跳过校验：{e}")

--- a/src/yutto/login.py
+++ b/src/yutto/login.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import sys
 import time
 from typing import TYPE_CHECKING, Any, cast
@@ -183,6 +184,9 @@ async def poll_qr_login(
     timeout: int,
     poll_interval: float,
 ) -> str:
+    if not math.isfinite(poll_interval) or poll_interval < 0:
+        raise ValueError("poll_interval must be finite and non-negative")
+
     deadline = time.monotonic() + timeout
     last_status: int | None = None
     while time.monotonic() < deadline:
@@ -218,8 +222,6 @@ async def poll_qr_login(
                 raise ValueError(f"登录成功但未返回跳转链接：{payload}")
             return redirect_url
 
-        if poll_interval < 0:
-            raise ValueError("poll_interval must be non-negative")
         await asyncio.sleep(poll_interval)
     raise TimeoutError(f"登录超时（>{timeout} 秒），请重试")
 

--- a/src/yutto/login.py
+++ b/src/yutto/login.py
@@ -18,7 +18,7 @@ from yutto.utils.fetcher import cookies_from_auth, create_client, resolve_proxy
 from yutto.utils.functional import as_sync
 
 if TYPE_CHECKING:
-    from yutto_core import NativeSession
+    from yutto_core import YuttoSession
 
     from yutto.types import UserInfo
 
@@ -149,7 +149,7 @@ def sanitize_url_for_log(url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}{path}"
 
 
-async def generate_qr_login(session: NativeSession) -> tuple[str, str]:
+async def generate_qr_login(session: YuttoSession) -> tuple[str, str]:
     payload = await request_json(session, QR_GENERATE_API, params={"source": "main-fe-header"})
     code = payload.get("code")
     if not isinstance(code, int) or code != 0:
@@ -177,7 +177,7 @@ def show_qr_code(url: str, mode: str) -> None:
 
 
 async def poll_qr_login(
-    session: NativeSession,
+    session: YuttoSession,
     qrcode_key: str,
     *,
     timeout: int,
@@ -224,7 +224,7 @@ async def poll_qr_login(
     raise TimeoutError(f"登录超时（>{timeout} 秒），请重试")
 
 
-async def request_json(session: NativeSession, url: str, *, params: dict[str, str]) -> dict[str, Any]:
+async def request_json(session: YuttoSession, url: str, *, params: dict[str, str]) -> dict[str, Any]:
     resp = await session.get(url, params=list(params.items()))
     resp.raise_for_status()
     payload_any = json.loads(resp.body)
@@ -249,7 +249,7 @@ def extract_bili_jct(redirect_url: str) -> str | None:
     return unquote(values[0])
 
 
-async def complete_login(session: NativeSession, redirect_url: str) -> tuple[str, str | None, str | None]:
+async def complete_login(session: YuttoSession, redirect_url: str) -> tuple[str, str | None, str | None]:
     # 登录成功后返回的 URL 需要真正请求一次，才能让 cookie jar 更新到最新值
     final_url = redirect_url
     try:
@@ -269,9 +269,9 @@ async def complete_login(session: NativeSession, redirect_url: str) -> tuple[str
     return final_url, sessdata, bili_jct
 
 
-def get_cookie_value(session: NativeSession, name: str) -> str | None:
+def get_cookie_value(session: YuttoSession, name: str) -> str | None:
     # 用只匹配目标 Domain/host-only cookie 的 URL 按旧优先级探测，
-    # 避免 NativeSession 需要暴露整个 cookie jar。
+    # 避免 YuttoSession 需要暴露整个 cookie jar。
     for url in COOKIE_PROBE_URLS:
         if value := session.cookie(name, url=url):
             return value

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -12,9 +12,9 @@ from yutto_core import (
     HttpError,
     HttpTimeoutError,
     InvalidUrlError,
-    NativeSession,
     SessionClosedError,
     UnsupportedProtocolError,
+    YuttoSession,
 )
 
 from yutto.core.operation import ReportLevel, emit_download_report
@@ -237,8 +237,8 @@ async def create_client(
     timeout: float = 5,
     *,
     verify: bool = False,
-) -> AsyncIterator[NativeSession]:
-    session = NativeSession(
+) -> AsyncIterator[YuttoSession]:
+    session = YuttoSession(
         headers=dict(headers or {}),
         cookies=dict(cookies or {}),
         proxy=proxy,

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import quote, unquote, urlparse
@@ -238,12 +239,16 @@ async def create_client(
     *,
     verify: bool = False,
 ) -> AsyncIterator[YuttoSession]:
+    ca_cert_file = os.environ.get("SSL_CERT_FILE") if trust_env and verify else None
+    ca_cert_dir = os.environ.get("SSL_CERT_DIR") if trust_env and verify and not ca_cert_file else None
     session = YuttoSession(
         headers=dict(headers or {}),
         cookies=dict(cookies or {}),
         proxy=proxy,
         use_system_proxy=trust_env,
         accept_invalid_certs=not verify,
+        ca_cert_file=ca_cert_file,
+        ca_cert_dir=ca_cert_dir,
         read_timeout=timeout,
         connect_timeout=timeout,
     )

--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import quote, unquote, urlparse
 
-import httpx
 from returns.result import Failure, Result, Success
 from typing_extensions import ParamSpec
 from yutto_core import (
@@ -89,7 +88,6 @@ DEFAULT_HEADERS: dict[str, str] = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
     "Referer": "https://www.bilibili.com",
 }
-DEFAULT_COOKIES = httpx.Cookies()
 SUPPORTED_PROXY_SCHEMES = frozenset({"http", "https", "socks5", "socks5h"})
 
 
@@ -105,15 +103,15 @@ def resolve_proxy(proxy: str) -> tuple[str | None, bool]:
     return proxy, False
 
 
-def cookies_from_auth(auth_info: AuthInfo | None) -> httpx.Cookies:
-    cookies = httpx.Cookies()
+def cookies_from_auth(auth_info: AuthInfo | None) -> dict[str, str]:
+    cookies: dict[str, str] = {}
     if auth_info is None:
         return cookies
     # 先解码后编码是防止获取到的 SESSDATA 是已经解码后的（包含「,」）
     # 而番剧无法使用解码后的 SESSDATA
-    cookies.set("SESSDATA", quote(unquote(auth_info["SESSDATA"])))
+    cookies["SESSDATA"] = quote(unquote(auth_info["SESSDATA"]))
     if auth_info["bili_jct"]:
-        cookies.set("bili_jct", auth_info["bili_jct"])
+        cookies["bili_jct"] = auth_info["bili_jct"]
     return cookies
 
 
@@ -230,32 +228,10 @@ def _query_value(value: Any) -> str:
     return str(value)
 
 
-def _sync_client_kwargs(
-    *,
-    headers: dict[str, str],
-    cookies: httpx.Cookies,
-    trust_env: bool,
-    proxy: str | None,
-    timeout: int | httpx.Timeout,
-    http2: bool,
-    verify: bool,
-) -> dict[str, Any]:
-    return {
-        "headers": headers,
-        "cookies": cookies,
-        "trust_env": trust_env,
-        "proxy": proxy,
-        "timeout": timeout,
-        "follow_redirects": True,
-        "http2": http2,
-        "verify": verify,
-    }
-
-
 @asynccontextmanager
 async def create_client(
-    headers: dict[str, str] = DEFAULT_HEADERS,
-    cookies: httpx.Cookies = DEFAULT_COOKIES,
+    headers: Mapping[str, str] | None = DEFAULT_HEADERS,
+    cookies: Mapping[str, str] | None = None,
     trust_env: bool = DEFAULT_TRUST_ENV,
     proxy: str | None = DEFAULT_PROXY,
     timeout: float = 5,
@@ -263,8 +239,8 @@ async def create_client(
     verify: bool = False,
 ) -> AsyncIterator[NativeSession]:
     session = NativeSession(
-        headers=dict(headers),
-        cookies=dict(cookies),
+        headers=dict(headers or {}),
+        cookies=dict(cookies or {}),
         proxy=proxy,
         use_system_proxy=trust_env,
         accept_invalid_certs=not verify,
@@ -275,27 +251,3 @@ async def create_client(
         yield session
     finally:
         session.close()
-
-
-def create_sync_client(
-    headers: dict[str, str] = DEFAULT_HEADERS,
-    cookies: httpx.Cookies = DEFAULT_COOKIES,
-    trust_env: bool = DEFAULT_TRUST_ENV,
-    proxy: str | None = DEFAULT_PROXY,
-    timeout: int | httpx.Timeout = 5,
-    *,
-    http2: bool = True,
-    verify: bool = False,
-) -> httpx.Client:
-    client = httpx.Client(
-        **_sync_client_kwargs(
-            headers=headers,
-            cookies=cookies,
-            trust_env=trust_env,
-            proxy=proxy,
-            timeout=timeout,
-            http2=http2,
-            verify=verify,
-        )
-    )
-    return client

--- a/tests/test_core/test_native_session.py
+++ b/tests/test_core/test_native_session.py
@@ -6,9 +6,9 @@ import pytest
 from yutto_core import (
     HttpStatusError,
     InvalidUrlError,
-    NativeSession,
     SessionClosedError,
     UnsupportedProtocolError,
+    YuttoSession,
     wait_for_transfer,
 )
 
@@ -19,9 +19,9 @@ pytestmark = pytest.mark.processor
 
 
 @as_sync
-async def test_native_session_get_exposes_response_and_typed_errors():
+async def test_yutto_session_get_exposes_response_and_typed_errors():
     with LocalRangeServer(b"payload") as server:
-        session = NativeSession(use_system_proxy=False)
+        session = YuttoSession(use_system_proxy=False)
         response = await session.get(server.url, params=[("query", "a b")])
         missing = await session.get(server.url, headers={"Range": "bytes=99-100"})
 
@@ -42,8 +42,8 @@ async def test_native_session_get_exposes_response_and_typed_errors():
 
 
 @as_sync
-async def test_native_session_close_is_idempotent_and_rejects_new_work(tmp_path):
-    session = NativeSession(use_system_proxy=False)
+async def test_yutto_session_close_is_idempotent_and_rejects_new_work(tmp_path):
+    session = YuttoSession(use_system_proxy=False)
 
     session.close()
     session.close()
@@ -56,10 +56,10 @@ async def test_native_session_close_is_idempotent_and_rejects_new_work(tmp_path)
 
 
 @as_sync
-async def test_native_session_get_propagates_asyncio_cancellation():
+async def test_yutto_session_get_propagates_asyncio_cancellation():
     payload = b"payload"
     with LocalRangeServer(payload, delays={(0, len(payload) - 1): 0.2}) as server:
-        session = NativeSession(use_system_proxy=False)
+        session = YuttoSession(use_system_proxy=False)
         future = asyncio.ensure_future(session.get(server.url, headers={"Range": f"bytes=0-{len(payload) - 1}"}))
         while not server.requests:
             await asyncio.sleep(0)
@@ -69,12 +69,12 @@ async def test_native_session_get_propagates_asyncio_cancellation():
 
 
 @as_sync
-async def test_native_session_starts_a_transfer_with_its_client(tmp_path):
+async def test_yutto_session_starts_a_transfer_with_its_client(tmp_path):
     payload = b"native transfer"
     target = tmp_path / "media"
 
     with LocalRangeServer(payload) as server:
-        session = NativeSession(use_system_proxy=False)
+        session = YuttoSession(use_system_proxy=False)
         handle = session.start_transfer([server.url], target, len(payload), overwrite=True)
         committed = await wait_for_transfer(handle, poll_interval=0)
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -15,7 +15,7 @@ from yutto.utils.functional import as_sync
 
 
 @as_sync
-async def test_validate_saved_auth_uses_native_session_with_auth_cookies(monkeypatch: pytest.MonkeyPatch):
+async def test_validate_saved_auth_uses_yutto_session_with_auth_cookies(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
     fake_session = object()
 
@@ -50,7 +50,7 @@ async def test_validate_saved_auth_uses_native_session_with_auth_cookies(monkeyp
 
 
 @as_sync
-async def test_run_login_reuses_one_verified_native_session(monkeypatch: pytest.MonkeyPatch):
+async def test_run_login_reuses_one_verified_yutto_session(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
     sessions: list[object] = []
     fake_session = object()

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -175,18 +175,15 @@ async def test_poll_qr_login_reports_status_changes_and_returns_redirect(monkeyp
 
 
 @as_sync
-async def test_poll_qr_login_rejects_negative_interval(monkeypatch: pytest.MonkeyPatch):
-    fake_session = object()
-
-    async def not_scanned(session: object, url: str, *, params: dict[str, str]) -> dict[str, Any]:
-        assert session is fake_session
-        assert url == login_module.QR_POLL_API
-        assert params == {"qrcode_key": "qr-key", "source": "main-fe-header"}
-        return {"code": 0, "data": {"code": login_module.QR_STATUS_NOT_SCANNED}}
-
-    monkeypatch.setattr(login_module, "request_json", not_scanned)
-    with pytest.raises(ValueError, match="poll_interval must be non-negative"):
-        await login_module.poll_qr_login(cast("Any", fake_session), "qr-key", timeout=10, poll_interval=-1)
+async def test_poll_qr_login_rejects_invalid_intervals():
+    for poll_interval in (-1, float("inf"), float("-inf"), float("nan")):
+        with pytest.raises(ValueError, match="poll_interval must be finite and non-negative"):
+            await login_module.poll_qr_login(
+                cast("Any", object()),
+                "qr-key",
+                timeout=10,
+                poll_interval=poll_interval,
+            )
 
 
 @as_sync

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,85 +1,107 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
-import httpx
 import pytest
+from yutto_core import HttpTransportError
 
 import yutto.login as login_module
 from yutto.api.user_info import USER_INFO_API
 from yutto.exceptions import ErrorCode
+from yutto.utils.functional import as_sync
 
 
-def test_validate_saved_auth_uses_sync_client_with_auth_cookies(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_validate_saved_auth_uses_native_session_with_auth_cookies(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
-    fake_client = object()
+    fake_session = object()
 
-    @contextmanager
-    def fake_create_sync_client(**kwargs: Any):
+    @asynccontextmanager
+    async def fake_create_client(**kwargs: Any):
         calls.update(kwargs)
-        yield fake_client
+        yield fake_session
 
-    def fake_request_json(client: object, url: str, *, params: dict[str, str]) -> dict[str, Any]:
-        calls["client"] = client
+    async def fake_request_json(session: object, url: str, *, params: dict[str, str]) -> dict[str, Any]:
+        calls["session"] = session
         calls["url"] = url
         calls["params"] = params
         return {"data": {"vipStatus": 0, "isLogin": True}}
 
-    monkeypatch.setattr(login_module, "create_sync_client", fake_create_sync_client)
+    monkeypatch.setattr(login_module, "create_client", fake_create_client)
     monkeypatch.setattr(login_module, "request_json", fake_request_json)
 
-    assert login_module.validate_saved_auth(
+    assert await login_module.validate_saved_auth(
         {"SESSDATA": "sess,data", "bili_jct": "csrf-token"},
         proxy="https://127.0.0.1:7890",
         trust_env=False,
     )
 
-    cookies = calls["cookies"]
-    assert isinstance(cookies, httpx.Cookies)
-    assert cookies.get("SESSDATA") == "sess%2Cdata"
-    assert cookies.get("bili_jct") == "csrf-token"
+    assert calls["cookies"] == {"SESSDATA": "sess%2Cdata", "bili_jct": "csrf-token"}
     assert calls["proxy"] == "https://127.0.0.1:7890"
     assert calls["trust_env"] is False
+    assert calls["timeout"] == 5
     assert calls["verify"] is True
-    assert calls["client"] is fake_client
+    assert calls["session"] is fake_session
     assert calls["url"] == USER_INFO_API
     assert calls["params"] == {}
 
 
-def test_run_login_uses_verified_sync_client(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_run_login_reuses_one_verified_native_session(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
-    fake_client = object()
+    sessions: list[object] = []
+    fake_session = object()
 
-    @contextmanager
-    def fake_create_sync_client(**kwargs: Any):
+    @asynccontextmanager
+    async def fake_create_client(**kwargs: Any):
         calls.update(kwargs)
-        yield fake_client
+        yield fake_session
 
-    def fake_generate_qr_login(client: object) -> tuple[str, str]:
+    async def fake_generate_qr_login(session: object) -> tuple[str, str]:
+        sessions.append(session)
         return ("https://example.com/qr", "qr-key")
 
     def fake_show_qr_code(url: str, mode: str) -> None:
-        return None
+        calls["qr"] = (url, mode)
 
-    def fake_poll_qr_login(client: object, qrcode_key: str, *, timeout: int, poll_interval: float) -> str:
+    async def fake_poll_qr_login(
+        session: object,
+        qrcode_key: str,
+        *,
+        timeout: int,
+        poll_interval: float,
+    ) -> str:
+        sessions.append(session)
+        calls["poll"] = (qrcode_key, timeout, poll_interval)
         return "https://example.com/redirect"
 
-    def fake_complete_login(client: object, redirect_url: str) -> tuple[str, str | None, str | None]:
+    async def fake_complete_login(
+        session: object,
+        redirect_url: str,
+    ) -> tuple[str, str | None, str | None]:
+        sessions.append(session)
+        calls["redirect_url"] = redirect_url
         return ("https://www.bilibili.com", "sessdata", "csrf-token")
 
     def fake_resolve_auth_file(args: SimpleNamespace) -> Path:
         return Path("/tmp/auth.toml")
 
     def fake_save_auth(auth_file: Path, profile: str, sessdata: str, bili_jct: str | None) -> None:
-        return None
+        calls["saved"] = (auth_file, profile, sessdata, bili_jct)
 
-    def fake_validate_saved_auth(auth: dict[str, str | None], *, proxy: str | None, trust_env: bool) -> bool:
+    async def fake_validate_saved_auth(
+        auth: dict[str, str | None],
+        *,
+        proxy: str | None,
+        trust_env: bool,
+    ) -> bool:
+        calls["validated"] = (auth, proxy, trust_env)
         return True
 
-    monkeypatch.setattr(login_module, "create_sync_client", fake_create_sync_client)
+    monkeypatch.setattr(login_module, "create_client", fake_create_client)
     monkeypatch.setattr(login_module, "generate_qr_login", fake_generate_qr_login)
     monkeypatch.setattr(login_module, "show_qr_code", fake_show_qr_code)
     monkeypatch.setattr(login_module, "poll_qr_login", fake_poll_qr_login)
@@ -88,7 +110,7 @@ def test_run_login_uses_verified_sync_client(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(login_module, "save_auth", fake_save_auth)
     monkeypatch.setattr(login_module, "validate_saved_auth", fake_validate_saved_auth)
 
-    login_module.run_login(
+    await login_module.run_login(
         SimpleNamespace(
             proxy="auto",
             auth_profile="default",
@@ -99,16 +121,145 @@ def test_run_login_uses_verified_sync_client(monkeypatch: pytest.MonkeyPatch):
     )
 
     assert calls["verify"] is True
+    assert calls["timeout"] == 10
+    assert sessions == [fake_session, fake_session, fake_session]
+    assert calls["qr"] == ("https://example.com/qr", "terminal")
+    assert calls["poll"] == ("qr-key", 180, 2.0)
+    assert calls["saved"] == (Path("/tmp/auth.toml"), "default", "sessdata", "csrf-token")
 
 
-def test_run_auth_status_reports_vip_login(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_poll_qr_login_reports_status_changes_and_returns_redirect(monkeypatch: pytest.MonkeyPatch):
+    responses = iter(
+        [
+            {"code": 0, "data": {"code": login_module.QR_STATUS_NOT_SCANNED}},
+            {"code": 0, "data": {"code": login_module.QR_STATUS_SCANNED}},
+            {
+                "code": 0,
+                "data": {
+                    "code": login_module.QR_STATUS_CONFIRMED,
+                    "url": "https://passport.bilibili.com/confirmed",
+                },
+            },
+        ]
+    )
+    messages: list[str] = []
+    sleeps: list[float] = []
+
+    async def fake_sleep(interval: float) -> None:
+        sleeps.append(interval)
+
+    async def poll_request(session: object, url: str, *, params: dict[str, str]) -> dict[str, Any]:
+        assert session is fake_session
+        assert url == login_module.QR_POLL_API
+        captured_params.append(dict(params))
+        return next(responses)
+
+    fake_session = object()
+    captured_params: list[dict[str, str]] = []
+    monkeypatch.setattr(login_module, "request_json", poll_request)
+    monkeypatch.setattr(login_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(login_module.Logger, "info", messages.append)
+
+    assert (
+        await login_module.poll_qr_login(cast("Any", fake_session), "qr-key", timeout=10, poll_interval=0.25)
+        == "https://passport.bilibili.com/confirmed"
+    )
+    assert captured_params == [
+        {"qrcode_key": "qr-key", "source": "main-fe-header"},
+        {"qrcode_key": "qr-key", "source": "main-fe-header"},
+        {"qrcode_key": "qr-key", "source": "main-fe-header"},
+    ]
+    assert messages == ["二维码待扫描", "已扫码，请在 App 内确认登录"]
+    assert sleeps == [0.25, 0.25]
+
+
+@as_sync
+async def test_poll_qr_login_rejects_negative_interval(monkeypatch: pytest.MonkeyPatch):
+    fake_session = object()
+
+    async def not_scanned(session: object, url: str, *, params: dict[str, str]) -> dict[str, Any]:
+        assert session is fake_session
+        assert url == login_module.QR_POLL_API
+        assert params == {"qrcode_key": "qr-key", "source": "main-fe-header"}
+        return {"code": 0, "data": {"code": login_module.QR_STATUS_NOT_SCANNED}}
+
+    monkeypatch.setattr(login_module, "request_json", not_scanned)
+    with pytest.raises(ValueError, match="poll_interval must be non-negative"):
+        await login_module.poll_qr_login(cast("Any", fake_session), "qr-key", timeout=10, poll_interval=-1)
+
+
+@as_sync
+async def test_complete_login_falls_back_to_redirect_query(monkeypatch: pytest.MonkeyPatch):
+    warnings: list[str] = []
+    redirect_url = "https://passport.bilibili.com/confirmed?SESSDATA=sess%2Cdata&bili_jct=csrf-token"
+
+    class FailedRedirectSession:
+        async def get(self, url: str) -> None:
+            raise HttpTransportError("redirect failed")
+
+        def cookie(self, name: str, *, url: str) -> None:
+            return None
+
+    monkeypatch.setattr(login_module.Logger, "warning", warnings.append)
+
+    assert await login_module.complete_login(cast("Any", FailedRedirectSession()), redirect_url) == (
+        redirect_url,
+        "sess,data",
+        "csrf-token",
+    )
+    assert warnings and "将尝试从返回 URL 提取 cookies" in warnings[0]
+
+
+def test_get_cookie_value_probes_bilibili_domains_in_priority_order():
+    probes: list[str] = []
+
+    class CookieSession:
+        def cookie(self, name: str, *, url: str) -> str | None:
+            assert name == "SESSDATA"
+            probes.append(url)
+            if url == "https://bilibili.com/":
+                return "preferred"
+            return None
+
+    assert login_module.get_cookie_value(cast("Any", CookieSession()), "SESSDATA") == "preferred"
+    assert probes == list(login_module.COOKIE_PROBE_URLS[:2])
+
+
+def test_run_auth_is_the_single_sync_cli_boundary(monkeypatch: pytest.MonkeyPatch):
+    calls: list[str] = []
+
+    async def fake_login(args: SimpleNamespace) -> None:
+        calls.append(f"login:{args.auth_command}")
+
+    async def fake_status(args: SimpleNamespace) -> None:
+        calls.append(f"status:{args.auth_command}")
+
+    def fake_logout(args: SimpleNamespace) -> None:
+        calls.append(f"logout:{args.auth_command}")
+
+    monkeypatch.setattr(login_module, "run_login", fake_login)
+    monkeypatch.setattr(login_module, "run_auth_status", fake_status)
+    monkeypatch.setattr(login_module, "run_auth_logout", fake_logout)
+
+    for command in ("login", "status", "logout"):
+        login_module.run_auth(SimpleNamespace(auth_command=command))
+
+    assert calls == ["login:login", "status:status", "logout:logout"]
+
+
+@as_sync
+async def test_run_auth_status_reports_vip_login(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
 
     def fake_resolve_auth(args: SimpleNamespace) -> dict[str, str | None]:
         return {"SESSDATA": "sessdata", "bili_jct": "csrf-token"}
 
-    def fake_fetch_authenticated_user_info(
-        auth: dict[str, str | None], *, proxy: str | None, trust_env: bool
+    async def fake_fetch_authenticated_user_info(
+        auth: dict[str, str | None],
+        *,
+        proxy: str | None,
+        trust_env: bool,
     ) -> dict[str, bool]:
         calls["proxy"] = proxy
         calls["trust_env"] = trust_env
@@ -122,7 +273,7 @@ def test_run_auth_status_reports_vip_login(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(login_module, "fetch_authenticated_user_info", fake_fetch_authenticated_user_info)
     monkeypatch.setattr(login_module.Logger, "custom", fake_custom)
 
-    login_module.run_auth_status(
+    await login_module.run_auth_status(
         SimpleNamespace(
             proxy="https://127.0.0.1:7890",
             auth="",
@@ -137,7 +288,8 @@ def test_run_auth_status_reports_vip_login(monkeypatch: pytest.MonkeyPatch):
     assert "大会员" in calls["badge"]
 
 
-def test_run_auth_status_exits_when_auth_missing(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_run_auth_status_exits_when_auth_missing(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
 
     def fake_resolve_auth(args: SimpleNamespace) -> None:
@@ -147,14 +299,10 @@ def test_run_auth_status_exits_when_auth_missing(monkeypatch: pytest.MonkeyPatch
         return str(calls.setdefault("message", message))
 
     monkeypatch.setattr(login_module, "resolve_auth", fake_resolve_auth)
-    monkeypatch.setattr(
-        login_module.Logger,
-        "warning",
-        fake_warning,
-    )
+    monkeypatch.setattr(login_module.Logger, "warning", fake_warning)
 
     with pytest.raises(SystemExit) as exc_info:
-        login_module.run_auth_status(
+        await login_module.run_auth_status(
             SimpleNamespace(
                 proxy="auto",
                 auth="",
@@ -167,7 +315,8 @@ def test_run_auth_status_exits_when_auth_missing(monkeypatch: pytest.MonkeyPatch
     assert "未找到可用认证信息" in calls["message"]
 
 
-def test_run_auth_status_exits_on_invalid_auth_file(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_run_auth_status_exits_on_invalid_auth_file(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
 
     def fake_resolve_auth(args: SimpleNamespace) -> dict[str, str | None]:
@@ -180,7 +329,7 @@ def test_run_auth_status_exits_on_invalid_auth_file(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(login_module.Logger, "error", fake_error)
 
     with pytest.raises(SystemExit) as exc_info:
-        login_module.run_auth_status(
+        await login_module.run_auth_status(
             SimpleNamespace(
                 proxy="auto",
                 auth="",
@@ -193,14 +342,18 @@ def test_run_auth_status_exits_on_invalid_auth_file(monkeypatch: pytest.MonkeyPa
     assert "认证信息文件格式无效" in calls["message"]
 
 
-def test_run_auth_status_exits_when_not_logged_in(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_run_auth_status_exits_when_not_logged_in(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
 
     def fake_resolve_auth(args: SimpleNamespace) -> dict[str, str | None]:
         return {"SESSDATA": "sessdata", "bili_jct": None}
 
-    def fake_fetch_authenticated_user_info(
-        auth: dict[str, str | None], *, proxy: str | None, trust_env: bool
+    async def fake_fetch_authenticated_user_info(
+        auth: dict[str, str | None],
+        *,
+        proxy: str | None,
+        trust_env: bool,
     ) -> dict[str, bool]:
         return {"vip_status": False, "is_login": False}
 
@@ -209,14 +362,10 @@ def test_run_auth_status_exits_when_not_logged_in(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(login_module, "resolve_auth", fake_resolve_auth)
     monkeypatch.setattr(login_module, "fetch_authenticated_user_info", fake_fetch_authenticated_user_info)
-    monkeypatch.setattr(
-        login_module.Logger,
-        "warning",
-        fake_warning,
-    )
+    monkeypatch.setattr(login_module.Logger, "warning", fake_warning)
 
     with pytest.raises(SystemExit) as exc_info:
-        login_module.run_auth_status(
+        await login_module.run_auth_status(
             SimpleNamespace(
                 proxy="auto",
                 auth="",
@@ -229,14 +378,18 @@ def test_run_auth_status_exits_when_not_logged_in(monkeypatch: pytest.MonkeyPatc
     assert "已失效或尚未登录" in calls["message"]
 
 
-def test_run_auth_status_exits_when_status_check_fails(monkeypatch: pytest.MonkeyPatch):
+@as_sync
+async def test_run_auth_status_exits_when_status_check_fails(monkeypatch: pytest.MonkeyPatch):
     calls: dict[str, Any] = {}
 
     def fake_resolve_auth(args: SimpleNamespace) -> dict[str, str | None]:
         return {"SESSDATA": "sessdata", "bili_jct": None}
 
-    def fake_fetch_authenticated_user_info(
-        auth: dict[str, str | None], *, proxy: str | None, trust_env: bool
+    async def fake_fetch_authenticated_user_info(
+        auth: dict[str, str | None],
+        *,
+        proxy: str | None,
+        trust_env: bool,
     ) -> dict[str, bool]:
         raise RuntimeError("boom")
 
@@ -248,7 +401,7 @@ def test_run_auth_status_exits_when_status_check_fails(monkeypatch: pytest.Monke
     monkeypatch.setattr(login_module.Logger, "error", fake_error)
 
     with pytest.raises(SystemExit) as exc_info:
-        login_module.run_auth_status(
+        await login_module.run_auth_status(
             SimpleNamespace(
                 proxy="auto",
                 auth="",

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -80,6 +80,37 @@ async def test_create_client_accepts_read_only_mappings_and_none(monkeypatch: py
     assert calls[1]["cookies"] == {}
 
 
+@as_sync
+async def test_create_client_preserves_environment_ca_settings(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict[str, Any]] = []
+
+    class FakeYuttoSession:
+        def __init__(self, **kwargs: Any):
+            calls.append(kwargs)
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(fetcher_module, "YuttoSession", FakeYuttoSession)
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/custom-ca.pem")
+    monkeypatch.setenv("SSL_CERT_DIR", "/tmp/custom-ca-directory")
+
+    async with create_client(trust_env=True, verify=True):
+        pass
+    monkeypatch.delenv("SSL_CERT_FILE")
+    async with create_client(trust_env=True, verify=True):
+        pass
+    async with create_client(trust_env=False, verify=True):
+        pass
+
+    assert calls[0]["ca_cert_file"] == "/tmp/custom-ca.pem"
+    assert calls[0]["ca_cert_dir"] is None
+    assert calls[1]["ca_cert_file"] is None
+    assert calls[1]["ca_cert_dir"] == "/tmp/custom-ca-directory"
+    assert calls[2]["ca_cert_file"] is None
+    assert calls[2]["ca_cert_dir"] is None
+
+
 def test_cookies_from_auth_returns_native_cookie_mapping():
     assert cookies_from_auth(None) == {}
     assert cookies_from_auth({"SESSDATA": "sess,data", "bili_jct": "csrf-token"}) == {

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import ssl
-from typing import Any, Protocol, cast
+from types import MappingProxyType
+from typing import Any, cast
 
 import pytest
 from returns.result import Failure, Success
@@ -9,22 +9,8 @@ from yutto_core import HttpStatusError, SessionClosedError
 
 import yutto.utils.fetcher as fetcher_module
 from yutto.core.execution import ExecutionScope
-from yutto.utils.fetcher import Fetcher, create_client, create_sync_client, resolve_proxy
+from yutto.utils.fetcher import Fetcher, cookies_from_auth, create_client, resolve_proxy
 from yutto.utils.functional import as_sync
-
-
-class _HasSSLContext(Protocol):
-    _ssl_context: ssl.SSLContext
-
-
-class _HasPool(Protocol):
-    _pool: _HasSSLContext
-
-
-def _transport_ssl_context(transport: Any) -> ssl.SSLContext:
-    # Test helper: inspect httpx's private transport internals to assert TLS policy wiring.
-    # If httpx changes `_pool._ssl_context`, this assertion helper will need to be updated too.
-    return cast("_HasPool", transport)._pool._ssl_context
 
 
 def test_resolve_proxy_auto_uses_system_proxy():
@@ -67,26 +53,39 @@ async def test_create_client_keeps_download_tls_verification_disabled_and_closes
     assert captured["connect_timeout"] == 5
 
 
-def test_create_sync_client_follows_default_download_tls_policy():
-    client = create_sync_client()
-    try:
-        transport: Any = client._transport
-        ssl_context = _transport_ssl_context(transport)
-        assert ssl_context.verify_mode == ssl.CERT_NONE
-        assert not ssl_context.check_hostname
-    finally:
-        client.close()
+@as_sync
+async def test_create_client_accepts_read_only_mappings_and_none(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict[str, Any]] = []
+
+    class FakeNativeSession:
+        def __init__(self, **kwargs: Any):
+            calls.append(kwargs)
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(fetcher_module, "NativeSession", FakeNativeSession)
+
+    async with create_client(
+        headers=MappingProxyType({"X-Test": "value"}),
+        cookies=MappingProxyType({"token": "secret"}),
+    ):
+        pass
+    async with create_client(headers=None, cookies=None):
+        pass
+
+    assert calls[0]["headers"] == {"X-Test": "value"}
+    assert calls[0]["cookies"] == {"token": "secret"}
+    assert calls[1]["headers"] == {}
+    assert calls[1]["cookies"] == {}
 
 
-def test_create_sync_client_can_enable_tls_verification():
-    client = create_sync_client(verify=True)
-    try:
-        transport: Any = client._transport
-        ssl_context = _transport_ssl_context(transport)
-        assert ssl_context.verify_mode == ssl.CERT_REQUIRED
-        assert ssl_context.check_hostname
-    finally:
-        client.close()
+def test_cookies_from_auth_returns_native_cookie_mapping():
+    assert cookies_from_auth(None) == {}
+    assert cookies_from_auth({"SESSDATA": "sess,data", "bili_jct": "csrf-token"}) == {
+        "SESSDATA": "sess%2Cdata",
+        "bili_jct": "csrf-token",
+    }
 
 
 class _StatusResponse:
@@ -113,7 +112,7 @@ class _StatusSession:
 
 
 @as_sync
-async def test_fetcher_preserves_httpx_query_parameter_encoding():
+async def test_fetcher_preserves_query_parameter_encoding():
     class QuerySession(_StatusSession):
         params: list[tuple[str, str]] | None = None
 

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -32,7 +32,7 @@ async def test_create_client_keeps_download_tls_verification_disabled_and_closes
 ):
     captured: dict[str, Any] = {}
 
-    class FakeNativeSession:
+    class FakeYuttoSession:
         is_closed = False
 
         def __init__(self, **kwargs: Any):
@@ -41,7 +41,7 @@ async def test_create_client_keeps_download_tls_verification_disabled_and_closes
         def close(self) -> None:
             self.is_closed = True
 
-    monkeypatch.setattr(fetcher_module, "NativeSession", FakeNativeSession)
+    monkeypatch.setattr(fetcher_module, "YuttoSession", FakeYuttoSession)
 
     async with create_client() as session:
         assert not session.is_closed
@@ -57,14 +57,14 @@ async def test_create_client_keeps_download_tls_verification_disabled_and_closes
 async def test_create_client_accepts_read_only_mappings_and_none(monkeypatch: pytest.MonkeyPatch):
     calls: list[dict[str, Any]] = []
 
-    class FakeNativeSession:
+    class FakeYuttoSession:
         def __init__(self, **kwargs: Any):
             calls.append(kwargs)
 
         def close(self) -> None:
             return None
 
-    monkeypatch.setattr(fetcher_module, "NativeSession", FakeNativeSession)
+    monkeypatch.setattr(fetcher_module, "YuttoSession", FakeYuttoSession)
 
     async with create_client(
         headers=MappingProxyType({"X-Test": "value"}),

--- a/uv.lock
+++ b/uv.lock
@@ -28,31 +28,8 @@ wheels = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
-]
-
-[[package]]
 name = "biliass"
 source = { editable = "packages/biliass" }
-
-[[package]]
-name = "certifi"
-version = "2025.11.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
-]
 
 [[package]]
 name = "colorama"
@@ -70,91 +47,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/47/abde6e5c4456f7074ddd2e0dd8bbf111d6de40ff5bb5761a5f6b20ad474b/dict2xml-1.7.8.tar.gz", hash = "sha256:6638da9ad32b0f8be8336d16e0f36a9c3821145e34ed3ef4889822a9b980fb28", size = 15644, upload-time = "2026-01-14T22:28:07.767Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/59/99390417ab1c8c118f6dad436aa9e85509b66ce1a80e130c8b61cf3b15bc/dict2xml-1.7.8-py3-none-any.whl", hash = "sha256:0da9213d78496322a9befaa4f934652315973fbf5437f0c0f70f14fc6d16acc5", size = 9460, upload-time = "2026-01-14T22:28:06.542Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[package.optional-dependencies]
-http2 = [
-    { name = "h2" },
-]
-socks = [
-    { name = "socksio" },
-]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -449,24 +341,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "socksio"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
-]
-
-[[package]]
 name = "syrupy"
 version = "5.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -664,7 +538,6 @@ dependencies = [
     { name = "biliass" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "dict2xml" },
-    { name = "httpx", extra = ["http2", "socks"] },
     { name = "pydantic" },
     { name = "returns" },
     { name = "segno" },
@@ -690,7 +563,6 @@ requires-dist = [
     { name = "biliass", editable = "packages/biliass" },
     { name = "colorama", marker = "sys_platform == 'win32'", specifier = ">=0.4.6" },
     { name = "dict2xml", specifier = ">=1.7.8" },
-    { name = "httpx", extras = ["http2", "socks"], specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "returns", specifier = ">=0.26.0" },
     { name = "segno", specifier = ">=1.6.6" },


### PR DESCRIPTION
## 动机

Fetcher 主链迁移后，HTTPX 只剩登录/认证与 corpus 抓取脚本仍在使用。若直接删除依赖，这两条路径会在运行时失败，因此需要在同一收尾层完成行为兼容迁移。

#789 合入后，本 PR 作为三层迁移栈的最后一层直接基于 main。Corpus 脚本的独立仓库改动见 yutto-dev/biliass-corpus#2，本层将子模块指向该改动合入 main 后的 merge commit。

## 解决方案

- 将二维码生成、轮询、登录确认和认证状态检查改为异步 `YuttoSession`，并在 CLI 仅保留一个 `run_auth` 同步边界。
- 将公开 binding 从 `NativeSession` 统一命名为 `YuttoSession`，同步更新 PyO3 导出、Python re-export、stub、调用点和测试，不保留兼容别名。
- 登录过程复用同一 cookie jar，保留 TLS 校验、代理、10 秒登录请求超时、5 秒认证检查超时和 redirect query fallback。
- 在可信环境与 TLS 校验同时启用时，保留 `SSL_CERT_FILE` / `SSL_CERT_DIR` 自定义 CA 行为，并保持 FILE 优先级。
- 通过按域名优先级探测 cookie，保持同名 Bilibili cookie 的选择语义；同时要求轮询间隔有限且非负，避免绕过登录总超时。
- 删除同步 client 构造、HTTPX cookie 容器与 Python HTTPX 依赖，并清理 `uv.lock` 中只由 HTTPX 引入的依赖链。
- 更新依赖致谢和 corpus gitlink，补充登录、cookie、redirect、CLI 边界及 native mapping 回归测试。

验证：

- `just fmt`
- `just lint`
- `uv lock --check`
- 登录、Fetcher 与 YuttoSession 聚焦测试：34 passed
- Rust workspace：56 passed，Clippy 通过
- Rust 1.85 MSRV check 通过
- 运行时确认仅导出 `YuttoSession`，全仓 `NativeSession` 零引用
- 真实 Bilibili deflate 弹幕响应及原失败 e2e 用例通过
- 全仓及 corpus `httpx` / `create_sync_client` 零引用

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [x] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [x] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
