### PR TITLE
♻️ refactor: prepare progress events for concurrent downloads

### DIFF
--- a/src/yutto/api/user_info.py
+++ b/src/yutto/api/user_info.py
@@ -40,9 +40,11 @@ def parse_user_info(res_json: dict[str, Any]) -> UserInfo:
 async def get_user_info(scope: ExecutionScope) -> UserInfo:
     if scope.user_info_cache is not None:
         return scope.user_info_cache
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, USER_INFO_API))
-    scope.user_info_cache = parse_user_info(res_json)
-    return scope.user_info_cache
+    async with scope.user_info_lock:
+        if scope.user_info_cache is None:
+            res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, USER_INFO_API))
+            scope.user_info_cache = parse_user_info(res_json)
+        return scope.user_info_cache
 
 
 def user_info_matches(user_info: UserInfo, check_option: UserInfo) -> bool:
@@ -68,16 +70,18 @@ async def validate_user_info(scope: ExecutionScope, check_option: UserInfo) -> b
 async def get_wbi_img(scope: ExecutionScope) -> WbiImg:
     if scope.wbi_img_cache is not None:
         return cast("WbiImg", scope.wbi_img_cache)
-    res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, USER_INFO_API))
-    wbi_img: WbiImg = {
-        "img_key": _get_key_from_url(res_json["data"]["wbi_img"]["img_url"]),
-        "sub_key": _get_key_from_url(res_json["data"]["wbi_img"]["sub_url"]),
-    }
-    scope.wbi_img_cache = {
-        "img_key": wbi_img["img_key"],
-        "sub_key": wbi_img["sub_key"],
-    }
-    return wbi_img
+    async with scope.wbi_img_lock:
+        if scope.wbi_img_cache is None:
+            res_json = unwrap_fetch_result(await Fetcher.fetch_json(scope, USER_INFO_API))
+            wbi_img: WbiImg = {
+                "img_key": _get_key_from_url(res_json["data"]["wbi_img"]["img_url"]),
+                "sub_key": _get_key_from_url(res_json["data"]["wbi_img"]["sub_url"]),
+            }
+            scope.wbi_img_cache = {
+                "img_key": wbi_img["img_key"],
+                "sub_key": wbi_img["sub_key"],
+            }
+        return cast("WbiImg", scope.wbi_img_cache)
 
 
 def _get_key_from_url(url: str) -> str:

--- a/src/yutto/core/events.py
+++ b/src/yutto/core/events.py
@@ -47,6 +47,7 @@ class DownloadProgress:
     # CLI-local buffer telemetry; intentionally excluded from the v1 task event payload.
     buffered_bytes: int = 0
     is_congested: bool = False
+    item: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/yutto/core/execution.py
+++ b/src/yutto/core/execution.py
@@ -28,7 +28,9 @@ class ExecutionScope:
     fetch_limiter: asyncio.Semaphore
     download_workers: int
     user_info_cache: UserInfo | None
+    user_info_lock: asyncio.Lock
     wbi_img_cache: Mapping[str, str] | None
+    wbi_img_lock: asyncio.Lock
     touched_urls: set[str]
 
     def __init__(
@@ -46,7 +48,9 @@ class ExecutionScope:
         self.fetch_limiter = asyncio.Semaphore(fetch_workers)
         self.download_workers = download_workers
         self.user_info_cache = None
+        self.user_info_lock = asyncio.Lock()
         self.wbi_img_cache = None
+        self.wbi_img_lock = asyncio.Lock()
         self.touched_urls = set()
 
     @asynccontextmanager

--- a/src/yutto/core/task_service.py
+++ b/src/yutto/core/task_service.py
@@ -181,14 +181,24 @@ def _encode_runtime_event(event: DownloadEvent) -> tuple[str, dict[str, object]]
             if item is not None:
                 data["item"] = item
             return "stage", data
-        case DownloadProgress(current=current, total=total, speed_per_second=speed, phase=phase, unit=unit):
-            return "progress", {
+        case DownloadProgress(
+            current=current,
+            total=total,
+            speed_per_second=speed,
+            phase=phase,
+            unit=unit,
+            item=item,
+        ):
+            data: dict[str, object] = {
                 "phase": phase.value,
                 "current": current,
                 "total": total,
                 "speed_per_second": speed,
                 "unit": unit,
             }
+            if item is not None:
+                data["item"] = item
+            return "progress", data
         case DownloadItemSkipped(item=item, reason=reason):
             return "item_skipped", {"item": item, "reason": reason.value}
         case DownloadArtifactCreated(item=item, path=path):

--- a/src/yutto/downloader/progressbar.py
+++ b/src/yutto/downloader/progressbar.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 SMOOTHING_WINDOW_SIZE = 10
 
 
-async def show_progress(handles: Sequence[TransferHandle], total_size: int) -> None:
+async def show_progress(handles: Sequence[TransferHandle], total_size: int, *, item: str | None = None) -> None:
     t = time.time()
     transferred = sum(
         max(0, snapshot.received_bytes - snapshot.origin_bytes)
@@ -59,6 +59,7 @@ async def show_progress(handles: Sequence[TransferHandle], total_size: int) -> N
                 speed_per_second=speed,
                 buffered_bytes=buffered_bytes,
                 is_congested=any(snapshot.window_saturated for snapshot in snapshots),
+                item=item,
             )
         )
         if all(handle.done() for handle in handles):

--- a/src/yutto/downloader/transfer.py
+++ b/src/yutto/downloader/transfer.py
@@ -95,7 +95,7 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
                 wait_tasks.append(wait_task)
                 batch_tasks.append(wait_task)
 
-            progress_task = asyncio.create_task(show_progress(handles, total_size))
+            progress_task = asyncio.create_task(show_progress(handles, total_size, item=plan.item))
             await _wait_for_native_transfers(batch_tasks)
             await progress_task
             progress_task = None

--- a/tests/test_api/test_user_info.py
+++ b/tests/test_api/test_user_info.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 
 import pytest
@@ -79,6 +80,29 @@ async def test_validate_user_info_reuses_execution_scope_session_and_cache(monke
 
 @pytest.mark.processor
 @as_sync
+async def test_concurrent_user_info_reads_share_one_fetch(monkeypatch: pytest.MonkeyPatch):
+    calls = 0
+
+    async def fake_fetch_json(scope, url):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return Success({"data": {"vipStatus": 1, "isLogin": True}})
+
+    monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
+    scope = ExecutionScope(cast("Any", object()))
+
+    results = await asyncio.gather(get_user_info(scope), get_user_info(scope))
+
+    assert results == [
+        {"vip_status": True, "is_login": True},
+        {"vip_status": True, "is_login": True},
+    ]
+    assert calls == 1
+
+
+@pytest.mark.processor
+@as_sync
 async def test_wbi_cache_is_scoped_to_execution_scope(monkeypatch: pytest.MonkeyPatch):
     responses = iter(
         [
@@ -124,3 +148,35 @@ async def test_wbi_cache_is_scoped_to_execution_scope(monkeypatch: pytest.Monkey
         "sub_key": "second-sub",
     }
     assert calls == 2
+
+
+@pytest.mark.processor
+@as_sync
+async def test_concurrent_wbi_reads_share_one_fetch(monkeypatch: pytest.MonkeyPatch):
+    calls = 0
+
+    async def fake_fetch_json(scope, url):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return Success(
+            {
+                "data": {
+                    "wbi_img": {
+                        "img_url": "https://example.com/img.png",
+                        "sub_url": "https://example.com/sub.png",
+                    }
+                }
+            }
+        )
+
+    monkeypatch.setattr(Fetcher, "fetch_json", fake_fetch_json)
+    scope = ExecutionScope(cast("Any", object()))
+
+    results = await asyncio.gather(get_wbi_img(scope), get_wbi_img(scope))
+
+    assert results == [
+        {"img_key": "img", "sub_key": "sub"},
+        {"img_key": "img", "sub_key": "sub"},
+    ]
+    assert calls == 1

--- a/tests/test_core/test_task_service.py
+++ b/tests/test_core/test_task_service.py
@@ -111,7 +111,7 @@ async def test_download_events_are_noop_outside_application_context():
             ("stage", {"name": "preparing", "item": "video"}),
         ),
         (
-            DownloadProgress(current=1, total=2, speed_per_second=3.0, buffered_bytes=1),
+            DownloadProgress(current=1, total=2, speed_per_second=3.0, buffered_bytes=1, item="video"),
             (
                 "progress",
                 {
@@ -120,6 +120,7 @@ async def test_download_events_are_noop_outside_application_context():
                     "total": 2,
                     "speed_per_second": 3.0,
                     "unit": "bytes",
+                    "item": "video",
                 },
             ),
         ),

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -80,7 +80,7 @@ async def test_native_resume_progress_does_not_count_existing_bytes_as_speed():
 
     sink = RecordingEventSink()
     with bind_download_event_sink(sink):
-        await show_progress([Handle()], page_size * 2)
+        await show_progress([Handle()], page_size * 2, item="video")
 
     assert sink.events == [
         DownloadProgress(
@@ -88,6 +88,7 @@ async def test_native_resume_progress_does_not_count_existing_bytes_as_speed():
             total=page_size * 2,
             speed_per_second=0,
             buffered_bytes=0,
+            item="video",
         )
     ]
 


### PR DESCRIPTION
## 动机

serve 与 CLI 要并发处理多个视频时，需要让同一事件流中的进度能够归属到具体条目，同时避免同一请求内的用户信息与 WBI 信息缓存被并发击穿。

本 PR 是多视频并发 stack 的基础层；后续为 #798、#799 和 #800。

## 解决方案

- 为 `DownloadProgress` 增加可选的条目标识，并从下载计划一路传递到 CLI 与 server 事件。
- 为请求级用户信息和 WBI 信息缓存增加双重检查的异步锁，保证并发首次读取只请求一次。
- 补充进度事件归属和并发缓存读取测试；字段保持可选以兼容现有消费者。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
