### PR TITLE
✨ feat: support concurrent server downloads

### DIFF
--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -89,12 +89,12 @@ yutto serve \
 
 除 runtime 自己产生的 `state` 外，下载事件的 `kind` 包括：
 
-| `kind`             | `data`                                              | 含义                                       |
-| ------------------ | --------------------------------------------------- | ------------------------------------------ |
-| `stage`            | `{ name, item? }`                                   | 进入解析、资源写入、下载或后处理阶段       |
-| `progress`         | `{ phase, current, total, speed_per_second, unit }` | 音视频字节下载进度                         |
-| `item_skipped`     | `{ item, reason }`                                  | 条目因媒体已存在或没有请求到可用媒体流跳过 |
-| `artifact_created` | `{ item, path }`                                    | 本次任务生成了最终媒体文件                 |
+| `kind`             | `data`                                                     | 含义                                       |
+| ------------------ | ---------------------------------------------------------- | ------------------------------------------ |
+| `stage`            | `{ name, item? }`                                          | 进入解析、资源写入、下载或后处理阶段       |
+| `progress`         | `{ phase, current, total, speed_per_second, unit, item? }` | 音视频字节下载进度                         |
+| `item_skipped`     | `{ item, reason }`                                         | 条目因媒体已存在或没有请求到可用媒体流跳过 |
+| `artifact_created` | `{ item, path }`                                           | 本次任务生成了最终媒体文件                 |
 
 `stage.name` 目前可能为 `resolving`、`preparing`、`writing_resources`、`downloading` 或 `postprocessing`。`artifact_created` 只在本次新生成最终媒体文件时发送；其他 sidecar 产物通过完成结果获取。
 
@@ -134,7 +134,8 @@ yutto serve \
 
 ## 本地资源边界
 
-- 同一 server 进程默认一次只运行一个下载任务，其余任务排队。
+- 同一 server 进程默认一次只运行一个下载任务；可用 `-j/--jobs` 设置同时运行的下载任务数。
+- 指向相同最终文件或临时文件命名空间的任务即使并发提交也会串行执行，避免覆盖彼此的下载产物。
 - 解析任务运行在独立的单 worker runtime 中，一次只运行一个解析，但不会排在下载任务之后。
 - 请求中的 `output.directory` 和 `output.temporary_directory` 必须是相对路径，并分别限制在 `--download-root` 与 `--tmp-root` 内。
 - `output.subpath_template` 不能使用绝对路径或 `..` 逃逸根目录。

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -133,6 +133,13 @@ def add_serve_arguments(parser: argparse.ArgumentParser, settings: YuttoSettings
         default=256,
         help="保留的任务及排队任务总数上限",
     )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=1,
+        help="同时执行的下载任务数，默认为 1",
+    )
 
 
 def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSettings):

--- a/src/yutto/core/task_service.py
+++ b/src/yutto/core/task_service.py
@@ -34,7 +34,7 @@ class ResolveApplication(Protocol):
 
 
 class DownloadTaskService:
-    """Run frontend-independent download requests through a single-worker runtime."""
+    """Run frontend-independent download requests through a bounded worker runtime."""
 
     def __init__(
         self,
@@ -43,6 +43,7 @@ class DownloadTaskService:
         *,
         replay_limit: int = 100,
         task_limit: int = 256,
+        worker_count: int = 1,
         task_id_factory: Callable[[], str] | None = None,
         seq_allocator: Callable[[], int] | None = None,
         capacity_pool: TaskCapacityPool | None = None,
@@ -51,7 +52,7 @@ class DownloadTaskService:
         self._application_factory = application_factory
         self.runtime = TaskRuntime[DownloadRequest, DownloadResult](
             self._run,
-            worker_count=1,
+            worker_count=worker_count,
             replay_limit=replay_limit,
             task_limit=task_limit,
             task_id_factory=task_id_factory,

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -12,6 +12,7 @@ from yutto.core.events import DownloadItemListed, DownloadStage, DownloadStageCh
 from yutto.core.operation import ReportLevel, emit_download_event, emit_download_report
 from yutto.core.result import DownloadResult, ItemResult, ResolvedItem, ResolveFailure, ResolveResult
 from yutto.downloader.downloader import process_download
+from yutto.downloader.path_leases import DownloadPathLeasePool
 from yutto.exceptions import NotLoginError, ResolveFailedError, WrongArgumentError, WrongUrlError
 from yutto.extractor import (
     BangumiBatchExtractor,
@@ -98,8 +99,9 @@ class _ResolvedItemsOutcome:
 class DownloadManager:
     """Execute requests sequentially with one explicit scope per request."""
 
-    def __init__(self):
+    def __init__(self, *, path_leases: DownloadPathLeasePool | None = None):
         self.unique_path = create_unique_path_resolver()
+        self.path_leases = path_leases or DownloadPathLeasePool()
 
     async def execute(
         self,
@@ -249,6 +251,7 @@ class DownloadManager:
                 scope,
                 episode_data,
                 request,
+                path_leases=self.path_leases,
             )
             item_results.append(previous_result)
             emit_download_report("", ReportLevel.PLAIN)

--- a/src/yutto/downloader/downloader.py
+++ b/src/yutto/downloader/downloader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 from yutto.core.events import DownloadStage, DownloadStageChanged
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
     from yutto.core.request import DownloadRequest
     from yutto.core.result import ItemResult
+    from yutto.downloader.path_leases import DownloadPathLeasePool
     from yutto.types import EpisodeData
 
 
@@ -18,10 +20,23 @@ async def process_download(
     scope: ExecutionScope,
     episode_data: EpisodeData,
     request: DownloadRequest,
+    *,
+    path_leases: DownloadPathLeasePool | None = None,
 ) -> ItemResult:
     """Plan and execute one episode while keeping planning side-effect free."""
     item = episode_data["info"]["path"].name
     emit_download_report(f"开始处理视频 {item}")
     emit_download_event(DownloadStageChanged(name=DownloadStage.PREPARING, item=item))
     plan = DownloadPlanner().plan(episode_data, request)
-    return await DownloadExecutor().execute(scope, episode_data, plan)
+    lease = (
+        path_leases.lease(
+            (
+                plan.paths.output.with_suffix(""),
+                plan.paths.temporary_dir / plan.paths.output.stem,
+            )
+        )
+        if path_leases is not None
+        else nullcontext()
+    )
+    async with lease:
+        return await DownloadExecutor().execute(scope, episode_data, plan)

--- a/src/yutto/downloader/path_leases.py
+++ b/src/yutto/downloader/path_leases.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterable
+    from pathlib import Path
+
+
+class DownloadPathLeasePool:
+    """Serialize downloads whose final or temporary artifact namespaces overlap."""
+
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self._leased: set[Path] = set()
+
+    @asynccontextmanager
+    async def lease(self, paths: Iterable[Path]) -> AsyncIterator[None]:
+        keys = frozenset(path.resolve() for path in paths)
+        if not keys:
+            raise ValueError("at least one path lease key is required")
+
+        async with self._condition:
+            await self._condition.wait_for(lambda: self._leased.isdisjoint(keys))
+            self._leased.update(keys)
+        try:
+            yield
+        finally:
+            async with self._condition:
+                self._leased.difference_update(keys)
+                self._condition.notify_all()

--- a/src/yutto/server/command.py
+++ b/src/yutto/server/command.py
@@ -11,6 +11,7 @@ from yutto.cli.request_adapter import download_request_parser_from_settings
 from yutto.core.application import YuttoApplication
 from yutto.core.task_service import DownloadTaskService, ResolveTaskService
 from yutto.download_manager import DownloadManager
+from yutto.downloader.path_leases import DownloadPathLeasePool
 from yutto.runtime import TaskCapacityPool, monotonic_seq_allocator
 from yutto.server.service import ServerPolicy, ServerPolicyOptions
 from yutto.server.websocket import WebSocketServerOptions, YuttoWebSocketServer
@@ -113,16 +114,25 @@ def build_server(args: argparse.Namespace, token: str, *, ffmpeg: FFmpeg | None 
     # 维持 v1 契约：`seq` 全局递增可去重、`--task-limit` 是两类任务的总量
     event_seq_allocator = monotonic_seq_allocator()
     task_capacity = TaskCapacityPool(args.task_limit)
+    path_leases = DownloadPathLeasePool()
+
+    def build_download_application(
+        factory: ExecutionScopeFactory,
+        event_sink: DownloadEventSink,
+    ) -> YuttoApplication:
+        return _build_download_application(factory, event_sink, path_leases=path_leases)
+
     task_service = DownloadTaskService(
         scope_factory,
-        _build_download_application,
+        build_download_application,
         task_limit=args.task_limit,
+        worker_count=args.jobs,
         seq_allocator=event_seq_allocator,
         capacity_pool=task_capacity,
     )
     resolve_service = ResolveTaskService(
         scope_factory,
-        _build_download_application,
+        build_download_application,
         task_limit=args.task_limit,
         seq_allocator=event_seq_allocator,
         capacity_pool=task_capacity,
@@ -144,8 +154,10 @@ def build_server(args: argparse.Namespace, token: str, *, ffmpeg: FFmpeg | None 
 def _build_download_application(
     scope_factory: ExecutionScopeFactory,
     event_sink: DownloadEventSink,
+    *,
+    path_leases: DownloadPathLeasePool | None = None,
 ) -> YuttoApplication:
-    manager = DownloadManager()
+    manager = DownloadManager(path_leases=path_leases)
     return YuttoApplication(
         scope_factory,
         workflow=manager,

--- a/tests/test_core/test_task_service.py
+++ b/tests/test_core/test_task_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING, get_type_hints
 
@@ -91,6 +92,47 @@ async def test_download_task_service_runs_requests_in_order_and_bridges_events()
         assert [(event.kind, event.data) for event in first_replay.events if event.kind == "stage"] == [
             ("stage", {"name": "resolving"})
         ]
+
+
+@as_sync
+async def test_download_task_service_runs_up_to_worker_count_concurrently():
+    scope_factory = RequestExecutionScopeFactory()
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    class ConcurrentApplication:
+        async def download(self, request: DownloadRequest) -> DownloadResult:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            if active == 2:
+                both_started.set()
+            try:
+                await release.wait()
+                return DownloadResult()
+            finally:
+                active -= 1
+
+    service = DownloadTaskService(
+        scope_factory,
+        application_factory=lambda factory, event_sink: ConcurrentApplication(),
+        worker_count=2,
+    )
+    async with service:
+        first = await service.submit(DownloadRequest.model_validate({"source": {"url": "BV1first"}}))
+        second = await service.submit(DownloadRequest.model_validate({"source": {"url": "BV1second"}}))
+        await asyncio.wait_for(both_started.wait(), timeout=1)
+        release.set()
+        first_done, second_done = await asyncio.gather(
+            service.runtime.wait(first.task_id),
+            service.runtime.wait(second.task_id),
+        )
+
+    assert first_done is not None and first_done.state is TaskState.COMPLETED
+    assert second_done is not None and second_done.state is TaskState.COMPLETED
+    assert max_active == 2
 
 
 @as_sync

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -164,6 +164,8 @@ async def test_process_request_preserves_extractor_mapping_and_passes_download_r
         scope: ExecutionScope,
         episode_data: EpisodeData,
         request: DownloadRequest,
+        *,
+        path_leases: object,
     ) -> ItemResult:
         nonlocal captured_download_request
         assert episode_data is episode
@@ -242,6 +244,8 @@ async def test_process_request_does_not_create_unreached_episode_coroutines(monk
         scope: ExecutionScope,
         episode_data: EpisodeData,
         request: DownloadRequest,
+        *,
+        path_leases: object,
     ) -> ItemResult:
         return ItemResult(state=ItemState.DONE, output_path=episode_data["info"]["path"])
 

--- a/tests/test_processor/test_path_leases.py
+++ b/tests/test_processor/test_path_leases.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from yutto.downloader.path_leases import DownloadPathLeasePool
+from yutto.utils.functional import as_sync
+
+pytestmark = pytest.mark.processor
+
+
+@as_sync
+async def test_path_leases_allow_disjoint_jobs_and_serialize_conflicts():
+    leases = DownloadPathLeasePool()
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    order: list[str] = []
+
+    async def first() -> None:
+        async with leases.lease([Path("same")]):
+            order.append("first-enter")
+            first_entered.set()
+            await release_first.wait()
+            order.append("first-exit")
+
+    async def conflicting() -> None:
+        await first_entered.wait()
+        async with leases.lease([Path("same")]):
+            order.append("conflicting-enter")
+
+    async def disjoint() -> None:
+        await first_entered.wait()
+        async with leases.lease([Path("other")]):
+            order.append("disjoint-enter")
+            release_first.set()
+
+    await asyncio.gather(first(), conflicting(), disjoint())
+
+    assert order == ["first-enter", "disjoint-enter", "first-exit", "conflicting-enter"]

--- a/tests/test_server/test_command.py
+++ b/tests/test_server/test_command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -10,7 +11,10 @@ import yutto.server.command as server_command_module
 from yutto.cli.cli import cli, handle_default_subcommand
 from yutto.core.operation import ReportLevel, emit_download_report
 from yutto.exceptions import ErrorCode
-from yutto.server.command import resolve_server_token
+from yutto.server.command import build_server, resolve_server_token
+
+if TYPE_CHECKING:
+    from yutto.core.task_service import DownloadTaskService
 
 pytestmark = pytest.mark.processor
 
@@ -21,6 +25,19 @@ def test_serve_is_an_explicit_subcommand():
     assert args.command == "serve"
     assert args.port == 12345
     assert args.allow_origin == ["https://ui.example"]
+    assert args.jobs == 1
+
+
+def test_serve_jobs_configures_download_runtime_workers():
+    args = cli().parse_args(["serve", "--jobs", "3"])
+
+    server = build_server(
+        args,
+        "token",
+        ffmpeg=cast("Any", SimpleNamespace(video_encodecs=(), audio_encodecs=())),
+    )
+
+    assert cast("DownloadTaskService", server._task_service).runtime.worker_count == 3
 
 
 def test_serve_io_error_is_rendered_without_traceback(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## 动机

server 的任务服务此前只有一个 worker；即使多个客户端分别提交下载，也只能串行执行。提高 worker 数后还需要防止不同任务写入相同最终路径或临时路径时互相破坏。

本 PR 依赖 #797，是多视频并发 stack 的 server 层；后续为 #799 和 #800。

## 解决方案

- 为 `yutto serve` 增加 `-j/--jobs`，并让任务服务按配置启动多个 worker。
- 引入共享的下载路径租约池：互不相交的路径可以并发，冲突的最终/临时 basename 会自动串行。
- 保持默认值为 `1`，兼容现有部署与行为。
- 更新 server 文档，并补充 worker、参数接线和路径冲突测试。

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
