### PR TITLE
♻️ refactor: render multiple CLI progress rows

### DIFF
--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -15,7 +15,7 @@ from yutto.core.operation import ReportColor, ReportLevel
 from yutto.core.result import ItemSkipReason
 from yutto.utils.console.attributes import get_terminal_size
 from yutto.utils.console.colorful import RGBColor, colored_string
-from yutto.utils.console.formatter import size_format
+from yutto.utils.console.formatter import get_char_width, get_string_width, size_format
 from yutto.utils.console.logger import Badge, Logger
 
 if TYPE_CHECKING:
@@ -61,7 +61,7 @@ def _render_bar(
 class CliApplicationEventRenderer:
     def __init__(self, *, progress_enabled: bool = True):
         self.progress_enabled = progress_enabled
-        self._progress_active = False
+        self._progress_items: set[str] = set()
         self._spinner_task: asyncio.Task[None] | None = None
 
     async def __aenter__(self) -> Self:
@@ -73,11 +73,11 @@ class CliApplicationEventRenderer:
         if self._spinner_task is not None:
             self._spinner_task.cancel()
             await asyncio.gather(self._spinner_task, return_exceptions=True)
-        Logger.status.clear()
+        Logger.status.reset()
 
     async def _run_spinner(self) -> None:
         while True:
-            if not self._progress_active:
+            if not self._progress_items:
                 Logger.status.next_tick()
             await asyncio.sleep(1)
 
@@ -116,13 +116,14 @@ class CliApplicationEventRenderer:
                 Logger.info(f"列表里共检测到 {total} 项")
             case DownloadRequestQueued(url=url, index=index, total=total):
                 Logger.custom(f"列表项 {url}", Badge(f"[{index}/{total}]", fore="black", back="cyan"))
-            case DownloadStageChanged():
-                self._progress_active = False
+            case DownloadStageChanged(item=item):
+                self._finish_progress(item)
             case DownloadProgress() as progress:
                 if self.progress_enabled:
-                    self._progress_active = True
+                    self._progress_items.add(_progress_key(progress.item))
                     self._render_progress(progress)
             case DownloadItemSkipped(item=item, reason=ItemSkipReason.ALREADY_EXISTS):
+                self._finish_progress(item)
                 Logger.info(f"文件 {item} 已存在")
             case _:
                 pass
@@ -133,7 +134,9 @@ class CliApplicationEventRenderer:
         buffered_color: Color = "red" if progress.is_congested else "yellow"
         buffered_bytes = min(max(progress.buffered_bytes, 0), progress.current)
         committed_bytes = progress.current - buffered_bytes
-        bar_width = min(get_terminal_size()[0] - 40, 50)
+        label = _truncate_label(progress.item, 20)
+        label_prefix = f"{label} " if label else ""
+        bar_width = min(get_terminal_size()[0] - 40 - get_string_width(label_prefix), 50)
         bar = (
             _render_bar(
                 committed_bytes,
@@ -149,15 +152,53 @@ class CliApplicationEventRenderer:
         speed_color: Color = "green" if is_fast else "cyan"
         speed_style: list[Style] | None = ["bold"] if is_fast else None
         speed_suffix = "/⚡" if is_fast else "/s"
-        Logger.status.set(
-            "{}{:>10}/{:>10} {:>12}  ".format(
-                bar + " " if bar else "",
-                size_format(progress.current),
-                size_format(progress.total),
-                colored_string(
-                    size_format(progress.speed_per_second) + speed_suffix,
-                    fore=speed_color,
-                    style=speed_style,
-                ),
-            )
+        rendered = "{}{}{:>10}/{:>10} {:>12}  ".format(
+            label_prefix,
+            bar + " " if bar else "",
+            size_format(progress.current),
+            size_format(progress.total),
+            colored_string(
+                size_format(progress.speed_per_second) + speed_suffix,
+                fore=speed_color,
+                style=speed_style,
+            ),
         )
+        if progress.item is None:
+            Logger.status.set(rendered)
+        else:
+            Logger.status.set_line(_progress_key(progress.item), rendered)
+
+    def _finish_progress(self, item: str | None) -> None:
+        if item is None:
+            return
+        key = _progress_key(item)
+        if key not in self._progress_items:
+            return
+        self._progress_items.remove(key)
+        if self.progress_enabled:
+            Logger.status.remove_line(key)
+            if not self._progress_items:
+                Logger.status.next_tick()
+
+
+def _progress_key(item: str | None) -> str:
+    return item or "__download__"
+
+
+def _truncate_label(item: str | None, max_width: int) -> str:
+    if item is None or max_width < 1:
+        return ""
+    if get_string_width(item) <= max_width:
+        return item
+
+    suffix = "…"
+    available = max_width - get_string_width(suffix)
+    current = 0
+    characters: list[str] = []
+    for character in item:
+        width = get_char_width(character)
+        if current + width > available:
+            break
+        characters.append(character)
+        current += width
+    return "".join(characters) + suffix

--- a/src/yutto/utils/console/logger.py
+++ b/src/yutto/utils/console/logger.py
@@ -106,6 +106,7 @@ class Logger:
     def print(cls, string: Any, *print_args: Any, **print_kwargs: Any):
         cls.status.clear()
         print(string, *print_args, **print_kwargs)
+        cls.status.next_tick()
 
     @classmethod
     def json(cls, obj: list[Any] | dict[str, Any], *print_args: Any, **print_kwargs: Any):

--- a/src/yutto/utils/console/status_bar.py
+++ b/src/yutto/utils/console/status_bar.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from yutto.utils.console.formatter import get_string_width
-
 
 class StatusBar:
+    _DEFAULT_KEY = "__status__"
     _enabled = False
     tip = ""
     _snippers = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
     _count = 0
-    _last_line_width = 0
+    _lines: dict[str, str] = {}
+    _rendered_line_count = 0
 
     @classmethod
     def enable(cls):
@@ -16,6 +16,7 @@ class StatusBar:
 
     @classmethod
     def disable(cls):
+        cls.reset()
         cls._enabled = False
 
     @classmethod
@@ -24,17 +25,50 @@ class StatusBar:
 
     @classmethod
     def clear(cls):
-        if not cls._enabled:
+        if not cls._enabled or cls._rendered_line_count == 0:
             return
-        print("\r" + cls._last_line_width * " " + "\r", end="")
+        for index in range(cls._rendered_line_count):
+            print("\r\x1b[2K", end="")
+            if index < cls._rendered_line_count - 1:
+                print("\x1b[1A", end="")
+        cls._rendered_line_count = 0
 
     @classmethod
-    def set(cls, text: str):
+    def redraw(cls):
         if not cls._enabled:
             return
         cls.clear()
-        print(text, end="\r")
-        cls._last_line_width = get_string_width(text)
+        lines = tuple(cls._lines.values())
+        for index, line in enumerate(lines):
+            print(line, end="\n" if index < len(lines) - 1 else "\r")
+        cls._rendered_line_count = len(lines)
+
+    @classmethod
+    def set(cls, text: str):
+        cls.set_line(cls._DEFAULT_KEY, text)
+
+    @classmethod
+    def set_line(cls, key: str, text: str):
+        if not key:
+            raise ValueError("status line key must not be empty")
+        if not cls._enabled:
+            return
+        if key != cls._DEFAULT_KEY:
+            cls._lines.pop(cls._DEFAULT_KEY, None)
+        cls._lines[key] = text
+        cls.redraw()
+
+    @classmethod
+    def remove_line(cls, key: str):
+        if not cls._enabled:
+            return
+        cls._lines.pop(key, None)
+        cls.redraw()
+
+    @classmethod
+    def reset(cls):
+        cls.clear()
+        cls._lines.clear()
 
     @classmethod
     def set_tip(cls, tip: str):
@@ -42,6 +76,9 @@ class StatusBar:
 
     @classmethod
     def next_tick(cls):
+        if any(key != cls._DEFAULT_KEY for key in cls._lines):
+            cls.redraw()
+            return
         cls.set(cls._snippers[cls._count] + " " + cls.tip)
         cls._count += 1
         cls._count %= len(cls._snippers)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ from yutto.cli.cli import (
     handle_default_subcommand,
 )
 from yutto.cli.settings import YuttoSettings
-from yutto.core.events import DownloadProgress
+from yutto.core.events import DownloadProgress, DownloadStage, DownloadStageChanged
 from yutto.core.execution import RequestExecutionScopeFactory
 from yutto.core.operation import (
     ReportColor,
@@ -274,6 +274,30 @@ def test_progress_renderer_turns_only_buffered_segment_red(monkeypatch: pytest.M
     ]
 
 
+def test_progress_renderer_tracks_multiple_items_and_removes_completed_rows(monkeypatch: pytest.MonkeyPatch):
+    rendered: list[tuple[str, str]] = []
+    removed: list[str] = []
+    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (100, 24))
+    monkeypatch.setattr(renderer_module.Logger.status, "set_line", lambda key, text: rendered.append((key, text)))
+    monkeypatch.setattr(renderer_module.Logger.status, "remove_line", removed.append)
+    monkeypatch.setattr(renderer_module.Logger.status, "next_tick", lambda: None)
+
+    renderer = renderer_module.CliApplicationEventRenderer()
+    renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item="视频一"))
+    renderer.emit(DownloadProgress(current=2, total=4, speed_per_second=5, item="视频二"))
+    renderer.emit(DownloadStageChanged(name=DownloadStage.POSTPROCESSING, item="视频一"))
+
+    assert [key for key, _ in rendered] == ["视频一", "视频二"]
+    assert "视频一" in rendered[0][1]
+    assert "视频二" in rendered[1][1]
+    assert removed == ["视频一"]
+
+
+def test_progress_labels_are_truncated_by_terminal_width():
+    assert renderer_module._truncate_label("short", 10) == "short"
+    assert renderer_module._truncate_label("一二三四五六", 7) == "一二三…"
+
+
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):
     output: list[tuple[str, object]] = []
 
@@ -289,7 +313,7 @@ def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch
         "custom",
         lambda message, badge: output.append(("badge", (message, badge.text))),
     )
-    monkeypatch.setattr(renderer_module.Logger.status, "clear", lambda: output.append(("cleared", True)))
+    monkeypatch.setattr(renderer_module.Logger.status, "reset", lambda: output.append(("cleared", True)))
     monkeypatch.setattr(renderer_module, "colored_string", lambda message, *, fore, **_: f"{fore}:{message}")
 
     emit_download_report("unbound")

--- a/tests/test_utils/test_status_bar.py
+++ b/tests/test_utils/test_status_bar.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+import yutto.utils.console.status_bar as status_bar_module
+from yutto.utils.console.status_bar import StatusBar
+
+
+@pytest.fixture(autouse=True)
+def reset_status_bar():
+    StatusBar._enabled = False
+    StatusBar._lines.clear()
+    StatusBar._rendered_line_count = 0
+    yield
+    StatusBar._enabled = False
+    StatusBar._lines.clear()
+    StatusBar._rendered_line_count = 0
+
+
+def test_status_bar_redraws_multiple_named_lines(monkeypatch: pytest.MonkeyPatch):
+    output: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        status_bar_module,
+        "print",
+        lambda text, *, end: output.append((text, end)),
+        raising=False,
+    )
+    StatusBar.enable()
+
+    StatusBar.set_line("first", "line one")
+    StatusBar.set_line("second", "line two")
+    StatusBar.redraw()
+
+    assert StatusBar._lines == {"first": "line one", "second": "line two"}
+    assert StatusBar._rendered_line_count == 2
+    assert ("line one", "\n") in output
+    assert ("line two", "\r") in output
+    assert ("\x1b[1A", "") in output
+
+
+def test_spinner_does_not_replace_active_progress_line(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(status_bar_module, "print", lambda *args, **kwargs: None, raising=False)
+    StatusBar.enable()
+    StatusBar.set_line("download", "progress")
+
+    StatusBar.next_tick()
+
+    assert StatusBar._lines == {"download": "progress"}


### PR DESCRIPTION
## 动机

CLI 原有状态栏只维护一行，无法同时展示多个视频的下载进度。现有进度条有自定义分段、配色和速度显示，不适合为了多行渲染整体替换为 Rich。

本 PR 依赖 #798，是多视频并发 stack 的终端渲染层；后续为 #800。

## 解决方案

- 扩展现有 `StatusBar`，支持按 key 管理多行，并使用 ANSI 清除/重绘底部区域。
- 保留 `_render_bar` 的自定义分段与颜色逻辑，不新增 Rich 或其他运行时依赖。
- CLI renderer 按进度事件的条目标识维护独立行，阶段结束时及时移除。
- 日志输出前清除状态区、输出后恢复多行进度，非 TTY 行为保持不变。
- 补充多行状态栏、日志重绘、标签截断和进度行生命周期测试。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
