### PR TITLE
✨ feat: support concurrent CLI downloads

### DIFF
--- a/docs/guide/cli/basic.md
+++ b/docs/guide/cli/basic.md
@@ -12,7 +12,15 @@ aside: true
 - 配置项 `basic.num_workers`
 - 默认值 `8`
 
-我使用协程来实现并发下载，本参数限制的是最大的并发 Worker 数量。
+本参数限制的是单个音视频的最大并发数。
+
+## 同时下载的音视频数量 <Badge text="Experimental" type="warning" />
+
+- 参数 `-j` 或 `--jobs`
+- 配置项 `basic.jobs`
+- 默认值 `1`
+
+本参数限制同时处理的音视频数量，适用于 URL 列表和批量来源中的多个分集。`--jobs` 控制音视频级并发，`--num-workers` 控制每个视频内部的分块下载 worker；例如 `-j 3 -n 8` 最多会同时处理 3 个视频，每个视频最多使用 8 个下载 worker。
 
 ## 批量解析最大并行请求数量
 

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -36,6 +36,12 @@
           "title": "Num Workers",
           "type": "integer"
         },
+        "jobs": {
+          "default": 1,
+          "exclusiveMinimum": 0,
+          "title": "Jobs",
+          "type": "integer"
+        },
         "fetch_workers": {
           "default": 8,
           "exclusiveMinimum": 0,
@@ -416,6 +422,7 @@
       "$ref": "#/$defs/YuttoBasicSettings",
       "default": {
         "num_workers": 8,
+        "jobs": 1,
         "fetch_workers": 8,
         "video_quality": 127,
         "audio_quality": 30251,

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -78,7 +78,7 @@ def main():
                         resolve_credentials,
                         on_open=_CliAuthAnnouncer(),
                     )
-                    run_download(scope_factory, requests, renderer)
+                    run_download(scope_factory, requests, renderer, jobs=args.jobs)
                 except YuttoBaseException as e:
                     Logger.error(e.message)
                     sys.exit(e.code.value)
@@ -109,11 +109,13 @@ async def run_download(
     scope_factory: ExecutionScopeFactory,
     requests: list[DownloadRequest],
     renderer: CliApplicationEventRenderer,
+    *,
+    jobs: int = 1,
 ):
     async with renderer:
         application = YuttoApplication(
             scope_factory,
-            workflow=DownloadManager(),
+            workflow=DownloadManager(jobs=jobs),
             event_sink=renderer,
         )
         with bind_download_report_sink(renderer.report):

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -137,7 +137,7 @@ def add_serve_arguments(parser: argparse.ArgumentParser, settings: YuttoSettings
         "-j",
         "--jobs",
         type=int,
-        default=1,
+        default=settings.basic.jobs,
         help="同时执行的下载任务数，默认为 1",
     )
 
@@ -147,6 +147,13 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
     group_basic = parser.add_argument_group("basic", "基础参数")
     group_basic.add_argument(
         "-n", "--num-workers", type=int, default=settings.basic.num_workers, help="同时用于下载的最大 Worker 数"
+    )
+    group_basic.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=settings.basic.jobs,
+        help="同时下载的视频数量，默认为 1",
     )
     group_basic.add_argument(
         "--fetch-workers",

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -17,6 +17,7 @@ from yutto.utils.time import TIME_DATE_FMT
 
 class YuttoBasicSettings(BaseModel):
     num_workers: Annotated[int, Field(8, gt=0)]
+    jobs: Annotated[int, Field(1, gt=0)]
     fetch_workers: Annotated[int, Field(8, gt=0)]
     video_quality: Annotated[VideoQuality, Field(127)]
     audio_quality: Annotated[AudioQuality, Field(30251)]

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -97,23 +97,45 @@ class _ResolvedItemsOutcome:
 
 
 class DownloadManager:
-    """Execute requests sequentially with one explicit scope per request."""
+    """Execute requests with bounded item concurrency and one explicit scope per request."""
 
-    def __init__(self, *, path_leases: DownloadPathLeasePool | None = None):
+    def __init__(self, *, jobs: int = 1, path_leases: DownloadPathLeasePool | None = None):
+        if jobs < 1:
+            raise ValueError("jobs must be at least 1")
+        self.jobs = jobs
         self.unique_path = create_unique_path_resolver()
         self.path_leases = path_leases or DownloadPathLeasePool()
+        self._item_limiter = asyncio.Semaphore(jobs)
 
     async def execute(
         self,
         scope_factory: ExecutionScopeFactory,
         requests: Sequence[DownloadRequest],
     ) -> DownloadResult:
-        """Run requests in order while keeping network state request-scoped."""
-        items: list[ItemResult] = []
-        for request in requests:
-            async with scope_factory.open(request) as scope:
-                items.extend(await self.process_request(scope, request))
-        return DownloadResult(items=tuple(items))
+        """Run requests with request-scoped network state and stable result ordering."""
+        results: list[tuple[ItemResult, ...] | None] = [None] * len(requests)
+        next_index = 0
+        failed = False
+
+        async def run_requests() -> None:
+            nonlocal failed, next_index
+            while not failed and next_index < len(requests):
+                index = next_index
+                next_index += 1
+                request = requests[index]
+                try:
+                    async with scope_factory.open(request) as scope:
+                        results[index] = await self.process_request(scope, request)
+                except BaseException:
+                    failed = True
+                    raise
+
+        tasks = [
+            asyncio.create_task(run_requests(), name=f"yutto-request-worker-{index}")
+            for index in range(min(self.jobs, len(requests)))
+        ]
+        await _gather_cancelling(tasks)
+        return DownloadResult(items=tuple(item for result in results if result is not None for item in result))
 
     async def execute_resolve(
         self,
@@ -205,58 +227,82 @@ class DownloadManager:
         outcome = await self.resolve_request(scope, request)
         download_list = outcome.items
 
-        item_results: list[ItemResult] = []
-        previous_result: ItemResult | None = None
+        prepared: list[tuple[ResolvableEpisode, Path, str | None]] = []
         current_display_group: str | None = None
+        for episode in download_list:
+            path = Path(self.unique_path(str(episode.info["path"])))
+            prepared.append((episode, path, current_display_group))
+            current_display_group = episode.info["listing"].display_group
 
-        # 下载～
-        for i, episode in enumerate(download_list):
-            # 中途校验基于请求级缓存的用户信息（见 get_user_info），不会重复请求；
-            # 凭据若在过程中失效，需等当前 ExecutionScope 关闭后才能被发现
-            if not await validate_user_info(
-                scope,
-                {"is_login": request.access.login_strict, "vip_status": request.access.vip_strict},
-            ):
-                raise NotLoginError("启用了严格校验大会员或登录模式，请检查认证信息（--auth）或大会员状态！")
+        if request.network.download_interval > 0 and len(prepared) > 1:
+            emit_download_report(f"下载任务启动间隔 {request.network.download_interval} 秒")
 
-            if (
-                previous_result is not None
-                and previous_result.has_downloaded_media
-                and request.network.download_interval > 0
-            ):
-                emit_download_report(f"下载间隔 {request.network.download_interval} 秒")
-                await asyncio.sleep(request.network.download_interval)
+        results: list[ItemResult | None] = [None] * len(prepared)
+        start_turns = [asyncio.Event() for _ in prepared]
+        if start_turns:
+            start_turns[0].set()
 
-            # 这时候才真正开始解析链接
-            episode_data = await episode.resolve_data()
-            if episode_data is None:
-                continue
-            # 保证路径唯一
-            episode_data = ensure_unique_path(episode_data, self.unique_path)
-            if request.output.enforce_directory_boundary:
-                ensure_output_path_is_scoped(
-                    episode_data["info"]["path"],
-                    request.output.directory,
-                    request.output.temporary_directory or request.output.directory,
+        async def run_item(
+            index: int,
+            episode: ResolvableEpisode,
+            path: Path,
+            previous_display_group: str | None,
+        ) -> None:
+            if index > 0 and request.network.download_interval > 0:
+                await asyncio.sleep(index * request.network.download_interval)
+            await start_turns[index].wait()
+            async with self._item_limiter:
+                # 中途校验基于请求级缓存的用户信息（见 get_user_info），不会重复请求；
+                # 凭据若在过程中失效，需等当前 ExecutionScope 关闭后才能被发现
+                if not await validate_user_info(
+                    scope,
+                    {"is_login": request.access.login_strict, "vip_status": request.access.vip_strict},
+                ):
+                    raise NotLoginError("启用了严格校验大会员或登录模式，请检查认证信息（--auth）或大会员状态！")
+                episode_data = await episode.resolve_data()
+                if episode_data is None:
+                    if index + 1 < len(start_turns):
+                        start_turns[index + 1].set()
+                    return
+                episode_data = ensure_unique_path(episode_data, lambda _path: str(path))
+                if request.output.enforce_directory_boundary:
+                    ensure_output_path_is_scoped(
+                        episode_data["info"]["path"],
+                        request.output.directory,
+                        request.output.temporary_directory or request.output.directory,
+                    )
+                if request.scope.batch:
+                    display_info: EpisodeInfo = {
+                        "listing": episode.info["listing"],
+                        "path": path,
+                    }
+                    show_batch_episode_title(
+                        display_info,
+                        index + 1,
+                        len(download_list),
+                        previous_display_group,
+                    )
+                # Event.set() 不会让出控制权，因此本任务会先进入 process_download、
+                # 输出“开始处理视频”，再在首次 await 时让下一条按序启动。
+                if index + 1 < len(start_turns):
+                    start_turns[index + 1].set()
+                results[index] = await process_download(
+                    scope,
+                    episode_data,
+                    request,
+                    path_leases=self.path_leases,
                 )
-            if request.scope.batch:
-                current_display_group = show_batch_episode_title(
-                    episode_data["info"],
-                    i + 1,
-                    len(download_list),
-                    current_display_group,
-                )
 
-            previous_result = await process_download(
-                scope,
-                episode_data,
-                request,
-                path_leases=self.path_leases,
+        tasks = [
+            asyncio.create_task(
+                run_item(index, episode, path, previous_display_group),
+                name=f"yutto-item-{index}",
             )
-            item_results.append(previous_result)
-            emit_download_report("", ReportLevel.PLAIN)
+            for index, (episode, path, previous_display_group) in enumerate(prepared)
+        ]
+        await _gather_cancelling(tasks)
         emit_download_report("", ReportLevel.PLAIN)
-        return tuple(item_results)
+        return tuple(result for result in results if result is not None)
 
     async def resolve_request(
         self,
@@ -371,3 +417,13 @@ def ensure_output_path_is_scoped(path: Path, output_root: Path, temporary_root: 
     for root in (output_root.resolve(), temporary_root.resolve()):
         if not (root / path).resolve().is_relative_to(root):
             raise WrongArgumentError("解析后的输出路径超出了 server 配置的根目录")
+
+
+async def _gather_cancelling(tasks: Sequence[asyncio.Task[None]]) -> None:
+    try:
+        await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise

--- a/src/yutto/validator.py
+++ b/src/yutto/validator.py
@@ -66,6 +66,10 @@ def validate_basic_arguments(args: argparse.Namespace):
         Logger.error(f"num_workers 参数值（{args.num_workers}）不满足要求哦（应为不小于 1 的整数）")
         sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 
+    if args.jobs < 1:
+        Logger.error(f"jobs 参数值（{args.jobs}）不满足要求哦（应为不小于 1 的整数）")
+        sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
+
     try:
         resolve_proxy(args.proxy)
     except ValueError as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,21 @@ def test_download_validation_rejects_non_positive_num_workers(monkeypatch: pytes
     assert errors == ["num_workers 参数值（0）不满足要求哦（应为不小于 1 的整数）"]
 
 
+def test_download_jobs_default_to_one_and_reject_non_positive_values(monkeypatch: pytest.MonkeyPatch):
+    parser = make_download_parser()
+    assert parser.parse_args(["https://example.com"]).jobs == 1
+    args = parser.parse_args(["https://example.com", "--jobs", "0"])
+    errors: list[str] = []
+    monkeypatch.setattr(validator_module, "FFmpeg", object)
+    monkeypatch.setattr(validator_module.Logger, "error", errors.append)
+
+    with pytest.raises(SystemExit) as exc_info:
+        validator_module.validate_basic_arguments(args)
+
+    assert exc_info.value.code == ErrorCode.WRONG_ARGUMENT_ERROR.value
+    assert errors == ["jobs 参数值（0）不满足要求哦（应为不小于 1 的整数）"]
+
+
 def test_login_parser_accepts_auth_file(tmp_path: Path):
     auth_file = tmp_path / "auth.toml"
 

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -343,6 +343,223 @@ async def test_execute_uses_request_scopes_and_keeps_path_resolver_order():
 
 
 @as_sync
+async def test_execute_runs_requests_concurrently_and_preserves_result_order():
+    requests = [
+        DownloadRequest.model_validate({"source": {"url": "BV1first"}}),
+        DownloadRequest.model_validate({"source": {"url": "BV1second"}}),
+        DownloadRequest.model_validate({"source": {"url": "BV1third"}}),
+    ]
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    class ConcurrentManager(DownloadManager):
+        def __init__(self) -> None:
+            super().__init__(jobs=2)
+
+        async def process_request(
+            self,
+            scope: ExecutionScope,
+            request: DownloadRequest,
+        ) -> tuple[ItemResult, ...]:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            if active == 2:
+                both_started.set()
+            try:
+                await release.wait()
+                return (ItemResult(state=ItemState.DONE, output_path=Path(request.source.url)),)
+            finally:
+                active -= 1
+
+    manager = ConcurrentManager()
+    execution = asyncio.create_task(manager.execute(RequestExecutionScopeFactory(), requests))
+    await asyncio.wait_for(both_started.wait(), timeout=1)
+    release.set()
+
+    result = await execution
+
+    assert [item.output_path for item in result.items] == [
+        Path("BV1first"),
+        Path("BV1second"),
+        Path("BV1third"),
+    ]
+    assert max_active == 2
+
+
+@as_sync
+async def test_concurrent_execute_preserves_original_error_and_cancels_siblings():
+    requests = [
+        DownloadRequest.model_validate({"source": {"url": "BV1fail"}}),
+        DownloadRequest.model_validate({"source": {"url": "BV1blocked"}}),
+        DownloadRequest.model_validate({"source": {"url": "BV1must-not-start"}}),
+    ]
+    both_started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    started = 0
+    calls: list[str] = []
+
+    class FailingConcurrentManager(DownloadManager):
+        def __init__(self) -> None:
+            super().__init__(jobs=2)
+
+        async def process_request(
+            self,
+            scope: ExecutionScope,
+            request: DownloadRequest,
+        ) -> tuple[ItemResult, ...]:
+            nonlocal started
+            calls.append(request.source.url)
+            started += 1
+            if started == 2:
+                both_started.set()
+            await both_started.wait()
+            if request.source.url == "BV1fail":
+                raise WrongArgumentError("request failed")
+            try:
+                await asyncio.Event().wait()
+            finally:
+                sibling_cancelled.set()
+            return ()
+
+    with pytest.raises(WrongArgumentError, match="request failed"):
+        await FailingConcurrentManager().execute(RequestExecutionScopeFactory(), requests)
+
+    assert sibling_cancelled.is_set()
+    assert calls == ["BV1fail", "BV1blocked"]
+
+
+@as_sync
+async def test_process_request_runs_items_concurrently_and_preserves_result_order(monkeypatch: pytest.MonkeyPatch):
+    episode_data = [make_episode("series/first"), make_episode("series/second")]
+
+    async def resolve_episode(index: int) -> EpisodeData:
+        return episode_data[index]
+
+    episodes = tuple(
+        ResolvableEpisode(
+            info=item["info"],
+            resolve_data=lambda index=index: resolve_episode(index),
+        )
+        for index, item in enumerate(episode_data)
+    )
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+
+    async def fake_resolve_request(
+        scope: ExecutionScope,
+        request: DownloadRequest,
+    ) -> ExtractorResolveOutcome:
+        return ResolveOutcome(items=episodes)
+
+    async def fake_process_download(
+        scope: ExecutionScope,
+        item: EpisodeData,
+        request: DownloadRequest,
+        *,
+        path_leases: object,
+    ) -> ItemResult:
+        nonlocal active
+        active += 1
+        if active == 2:
+            both_started.set()
+        try:
+            await release.wait()
+            return ItemResult(state=ItemState.DONE, output_path=item["info"]["path"])
+        finally:
+            active -= 1
+
+    manager = DownloadManager(jobs=2)
+    monkeypatch.setattr(manager, "resolve_request", fake_resolve_request)
+    monkeypatch.setattr(download_manager_module, "process_download", fake_process_download)
+    execution = asyncio.create_task(manager.process_request(ExecutionScope(cast("Any", object())), make_request(None)))
+    await asyncio.wait_for(both_started.wait(), timeout=1)
+    release.set()
+
+    result = await execution
+
+    assert [item.output_path for item in result] == [Path("series/first"), Path("series/second")]
+
+
+@as_sync
+async def test_concurrent_batch_resolves_and_reports_item_only_when_it_starts(monkeypatch: pytest.MonkeyPatch):
+    episode_data = [make_episode(f"series/episode-{index}") for index in range(1, 4)]
+    first_resolution_started = asyncio.Event()
+    second_resolved = asyncio.Event()
+    release_first_resolution = asyncio.Event()
+
+    async def resolve_episode(index: int) -> EpisodeData:
+        if index == 0:
+            first_resolution_started.set()
+            await release_first_resolution.wait()
+        elif index == 1:
+            second_resolved.set()
+        return episode_data[index]
+
+    episodes = tuple(
+        ResolvableEpisode(
+            info=item["info"],
+            resolve_data=lambda index=index: resolve_episode(index),
+        )
+        for index, item in enumerate(episode_data)
+    )
+    first_jobs_started = asyncio.Event()
+    release = asyncio.Event()
+    active = 0
+    title_badges: list[str] = []
+
+    async def fake_resolve_request(
+        scope: ExecutionScope,
+        request: DownloadRequest,
+    ) -> ExtractorResolveOutcome:
+        return ResolveOutcome(items=episodes)
+
+    async def fake_process_download(
+        scope: ExecutionScope,
+        item: EpisodeData,
+        request: DownloadRequest,
+        *,
+        path_leases: object,
+    ) -> ItemResult:
+        nonlocal active
+        active += 1
+        if active == 2:
+            first_jobs_started.set()
+        try:
+            await release.wait()
+            return ItemResult(state=ItemState.DONE, output_path=item["info"]["path"])
+        finally:
+            active -= 1
+
+    def capture_report(message: str, _level: Any, badge: str | None, _color: Any) -> None:
+        if badge is not None and badge.startswith("["):
+            title_badges.append(badge)
+
+    request = make_request(None)
+    request = request.model_copy(update={"scope": request.scope.model_copy(update={"batch": True})})
+    manager = DownloadManager(jobs=2)
+    monkeypatch.setattr(manager, "resolve_request", fake_resolve_request)
+    monkeypatch.setattr(download_manager_module, "process_download", fake_process_download)
+
+    with bind_download_report_sink(capture_report):
+        execution = asyncio.create_task(manager.process_request(ExecutionScope(cast("Any", object())), request))
+        await asyncio.wait_for(first_resolution_started.wait(), timeout=1)
+        assert not second_resolved.is_set()
+        assert title_badges == []
+        release_first_resolution.set()
+        await asyncio.wait_for(first_jobs_started.wait(), timeout=1)
+        assert second_resolved.is_set()
+        assert title_badges == ["[1/3]", "[2/3]"]
+        release.set()
+        await execution
+
+    assert title_badges == ["[1/3]", "[2/3]", "[3/3]"]
+
+
+@as_sync
 async def test_execute_stops_on_failure_and_closes_session():
     requests = [
         DownloadRequest.model_validate({"source": {"url": "BV1first"}}),

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -203,7 +203,7 @@ def configure_download_cli(
     *,
     replace_logger: bool = True,
 ) -> tuple[list[str], list[str]]:
-    parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="download", no_progress=True))
+    parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="download", no_progress=True, jobs=1))
     rendered_errors: list[str] = []
     rendered_info: list[str] = []
 
@@ -211,6 +211,8 @@ def configure_download_cli(
         scope_factory: object,
         requests: list[DownloadRequest],
         renderer: object,
+        *,
+        jobs: int,
     ):
         raise failure
 


### PR DESCRIPTION
## 动机

CLI 目前会串行执行 URL 列表和批量来源中的分集，无法利用多视频并发；同时需要保留结果顺序、下载间隔、错误语义以及批量标题的可读性。

本 PR 依赖 #799，是多视频并发 stack 的最终 CLI 层。

## 解决方案

- 为下载命令和 `basic` 配置增加 `-j/--jobs`，默认 `1`，与单视频内部的 `--num-workers` 分工明确。
- 用共享 semaphore 限制 URL 列表与批量分集的总视频并发，并按输入顺序返回结果。
- 并发失败时取消兄弟任务并继续抛出原始 yutto 异常。
- 预先按列表顺序预占输出路径；批量标题仅在条目真正启动时显示，并按 `[1/N]` 到 `[N/N]` 顺序放行，不等待前一条下载完成。
- 更新配置 schema 与 CLI 文档，补充并发、顺序、取消、参数校验和标题时序回归测试。

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
