### PR TITLE
✨ feat: support custom FFmpeg paths

### DIFF
--- a/docs/guide/cli/basic.md
+++ b/docs/guide/cli/basic.md
@@ -163,6 +163,13 @@ download_vcodec_priority = ["hevc", "avc", "av1"]
 
 :::
 
+## 指定 FFmpeg 路径
+
+- 参数 `--ffmpeg-path`
+- 默认值 `"ffmpeg"`
+
+FFmpeg 可执行文件路径。默认值 `"ffmpeg"` 表示按名从 `PATH` 解析；当 FFmpeg 不在 `PATH` 中时，可用本参数指定可执行文件的完整路径，如 `--ffmpeg-path /opt/ffmpeg/ffmpeg`。`yutto serve` 同样支持本参数。
+
 ## 启用 AI 原声翻译功能
 
 - 参数 `--ai-translation-language`

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -24,6 +24,12 @@ yutto serve \
   --allow-origin http://127.0.0.1:3000
 ```
 
+若 FFmpeg 不在 `PATH` 中，可用 `--ffmpeg-path` 指定可执行文件的完整路径（默认按名从 `PATH` 解析）；server 进程内的下载合并会复用该路径：
+
+```bash
+yutto serve --token-file ~/.config/yutto/server.token --ffmpeg-path /opt/ffmpeg/ffmpeg
+```
+
 ## 调用流程
 
 连接建立后，第一条消息必须调用 `server.authenticate`。Token 不放在 URL 中。

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -97,6 +97,9 @@ def main():
                     run_server_command(args)
             except KeyboardInterrupt:
                 Logger.info("yutto server 已停止")
+            except YuttoBaseException as e:
+                Logger.error(e.message)
+                sys.exit(e.code.value)
             except (OSError, ValueError) as e:
                 Logger.error(str(e))
                 sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -20,7 +20,7 @@ from yutto.exceptions import ErrorCode, YuttoBaseException
 from yutto.input_parser import file_scheme_parser
 from yutto.login import run_auth
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.ffmpeg import FFmpegNotFoundError
+from yutto.utils.ffmpeg import FFmpeg, FFmpegNotFoundError
 from yutto.utils.functional import as_sync
 from yutto.validator import (
     hydrate_auth,
@@ -64,6 +64,7 @@ def main():
             with bind_download_report_sink(renderer.report):
                 try:
                     initial_validation(args)
+                    FFmpeg.setup_ffmpeg_path(args.ffmpeg_path)
                     args_list = flatten_args(args, parser)
                     auth_list = [hydrate_auth(item) for item in args_list]
                     requests = [download_request_from_namespace(item) for item in args_list]

--- a/src/yutto/__main__.py
+++ b/src/yutto/__main__.py
@@ -20,7 +20,7 @@ from yutto.exceptions import ErrorCode, YuttoBaseException
 from yutto.input_parser import file_scheme_parser
 from yutto.login import run_auth
 from yutto.utils.console.logger import Badge, Logger
-from yutto.utils.ffmpeg import FFmpeg, FFmpegNotFoundError
+from yutto.utils.ffmpeg import FFmpeg
 from yutto.utils.functional import as_sync
 from yutto.validator import (
     hydrate_auth,
@@ -97,7 +97,7 @@ def main():
                     run_server_command(args)
             except KeyboardInterrupt:
                 Logger.info("yutto server 已停止")
-            except (FFmpegNotFoundError, OSError, ValueError) as e:
+            except (OSError, ValueError) as e:
                 Logger.error(str(e))
                 sys.exit(ErrorCode.WRONG_ARGUMENT_ERROR.value)
 

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -84,6 +84,11 @@ def cli() -> argparse.ArgumentParser:
 def add_serve_arguments(parser: argparse.ArgumentParser, settings: YuttoSettings) -> None:
     parser.set_defaults(server_settings=settings)
     parser.add_argument("--config", help="配置文件路径")
+    parser.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg 可执行文件路径，默认从 PATH 解析（`ffmpeg`）",
+    )
     parser.add_argument("--host", default="127.0.0.1", help="监听地址（仅允许本机回环地址）")
     parser.add_argument("--port", type=int, default=11223, help="监听端口，默认为 11223")
     parser.add_argument(
@@ -206,6 +211,11 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         default=settings.basic.output_format_audio_only,
         choices=["infer", "m4a", "aac", "mp3", "flac", "mp4", "mkv", "mov"],
         help="仅包含音频流时所使用的输出格式（infer 为自动推断）",
+    )
+    group_basic.add_argument(
+        "--ffmpeg-path",
+        default="ffmpeg",
+        help="FFmpeg 可执行文件路径，默认从 PATH 解析（`ffmpeg`）",
     )
     group_basic.add_argument(
         "--ai-translation-language",

--- a/src/yutto/server/command.py
+++ b/src/yutto/server/command.py
@@ -169,7 +169,8 @@ def _build_download_application(
 @as_sync
 async def run_server_command(args: argparse.Namespace) -> None:
     # 与 download 子命令一样，在真正接收任务前确认 FFmpeg 可用。
-    ffmpeg = FFmpeg(args.ffmpeg_path)
+    ffmpeg = FFmpeg()
+    ffmpeg.setup_ffmpeg_path(args.ffmpeg_path)
     token = resolve_server_token(args.token_file)
     server = build_server(args, token.value, ffmpeg=ffmpeg)
     await server.start()

--- a/src/yutto/server/command.py
+++ b/src/yutto/server/command.py
@@ -169,7 +169,7 @@ def _build_download_application(
 @as_sync
 async def run_server_command(args: argparse.Namespace) -> None:
     # 与 download 子命令一样，在真正接收任务前确认 FFmpeg 可用。
-    ffmpeg = FFmpeg()
+    ffmpeg = FFmpeg(args.ffmpeg_path)
     token = resolve_server_token(args.token_file)
     server = build_server(args, token.value, ffmpeg=ffmpeg)
     await server.start()

--- a/src/yutto/server/command.py
+++ b/src/yutto/server/command.py
@@ -168,9 +168,8 @@ def _build_download_application(
 
 @as_sync
 async def run_server_command(args: argparse.Namespace) -> None:
-    # 与 download 子命令一样，在真正接收任务前确认 FFmpeg 可用。
+    FFmpeg.setup_ffmpeg_path(args.ffmpeg_path)
     ffmpeg = FFmpeg()
-    ffmpeg.setup_ffmpeg_path(args.ffmpeg_path)
     token = resolve_server_token(args.token_file)
     server = build_server(args, token.value, ffmpeg=ffmpeg)
     await server.start()

--- a/src/yutto/utils/ffmpeg.py
+++ b/src/yutto/utils/ffmpeg.py
@@ -8,6 +8,7 @@ from functools import cached_property, reduce
 from pathlib import Path
 
 from yutto.core.operation import ReportLevel, emit_download_report
+from yutto.exceptions import WrongArgumentError
 from yutto.utils.functional import Singleton
 
 _TERMINATE_TIMEOUT_SECONDS = 3.0
@@ -21,6 +22,11 @@ class FFmpeg(metaclass=Singleton):
 
     @classmethod
     def setup_ffmpeg_path(cls, path: str) -> None:
+        try:
+            if subprocess.run([path], capture_output=True).returncode != 1:
+                raise WrongArgumentError("请配置正确的 FFmpeg 路径")
+        except FileNotFoundError:
+            raise WrongArgumentError("请配置正确的 FFmpeg 路径") from None
         cls.FFMPEG_PATH = path
 
     def exec(self, args: list[str]):

--- a/src/yutto/utils/ffmpeg.py
+++ b/src/yutto/utils/ffmpeg.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import operator
-import os
 import re
 import subprocess
 from functools import cached_property, reduce
@@ -14,27 +13,15 @@ from yutto.utils.functional import Singleton
 _TERMINATE_TIMEOUT_SECONDS = 3.0
 
 
-class FFmpegNotFoundError(Exception):
-    def __init__(self):
-        super().__init__("请配置正确的 FFmpeg 路径")
-
-
 class FFmpeg(metaclass=Singleton):
+    FFMPEG_PATH = "ffmpeg"
+
     def __init__(self):
-        self.path = "ffmpeg"
+        self.path = self.FFMPEG_PATH
 
     @classmethod
-    def setup_ffmpeg_path(cls, ffmpeg_path: str) -> None:
-        try:
-            if subprocess.run([ffmpeg_path], capture_output=True).returncode != 1:
-                raise FFmpegNotFoundError
-        except FileNotFoundError:
-            raise FFmpegNotFoundError from None
-
-        ffmpeg = cls()
-        ffmpeg.path = os.path.normpath(ffmpeg_path)
-        for property_name in ("version", "video_encodecs", "audio_encodecs"):
-            ffmpeg.__dict__.pop(property_name, None)
+    def setup_ffmpeg_path(cls, path: str) -> None:
+        cls.FFMPEG_PATH = path
 
     def exec(self, args: list[str]):
         cmd = [self.path]

--- a/src/yutto/utils/ffmpeg.py
+++ b/src/yutto/utils/ffmpeg.py
@@ -22,11 +22,8 @@ class FFmpeg(metaclass=Singleton):
 
     @classmethod
     def setup_ffmpeg_path(cls, path: str) -> None:
-        try:
-            if subprocess.run([path], capture_output=True).returncode != 1:
-                raise WrongArgumentError("请配置正确的 FFmpeg 路径")
-        except FileNotFoundError:
-            raise WrongArgumentError("请配置正确的 FFmpeg 路径") from None
+        if path != "ffmpeg" and not Path(path).is_file():
+            raise WrongArgumentError("请配置正确的 FFmpeg 路径")
         cls.FFMPEG_PATH = path
 
     def exec(self, args: list[str]):

--- a/src/yutto/utils/ffmpeg.py
+++ b/src/yutto/utils/ffmpeg.py
@@ -20,14 +20,21 @@ class FFmpegNotFoundError(Exception):
 
 
 class FFmpeg(metaclass=Singleton):
-    def __init__(self, ffmpeg_path: str = "ffmpeg"):
+    def __init__(self):
+        self.path = "ffmpeg"
+
+    @classmethod
+    def setup_ffmpeg_path(cls, ffmpeg_path: str) -> None:
         try:
             if subprocess.run([ffmpeg_path], capture_output=True).returncode != 1:
                 raise FFmpegNotFoundError
         except FileNotFoundError:
             raise FFmpegNotFoundError from None
 
-        self.path = os.path.normpath(ffmpeg_path)
+        ffmpeg = cls()
+        ffmpeg.path = os.path.normpath(ffmpeg_path)
+        for property_name in ("version", "video_encodecs", "audio_encodecs"):
+            ffmpeg.__dict__.pop(property_name, None)
 
     def exec(self, args: list[str]):
         cmd = [self.path]

--- a/src/yutto/validator.py
+++ b/src/yutto/validator.py
@@ -54,7 +54,7 @@ def initial_validation(args: argparse.Namespace):
 def validate_basic_arguments(args: argparse.Namespace):
     """检查 argparse 无法检查的选项，并设置某些全局的状态"""
 
-    ffmpeg = FFmpeg(args.ffmpeg_path)
+    ffmpeg = FFmpeg()
 
     # fetch_workers 检查
     if args.fetch_workers < 1:

--- a/src/yutto/validator.py
+++ b/src/yutto/validator.py
@@ -54,7 +54,7 @@ def initial_validation(args: argparse.Namespace):
 def validate_basic_arguments(args: argparse.Namespace):
     """检查 argparse 无法检查的选项，并设置某些全局的状态"""
 
-    ffmpeg = FFmpeg()
+    ffmpeg = FFmpeg(args.ffmpeg_path)
 
     # fetch_workers 检查
     if args.fetch_workers < 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,26 +87,37 @@ def test_download_parser_accepts_ffmpeg_path():
     )
 
 
-def test_download_passes_ffmpeg_path_to_ffmpeg(monkeypatch: pytest.MonkeyPatch):
-    recorded: dict[str, str] = {}
+def test_download_configures_ffmpeg_path_at_command_boundary(monkeypatch: pytest.MonkeyPatch):
+    recorded: list[str] = []
+    args = argparse.Namespace(
+        command="download",
+        no_progress=True,
+        no_color=False,
+        debug=False,
+        ffmpeg_path="/opt/ffmpeg/ffmpeg",
+    )
 
     class RecordingFFmpeg:
-        def __init__(self, ffmpeg_path: str = "ffmpeg") -> None:
-            recorded["path"] = ffmpeg_path
+        @classmethod
+        def setup_ffmpeg_path(cls, ffmpeg_path: str) -> None:
+            recorded.append(ffmpeg_path)
             raise RuntimeError("stop after recording")
 
-    monkeypatch.setattr(validator_module, "FFmpeg", RecordingFFmpeg)
-    args = make_download_parser().parse_args(["https://example.com", "--ffmpeg-path", "/opt/ffmpeg/ffmpeg"])
-    with pytest.raises(RuntimeError, match="stop after recording"):
-        validator_module.validate_basic_arguments(args)
+    monkeypatch.setattr(main_module, "cli", lambda: argparse.ArgumentParser())
+    monkeypatch.setattr(main_module.sys, "argv", ["yutto", "download"])
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda *_args: args)
+    monkeypatch.setattr(main_module, "FFmpeg", RecordingFFmpeg)
 
-    assert recorded["path"] == "/opt/ffmpeg/ffmpeg"
+    with pytest.raises(RuntimeError, match="stop after recording"):
+        main_module.main()
+
+    assert recorded == ["/opt/ffmpeg/ffmpeg"]
 
 
 def test_download_validation_rejects_non_positive_num_workers(monkeypatch: pytest.MonkeyPatch):
     args = make_download_parser().parse_args(["https://example.com", "--num-workers", "0"])
     errors: list[str] = []
-    monkeypatch.setattr(validator_module, "FFmpeg", lambda _path: object())
+    monkeypatch.setattr(validator_module, "FFmpeg", lambda: object())
     monkeypatch.setattr(validator_module.Logger, "error", errors.append)
 
     with pytest.raises(SystemExit) as exc_info:
@@ -121,7 +132,7 @@ def test_download_jobs_default_to_one_and_reject_non_positive_values(monkeypatch
     assert parser.parse_args(["https://example.com"]).jobs == 1
     args = parser.parse_args(["https://example.com", "--jobs", "0"])
     errors: list[str] = []
-    monkeypatch.setattr(validator_module, "FFmpeg", lambda _path: object())
+    monkeypatch.setattr(validator_module, "FFmpeg", lambda: object())
     monkeypatch.setattr(validator_module.Logger, "error", errors.append)
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,10 +77,36 @@ def test_download_parser_rejects_auth_config(tmp_path: Path):
     assert exc_info.value.code == 2
 
 
+def test_download_parser_accepts_ffmpeg_path():
+    parser = make_download_parser()
+
+    assert parser.parse_args(["https://example.com"]).ffmpeg_path == "ffmpeg"
+    assert (
+        parser.parse_args(["https://example.com", "--ffmpeg-path", "/opt/ffmpeg/ffmpeg"]).ffmpeg_path
+        == "/opt/ffmpeg/ffmpeg"
+    )
+
+
+def test_download_passes_ffmpeg_path_to_ffmpeg(monkeypatch: pytest.MonkeyPatch):
+    recorded: dict[str, str] = {}
+
+    class RecordingFFmpeg:
+        def __init__(self, ffmpeg_path: str = "ffmpeg") -> None:
+            recorded["path"] = ffmpeg_path
+            raise RuntimeError("stop after recording")
+
+    monkeypatch.setattr(validator_module, "FFmpeg", RecordingFFmpeg)
+    args = make_download_parser().parse_args(["https://example.com", "--ffmpeg-path", "/opt/ffmpeg/ffmpeg"])
+    with pytest.raises(RuntimeError, match="stop after recording"):
+        validator_module.validate_basic_arguments(args)
+
+    assert recorded["path"] == "/opt/ffmpeg/ffmpeg"
+
+
 def test_download_validation_rejects_non_positive_num_workers(monkeypatch: pytest.MonkeyPatch):
     args = make_download_parser().parse_args(["https://example.com", "--num-workers", "0"])
     errors: list[str] = []
-    monkeypatch.setattr(validator_module, "FFmpeg", object)
+    monkeypatch.setattr(validator_module, "FFmpeg", lambda _path: object())
     monkeypatch.setattr(validator_module.Logger, "error", errors.append)
 
     with pytest.raises(SystemExit) as exc_info:
@@ -95,7 +121,7 @@ def test_download_jobs_default_to_one_and_reject_non_positive_values(monkeypatch
     assert parser.parse_args(["https://example.com"]).jobs == 1
     args = parser.parse_args(["https://example.com", "--jobs", "0"])
     errors: list[str] = []
-    monkeypatch.setattr(validator_module, "FFmpeg", object)
+    monkeypatch.setattr(validator_module, "FFmpeg", lambda _path: object())
     monkeypatch.setattr(validator_module.Logger, "error", errors.append)
 
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -203,7 +203,9 @@ def configure_download_cli(
     *,
     replace_logger: bool = True,
 ) -> tuple[list[str], list[str]]:
-    parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="download", no_progress=True, jobs=1))
+    parser = SimpleNamespace(
+        parse_args=lambda args: SimpleNamespace(command="download", no_progress=True, jobs=1, ffmpeg_path="ffmpeg")
+    )
     rendered_errors: list[str] = []
     rendered_info: list[str] = []
 
@@ -219,6 +221,7 @@ def configure_download_cli(
     monkeypatch.setattr(main_module, "cli", lambda: parser)
     monkeypatch.setattr(main_module.sys, "argv", ["yutto", "BV1structured"])
     monkeypatch.setattr(main_module, "initial_validation", lambda args: None)
+    monkeypatch.setattr(main_module.FFmpeg, "setup_ffmpeg_path", lambda path: None)
     monkeypatch.setattr(main_module, "flatten_args", lambda args, parser: [args])
     monkeypatch.setattr(main_module, "hydrate_auth", lambda args: None)
     monkeypatch.setattr(main_module, "download_request_from_namespace", lambda args: make_request())

--- a/tests/test_server/test_command.py
+++ b/tests/test_server/test_command.py
@@ -49,7 +49,8 @@ def test_serve_configures_ffmpeg_path_at_command_boundary(monkeypatch: pytest.Mo
     recorded: list[str] = []
 
     class RecordingFFmpeg:
-        def setup_ffmpeg_path(self, ffmpeg_path: str) -> None:
+        @classmethod
+        def setup_ffmpeg_path(cls, ffmpeg_path: str) -> None:
             recorded.append(ffmpeg_path)
             raise RuntimeError("stop after recording")
 

--- a/tests/test_server/test_command.py
+++ b/tests/test_server/test_command.py
@@ -45,12 +45,12 @@ def test_serve_accepts_ffmpeg_path():
     assert cli().parse_args(["serve", "--ffmpeg-path", "/opt/ffmpeg/ffmpeg"]).ffmpeg_path == "/opt/ffmpeg/ffmpeg"
 
 
-def test_serve_passes_ffmpeg_path_to_ffmpeg(monkeypatch: pytest.MonkeyPatch):
-    recorded: dict[str, str] = {}
+def test_serve_configures_ffmpeg_path_at_command_boundary(monkeypatch: pytest.MonkeyPatch):
+    recorded: list[str] = []
 
     class RecordingFFmpeg:
-        def __init__(self, ffmpeg_path: str = "ffmpeg") -> None:
-            recorded["path"] = ffmpeg_path
+        def setup_ffmpeg_path(self, ffmpeg_path: str) -> None:
+            recorded.append(ffmpeg_path)
             raise RuntimeError("stop after recording")
 
     monkeypatch.setattr(server_command_module, "FFmpeg", RecordingFFmpeg)
@@ -58,7 +58,7 @@ def test_serve_passes_ffmpeg_path_to_ffmpeg(monkeypatch: pytest.MonkeyPatch):
     with pytest.raises(RuntimeError, match="stop after recording"):
         server_command_module.run_server_command(args)
 
-    assert recorded["path"] == "/opt/ffmpeg/ffmpeg"
+    assert recorded == ["/opt/ffmpeg/ffmpeg"]
 
 
 def test_serve_io_error_is_rendered_without_traceback(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_server/test_command.py
+++ b/tests/test_server/test_command.py
@@ -10,7 +10,7 @@ import yutto.__main__ as main_module
 import yutto.server.command as server_command_module
 from yutto.cli.cli import cli, handle_default_subcommand
 from yutto.core.operation import ReportLevel, emit_download_report
-from yutto.exceptions import ErrorCode
+from yutto.exceptions import ErrorCode, WrongArgumentError
 from yutto.server.command import build_server, resolve_server_token
 
 if TYPE_CHECKING:
@@ -62,7 +62,26 @@ def test_serve_configures_ffmpeg_path_at_command_boundary(monkeypatch: pytest.Mo
     assert recorded == ["/opt/ffmpeg/ffmpeg"]
 
 
-def test_serve_io_error_is_rendered_without_traceback(monkeypatch: pytest.MonkeyPatch):
+def test_serve_argument_error_is_rendered_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="serve"))
+
+    def fail_server(args: object) -> None:
+        raise WrongArgumentError("请配置正确的 FFmpeg 路径")
+
+    monkeypatch.setattr(main_module, "cli", lambda: parser)
+    monkeypatch.setattr(main_module.sys, "argv", ["yutto", "serve"])
+    monkeypatch.setattr(server_command_module, "run_server_command", fail_server)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.main()
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == ErrorCode.WRONG_ARGUMENT_ERROR.value
+    assert "请配置正确的 FFmpeg 路径" in captured.out
+    assert "Traceback" not in captured.out + captured.err
+
     parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="serve"))
     rendered_errors: list[str] = []
 

--- a/tests/test_server/test_command.py
+++ b/tests/test_server/test_command.py
@@ -40,6 +40,27 @@ def test_serve_jobs_configures_download_runtime_workers():
     assert cast("DownloadTaskService", server._task_service).runtime.worker_count == 3
 
 
+def test_serve_accepts_ffmpeg_path():
+    assert cli().parse_args(["serve"]).ffmpeg_path == "ffmpeg"
+    assert cli().parse_args(["serve", "--ffmpeg-path", "/opt/ffmpeg/ffmpeg"]).ffmpeg_path == "/opt/ffmpeg/ffmpeg"
+
+
+def test_serve_passes_ffmpeg_path_to_ffmpeg(monkeypatch: pytest.MonkeyPatch):
+    recorded: dict[str, str] = {}
+
+    class RecordingFFmpeg:
+        def __init__(self, ffmpeg_path: str = "ffmpeg") -> None:
+            recorded["path"] = ffmpeg_path
+            raise RuntimeError("stop after recording")
+
+    monkeypatch.setattr(server_command_module, "FFmpeg", RecordingFFmpeg)
+    args = cli().parse_args(["serve", "--ffmpeg-path", "/opt/ffmpeg/ffmpeg"])
+    with pytest.raises(RuntimeError, match="stop after recording"):
+        server_command_module.run_server_command(args)
+
+    assert recorded["path"] == "/opt/ffmpeg/ffmpeg"
+
+
 def test_serve_io_error_is_rendered_without_traceback(monkeypatch: pytest.MonkeyPatch):
     parser = SimpleNamespace(parse_args=lambda args: SimpleNamespace(command="serve"))
     rendered_errors: list[str] = []

--- a/tests/test_utils/test_ffmpeg.py
+++ b/tests/test_utils/test_ffmpeg.py
@@ -38,50 +38,21 @@ def reset_ffmpeg_singleton():
     Singleton._instances.pop(FFmpeg, None)
 
 
-def test_setup_ffmpeg_path_configures_first_instance(
-    monkeypatch: pytest.MonkeyPatch,
-    reset_ffmpeg_singleton: None,
-):
-    monkeypatch.setattr(
-        ffmpeg_module.subprocess,
-        "run",
-        lambda args, capture_output: subprocess.CompletedProcess(args, 1),
-    )
+def test_setup_ffmpeg_path_configures_first_instance(tmp_path: Path, reset_ffmpeg_singleton: None):
+    ffmpeg_path = tmp_path / "ffmpeg"
+    ffmpeg_path.touch()
 
-    FFmpeg.setup_ffmpeg_path("/opt/ffmpeg/ffmpeg")
+    FFmpeg.setup_ffmpeg_path(str(ffmpeg_path))
 
-    assert FFmpeg().path == "/opt/ffmpeg/ffmpeg"
-
-
-@pytest.mark.parametrize("returncode", [0, 2])
-def test_setup_ffmpeg_path_rejects_non_ffmpeg_executable(
-    monkeypatch: pytest.MonkeyPatch,
-    reset_ffmpeg_singleton: None,
-    returncode: int,
-):
-    monkeypatch.setattr(
-        ffmpeg_module.subprocess,
-        "run",
-        lambda args, capture_output: subprocess.CompletedProcess(args, returncode),
-    )
-
-    with pytest.raises(WrongArgumentError, match="请配置正确的 FFmpeg 路径"):
-        FFmpeg.setup_ffmpeg_path("not-ffmpeg")
-
-    assert FFmpeg.FFMPEG_PATH == "ffmpeg"
+    assert FFmpeg().path == str(ffmpeg_path)
 
 
 def test_setup_ffmpeg_path_rejects_missing_executable(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     reset_ffmpeg_singleton: None,
 ):
-    def raise_file_not_found(_args: list[str], capture_output: bool) -> subprocess.CompletedProcess[bytes]:
-        raise FileNotFoundError
-
-    monkeypatch.setattr(ffmpeg_module.subprocess, "run", raise_file_not_found)
-
     with pytest.raises(WrongArgumentError, match="请配置正确的 FFmpeg 路径"):
-        FFmpeg.setup_ffmpeg_path("missing-ffmpeg")
+        FFmpeg.setup_ffmpeg_path(str(tmp_path / "missing-ffmpeg"))
 
     assert FFmpeg.FFMPEG_PATH == "ffmpeg"
 

--- a/tests/test_utils/test_ffmpeg.py
+++ b/tests/test_utils/test_ffmpeg.py
@@ -13,7 +13,7 @@ from yutto.core.request import DownloadRequest
 from yutto.core.result import ResolvedItem
 from yutto.downloader.media_muxer import MediaMuxer
 from yutto.downloader.planner import DownloadPlan, DownloadPlanner, should_attach_hvc1_tag
-from yutto.exceptions import PostprocessingError
+from yutto.exceptions import PostprocessingError, WrongArgumentError
 from yutto.types import AId, CId
 from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
 from yutto.utils.functional import Singleton, as_sync
@@ -38,10 +38,52 @@ def reset_ffmpeg_singleton():
     Singleton._instances.pop(FFmpeg, None)
 
 
-def test_setup_ffmpeg_path_configures_first_instance(reset_ffmpeg_singleton: None):
+def test_setup_ffmpeg_path_configures_first_instance(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_ffmpeg_singleton: None,
+):
+    monkeypatch.setattr(
+        ffmpeg_module.subprocess,
+        "run",
+        lambda args, capture_output: subprocess.CompletedProcess(args, 1),
+    )
+
     FFmpeg.setup_ffmpeg_path("/opt/ffmpeg/ffmpeg")
 
     assert FFmpeg().path == "/opt/ffmpeg/ffmpeg"
+
+
+@pytest.mark.parametrize("returncode", [0, 2])
+def test_setup_ffmpeg_path_rejects_non_ffmpeg_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_ffmpeg_singleton: None,
+    returncode: int,
+):
+    monkeypatch.setattr(
+        ffmpeg_module.subprocess,
+        "run",
+        lambda args, capture_output: subprocess.CompletedProcess(args, returncode),
+    )
+
+    with pytest.raises(WrongArgumentError, match="请配置正确的 FFmpeg 路径"):
+        FFmpeg.setup_ffmpeg_path("not-ffmpeg")
+
+    assert FFmpeg.FFMPEG_PATH == "ffmpeg"
+
+
+def test_setup_ffmpeg_path_rejects_missing_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_ffmpeg_singleton: None,
+):
+    def raise_file_not_found(_args: list[str], capture_output: bool) -> subprocess.CompletedProcess[bytes]:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(ffmpeg_module.subprocess, "run", raise_file_not_found)
+
+    with pytest.raises(WrongArgumentError, match="请配置正确的 FFmpeg 路径"):
+        FFmpeg.setup_ffmpeg_path("missing-ffmpeg")
+
+    assert FFmpeg.FFMPEG_PATH == "ffmpeg"
 
 
 def test_ffmpeg_uses_default_path(reset_ffmpeg_singleton: None):

--- a/tests/test_utils/test_ffmpeg.py
+++ b/tests/test_utils/test_ffmpeg.py
@@ -15,7 +15,7 @@ from yutto.downloader.media_muxer import MediaMuxer
 from yutto.downloader.planner import DownloadPlan, DownloadPlanner, should_attach_hvc1_tag
 from yutto.exceptions import PostprocessingError
 from yutto.types import AId, CId
-from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder, FFmpegNotFoundError
+from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
 from yutto.utils.functional import Singleton, as_sync
 
 if TYPE_CHECKING:
@@ -31,49 +31,21 @@ def make_ffmpeg(path: str) -> FFmpeg:
 
 @pytest.fixture
 def reset_ffmpeg_singleton():
+    original_path = FFmpeg.FFMPEG_PATH
     Singleton._instances.pop(FFmpeg, None)
     yield
+    FFmpeg.FFMPEG_PATH = original_path
     Singleton._instances.pop(FFmpeg, None)
 
 
-def test_setup_ffmpeg_path_reconfigures_existing_singleton_and_clears_caches(
-    monkeypatch: pytest.MonkeyPatch,
-    reset_ffmpeg_singleton: None,
-):
-    ffmpeg = FFmpeg()
-    ffmpeg.path = "first-ffmpeg"
-    ffmpeg.__dict__.update(version="first", video_encodecs=["h264"], audio_encodecs=["aac"])
-    monkeypatch.setattr(
-        ffmpeg_module.subprocess,
-        "run",
-        lambda args, capture_output: subprocess.CompletedProcess(args, 1),
-    )
+def test_setup_ffmpeg_path_configures_first_instance(reset_ffmpeg_singleton: None):
+    FFmpeg.setup_ffmpeg_path("/opt/ffmpeg/ffmpeg")
 
-    FFmpeg.setup_ffmpeg_path("custom/../ffmpeg")
-
-    assert FFmpeg() is ffmpeg
-    assert ffmpeg.path == "ffmpeg"
-    assert {"version", "video_encodecs", "audio_encodecs"}.isdisjoint(ffmpeg.__dict__)
+    assert FFmpeg().path == "/opt/ffmpeg/ffmpeg"
 
 
-def test_setup_ffmpeg_path_preserves_state_when_validation_fails(
-    monkeypatch: pytest.MonkeyPatch,
-    reset_ffmpeg_singleton: None,
-):
-    ffmpeg = FFmpeg()
-    ffmpeg.path = "first-ffmpeg"
-    ffmpeg.__dict__["version"] = "first"
-    monkeypatch.setattr(
-        ffmpeg_module.subprocess,
-        "run",
-        lambda _args, capture_output: (_ for _ in ()).throw(FileNotFoundError),
-    )
-
-    with pytest.raises(FFmpegNotFoundError):
-        FFmpeg.setup_ffmpeg_path("missing-ffmpeg")
-
-    assert ffmpeg.path == "first-ffmpeg"
-    assert ffmpeg.version == "first"
+def test_ffmpeg_uses_default_path(reset_ffmpeg_singleton: None):
+    assert FFmpeg().path == "ffmpeg"
 
 
 def make_audio() -> AudioUrlMeta:

--- a/tests/test_utils/test_ffmpeg.py
+++ b/tests/test_utils/test_ffmpeg.py
@@ -15,8 +15,8 @@ from yutto.downloader.media_muxer import MediaMuxer
 from yutto.downloader.planner import DownloadPlan, DownloadPlanner, should_attach_hvc1_tag
 from yutto.exceptions import PostprocessingError
 from yutto.types import AId, CId
-from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder
-from yutto.utils.functional import as_sync
+from yutto.utils.ffmpeg import FFmpeg, FFmpegCommandBuilder, FFmpegNotFoundError
+from yutto.utils.functional import Singleton, as_sync
 
 if TYPE_CHECKING:
     from yutto.media.codec import VideoCodec
@@ -27,6 +27,53 @@ def make_ffmpeg(path: str) -> FFmpeg:
     ffmpeg = object.__new__(FFmpeg)
     ffmpeg.path = path
     return ffmpeg
+
+
+@pytest.fixture
+def reset_ffmpeg_singleton():
+    Singleton._instances.pop(FFmpeg, None)
+    yield
+    Singleton._instances.pop(FFmpeg, None)
+
+
+def test_setup_ffmpeg_path_reconfigures_existing_singleton_and_clears_caches(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_ffmpeg_singleton: None,
+):
+    ffmpeg = FFmpeg()
+    ffmpeg.path = "first-ffmpeg"
+    ffmpeg.__dict__.update(version="first", video_encodecs=["h264"], audio_encodecs=["aac"])
+    monkeypatch.setattr(
+        ffmpeg_module.subprocess,
+        "run",
+        lambda args, capture_output: subprocess.CompletedProcess(args, 1),
+    )
+
+    FFmpeg.setup_ffmpeg_path("custom/../ffmpeg")
+
+    assert FFmpeg() is ffmpeg
+    assert ffmpeg.path == "ffmpeg"
+    assert {"version", "video_encodecs", "audio_encodecs"}.isdisjoint(ffmpeg.__dict__)
+
+
+def test_setup_ffmpeg_path_preserves_state_when_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_ffmpeg_singleton: None,
+):
+    ffmpeg = FFmpeg()
+    ffmpeg.path = "first-ffmpeg"
+    ffmpeg.__dict__["version"] = "first"
+    monkeypatch.setattr(
+        ffmpeg_module.subprocess,
+        "run",
+        lambda _args, capture_output: (_ for _ in ()).throw(FileNotFoundError),
+    )
+
+    with pytest.raises(FFmpegNotFoundError):
+        FFmpeg.setup_ffmpeg_path("missing-ffmpeg")
+
+    assert ffmpeg.path == "first-ffmpeg"
+    assert ffmpeg.version == "first"
 
 
 def make_audio() -> AudioUrlMeta:


### PR DESCRIPTION
## 动机

当前 `FFmpeg` 已支持接收可执行文件路径，但 CLI 和 `yutto serve` 都始终用无参 `FFmpeg()` 初始化。桌面或嵌入式使用方无法可靠指定用户选中的 FFmpeg 二进制，只能修改 PATH，容易与环境检查使用的具体文件不一致。

## 解决方案

- 为普通下载和 `yutto serve` 添加 `--ffmpeg-path`，默认仍为 `ffmpeg`，保持现有 PATH 行为。
- 在两个入口的首次 `FFmpeg` 初始化中传入该路径；后续 native 下载后的 `MediaMuxer` 无参复用同一进程实例，因此合并和转码会使用指定的可执行文件。
- 覆盖 download / serve 的参数解析和路径传递，并更新 CLI/server 文档。

## 类型

- [x] :sparkles: feat: 添加新功能
- [ ] :bug: fix: 修复 bug
- [x] :pencil: docs: 对文档进行修改
- [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
- [ ] :zap: perf: 提高性能的代码修改
- [ ] :technologist: dx: 优化开发体验
- [ ] :hammer: workflow: 工作流变动
- [ ] :label: types: 类型声明修改
- [ ] :construction: wip: 工作正在进行中
- [x] :white_check_mark: test: 测试用例添加及修改
- [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
- [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
- [ ] :question: chore: 其它不涉及源码以及测试的修改
- [ ] :arrow_up: deps: 依赖项修改
- [ ] :bookmark: release: 发布新版本

