### PR TITLE
🐛 fix: align multi-video progress bars

### DIFF
--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from yutto.utils.console.colorful import Color, Style
 
 _PROGRESS_LABEL_WIDTH = 20
+_MIN_PROGRESS_BAR_WIDTH = 10
+_PROGRESS_DETAILS_WIDTH = 40
 
 
 def _render_bar(
@@ -136,8 +138,13 @@ class CliApplicationEventRenderer:
         buffered_color: Color = "red" if progress.is_congested else "yellow"
         buffered_bytes = min(max(progress.buffered_bytes, 0), progress.current)
         committed_bytes = progress.current - buffered_bytes
-        label_prefix = f"{_fit_label(progress.item, _PROGRESS_LABEL_WIDTH)} " if progress.item is not None else ""
-        bar_width = min(get_terminal_size()[0] - 40 - get_string_width(label_prefix), 50)
+        terminal_width = get_terminal_size()[0]
+        label_width = min(
+            _PROGRESS_LABEL_WIDTH,
+            max(1, terminal_width - _PROGRESS_DETAILS_WIDTH - _MIN_PROGRESS_BAR_WIDTH - 1),
+        )
+        label_prefix = f"{_fit_label(progress.item, label_width)} " if progress.item is not None else ""
+        bar_width = min(terminal_width - _PROGRESS_DETAILS_WIDTH - get_string_width(label_prefix), 50)
         bar = (
             _render_bar(
                 committed_bytes,
@@ -147,7 +154,7 @@ class CliApplicationEventRenderer:
                 buffered_color,
                 bar_width,
             )
-            if bar_width >= 10 and progress.total > 0
+            if bar_width >= _MIN_PROGRESS_BAR_WIDTH and progress.total > 0
             else ""
         )
         speed_color: Color = "green" if is_fast else "cyan"

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -21,6 +21,8 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     from yutto.utils.console.colorful import Color, Style
 
+_PROGRESS_LABEL_WIDTH = 20
+
 
 def _render_bar(
     committed: int,
@@ -134,8 +136,7 @@ class CliApplicationEventRenderer:
         buffered_color: Color = "red" if progress.is_congested else "yellow"
         buffered_bytes = min(max(progress.buffered_bytes, 0), progress.current)
         committed_bytes = progress.current - buffered_bytes
-        label = _truncate_label(progress.item, 20)
-        label_prefix = f"{label} " if label else ""
+        label_prefix = f"{_fit_label(progress.item, _PROGRESS_LABEL_WIDTH)} " if progress.item is not None else ""
         bar_width = min(get_terminal_size()[0] - 40 - get_string_width(label_prefix), 50)
         bar = (
             _render_bar(
@@ -202,3 +203,8 @@ def _truncate_label(item: str | None, max_width: int) -> str:
         characters.append(character)
         current += width
     return "".join(characters) + suffix
+
+
+def _fit_label(item: str, width: int) -> str:
+    label = _truncate_label(item, width)
+    return label + " " * max(0, width - get_string_width(label))

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from yutto.utils.console.colorful import Color, Style
 
 _PROGRESS_LABEL_WIDTH = 20
-_MIN_PROGRESS_BAR_WIDTH = 10
 _PROGRESS_DETAILS_WIDTH = 40
 
 
@@ -139,12 +138,14 @@ class CliApplicationEventRenderer:
         buffered_bytes = min(max(progress.buffered_bytes, 0), progress.current)
         committed_bytes = progress.current - buffered_bytes
         terminal_width = get_terminal_size()[0]
-        label_width = min(
-            _PROGRESS_LABEL_WIDTH,
-            max(1, terminal_width - _PROGRESS_DETAILS_WIDTH - _MIN_PROGRESS_BAR_WIDTH - 1),
-        )
-        label_prefix = f"{_fit_label(progress.item, label_width)} " if progress.item is not None else ""
-        bar_width = min(terminal_width - _PROGRESS_DETAILS_WIDTH - get_string_width(label_prefix), 50)
+        available_width = max(0, terminal_width - _PROGRESS_DETAILS_WIDTH)
+        if progress.item is None:
+            label_prefix = ""
+            bar_width = min(available_width, 50)
+        else:
+            label_width = min(_PROGRESS_LABEL_WIDTH, max(0, available_width - 1))
+            label_prefix = f"{_fit_label(progress.item, label_width)} " if label_width > 0 else ""
+            bar_width = min(max(0, available_width - _PROGRESS_LABEL_WIDTH - 1), 50)
         bar = (
             _render_bar(
                 committed_bytes,
@@ -154,7 +155,7 @@ class CliApplicationEventRenderer:
                 buffered_color,
                 bar_width,
             )
-            if bar_width >= _MIN_PROGRESS_BAR_WIDTH and progress.total > 0
+            if bar_width > 0 and progress.total > 0
             else ""
         )
         speed_color: Color = "green" if is_fast else "cyan"

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 PROGRESS_BAR_MIN_WIDTH = 10
 PROGRESS_LABEL_MAX_WIDTH = 20
 PROGRESS_LABEL_MIN_WIDTH = 10
-PROGRESS_SIZE_WIDTH = 13
-PROGRESS_SPEED_WIDTH = 15
+PROGRESS_SIZE_MIN_WIDTH = 10
+PROGRESS_SPEED_MIN_WIDTH = 12
 
 
 def _render_bar(
@@ -143,9 +143,9 @@ class CliApplicationEventRenderer:
         speed_color: Color = "green" if is_fast else "cyan"
         speed_style: list[Style] | None = ["bold"] if is_fast else None
         speed_suffix = "/⚡" if is_fast else "/s"
-        current_text = f"{size_format(progress.current):>{PROGRESS_SIZE_WIDTH}}"
-        total_text = f"{size_format(progress.total):>{PROGRESS_SIZE_WIDTH}}"
-        speed_text = f"{size_format(progress.speed_per_second) + speed_suffix:>{PROGRESS_SPEED_WIDTH}}"
+        current_text = f"{size_format(progress.current):>{PROGRESS_SIZE_MIN_WIDTH}}"
+        total_text = f"{size_format(progress.total):>{PROGRESS_SIZE_MIN_WIDTH}}"
+        speed_text = f"{size_format(progress.speed_per_second) + speed_suffix:>{PROGRESS_SPEED_MIN_WIDTH}}"
         stats_text = f"{current_text}/{total_text} {speed_text}  "
         rendered_stats = (
             f"{current_text}/{total_text} {colored_string(speed_text, fore=speed_color, style=speed_style)}  "

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -21,10 +21,10 @@ from yutto.utils.console.logger import Badge, Logger
 if TYPE_CHECKING:
     from yutto.utils.console.colorful import Color, Style
 
-_PROGRESS_LABEL_WIDTH = 20
-_MIN_PROGRESS_BAR_WIDTH = 10
-_MIN_PROGRESS_LABEL_WIDTH = 10
-_PROGRESS_DETAILS_WIDTH = 40
+PROGRESS_BAR_MIN_WIDTH = 10
+PROGRESS_LABEL_MAX_WIDTH = 20
+PROGRESS_LABEL_MIN_WIDTH = 10
+PROGRESS_STATS_RESERVED_WIDTH = 40
 
 
 def _render_bar(
@@ -140,16 +140,16 @@ class CliApplicationEventRenderer:
         buffered_bytes = min(max(progress.buffered_bytes, 0), progress.current)
         committed_bytes = progress.current - buffered_bytes
         terminal_width = get_terminal_size()[0]
-        available_width = max(0, terminal_width - _PROGRESS_DETAILS_WIDTH)
+        available_width = max(0, terminal_width - PROGRESS_STATS_RESERVED_WIDTH)
         if progress.item is None:
             label_prefix = ""
             bar_width = min(available_width, 50)
         else:
-            label_width = min(_PROGRESS_LABEL_WIDTH, max(0, available_width - 1))
+            label_width = min(PROGRESS_LABEL_MAX_WIDTH, max(0, available_width - 1))
             label_prefix = (
-                f"{_fit_label(progress.item, label_width)} " if label_width >= _MIN_PROGRESS_LABEL_WIDTH else ""
+                f"{_fit_label(progress.item, label_width)} " if label_width >= PROGRESS_LABEL_MIN_WIDTH else ""
             )
-            bar_width = min(max(0, available_width - _PROGRESS_LABEL_WIDTH - 1), 50)
+            bar_width = min(max(0, available_width - PROGRESS_LABEL_MAX_WIDTH - 1), 50)
         bar = (
             _render_bar(
                 committed_bytes,
@@ -159,7 +159,7 @@ class CliApplicationEventRenderer:
                 buffered_color,
                 bar_width,
             )
-            if bar_width >= _MIN_PROGRESS_BAR_WIDTH and progress.total > 0
+            if bar_width >= PROGRESS_BAR_MIN_WIDTH and progress.total > 0
             else ""
         )
         speed_color: Color = "green" if is_fast else "cyan"

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from yutto.utils.console.colorful import Color, Style
 
 _PROGRESS_LABEL_WIDTH = 20
+_MIN_PROGRESS_BAR_WIDTH = 10
 _MIN_PROGRESS_LABEL_WIDTH = 10
 _PROGRESS_DETAILS_WIDTH = 40
 
@@ -158,7 +159,7 @@ class CliApplicationEventRenderer:
                 buffered_color,
                 bar_width,
             )
-            if bar_width > 0 and progress.total > 0
+            if bar_width >= _MIN_PROGRESS_BAR_WIDTH and progress.total > 0
             else ""
         )
         speed_color: Color = "green" if is_fast else "cyan"

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from yutto.utils.console.colorful import Color, Style
 
 _PROGRESS_LABEL_WIDTH = 20
+_MIN_PROGRESS_LABEL_WIDTH = 10
 _PROGRESS_DETAILS_WIDTH = 40
 
 
@@ -144,7 +145,9 @@ class CliApplicationEventRenderer:
             bar_width = min(available_width, 50)
         else:
             label_width = min(_PROGRESS_LABEL_WIDTH, max(0, available_width - 1))
-            label_prefix = f"{_fit_label(progress.item, label_width)} " if label_width > 0 else ""
+            label_prefix = (
+                f"{_fit_label(progress.item, label_width)} " if label_width >= _MIN_PROGRESS_LABEL_WIDTH else ""
+            )
             bar_width = min(max(0, available_width - _PROGRESS_LABEL_WIDTH - 1), 50)
         bar = (
             _render_bar(

--- a/src/yutto/cli/event_renderer.py
+++ b/src/yutto/cli/event_renderer.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 PROGRESS_BAR_MIN_WIDTH = 10
 PROGRESS_LABEL_MAX_WIDTH = 20
 PROGRESS_LABEL_MIN_WIDTH = 10
-PROGRESS_STATS_RESERVED_WIDTH = 40
+PROGRESS_SIZE_WIDTH = 13
+PROGRESS_SPEED_WIDTH = 15
 
 
 def _render_bar(
@@ -139,17 +140,27 @@ class CliApplicationEventRenderer:
         buffered_color: Color = "red" if progress.is_congested else "yellow"
         buffered_bytes = min(max(progress.buffered_bytes, 0), progress.current)
         committed_bytes = progress.current - buffered_bytes
+        speed_color: Color = "green" if is_fast else "cyan"
+        speed_style: list[Style] | None = ["bold"] if is_fast else None
+        speed_suffix = "/⚡" if is_fast else "/s"
+        current_text = f"{size_format(progress.current):>{PROGRESS_SIZE_WIDTH}}"
+        total_text = f"{size_format(progress.total):>{PROGRESS_SIZE_WIDTH}}"
+        speed_text = f"{size_format(progress.speed_per_second) + speed_suffix:>{PROGRESS_SPEED_WIDTH}}"
+        stats_text = f"{current_text}/{total_text} {speed_text}  "
+        rendered_stats = (
+            f"{current_text}/{total_text} {colored_string(speed_text, fore=speed_color, style=speed_style)}  "
+        )
         terminal_width = get_terminal_size()[0]
-        available_width = max(0, terminal_width - PROGRESS_STATS_RESERVED_WIDTH)
+        available_width = max(0, terminal_width - get_string_width(stats_text))
         if progress.item is None:
             label_prefix = ""
-            bar_width = min(available_width, 50)
+            bar_width = min(max(0, available_width - 1), 50)
         else:
             label_width = min(PROGRESS_LABEL_MAX_WIDTH, max(0, available_width - 1))
             label_prefix = (
                 f"{_fit_label(progress.item, label_width)} " if label_width >= PROGRESS_LABEL_MIN_WIDTH else ""
             )
-            bar_width = min(max(0, available_width - PROGRESS_LABEL_MAX_WIDTH - 1), 50)
+            bar_width = min(max(0, available_width - PROGRESS_LABEL_MAX_WIDTH - 2), 50)
         bar = (
             _render_bar(
                 committed_bytes,
@@ -162,20 +173,7 @@ class CliApplicationEventRenderer:
             if bar_width >= PROGRESS_BAR_MIN_WIDTH and progress.total > 0
             else ""
         )
-        speed_color: Color = "green" if is_fast else "cyan"
-        speed_style: list[Style] | None = ["bold"] if is_fast else None
-        speed_suffix = "/⚡" if is_fast else "/s"
-        rendered = "{}{}{:>10}/{:>10} {:>12}  ".format(
-            label_prefix,
-            bar + " " if bar else "",
-            size_format(progress.current),
-            size_format(progress.total),
-            colored_string(
-                size_format(progress.speed_per_second) + speed_suffix,
-                fore=speed_color,
-                style=speed_style,
-            ),
-        )
+        rendered = f"{label_prefix}{bar + ' ' if bar else ''}{rendered_stats}"
         if progress.item is None:
             Logger.status.set(rendered)
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -325,7 +325,7 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
     monkeypatch.setattr(renderer_module.Logger.status, "set_line", lambda _key, text: rendered.append(text))
 
     renderer = renderer_module.CliApplicationEventRenderer()
-    for title in ("第94话 厉天行与皇帝", "第95话 皇帝“驾崩”", "第96话", "这是一个超过固定列宽的标题"):
+    for title in ("短标题", "中等长度标题", "这是一个普通长度标题", "这是一个超过固定列宽的占位标题"):
         renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item=title))
 
     assert bar_widths == [39, 39, 39, 39]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,10 +333,26 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
     assert "…" in rendered[-1]
 
 
-def test_progress_renderer_preserves_bar_on_narrow_terminal(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    ("terminal_width", "expected_label_width", "expected_bar_width"),
+    [
+        (100, 20, 39),
+        (70, 20, 9),
+        (61, 20, 0),
+        (60, 19, 0),
+        (42, 1, 0),
+        (41, 0, 0),
+    ],
+)
+def test_progress_renderer_compresses_bar_before_label(
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_width: int,
+    expected_label_width: int,
+    expected_bar_width: int,
+):
     rendered: list[str] = []
     bar_widths: list[int] = []
-    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (70, 24))
+    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (terminal_width, 24))
     monkeypatch.setattr(
         renderer_module,
         "_render_bar",
@@ -347,8 +363,9 @@ def test_progress_renderer_preserves_bar_on_narrow_terminal(monkeypatch: pytest.
     renderer = renderer_module.CliApplicationEventRenderer()
     renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item="短标题"))
 
-    assert bar_widths == [10]
-    assert "bar" in rendered[0]
+    expected_label = f"{renderer_module._fit_label('短标题', expected_label_width)} " if expected_label_width else ""
+    assert rendered[0].startswith(expected_label)
+    assert bar_widths == ([expected_bar_width] if expected_bar_width else [])
 
 
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -284,8 +284,8 @@ def test_progress_renderer_turns_only_buffered_segment_red(monkeypatch: pytest.M
     )
 
     assert rendered_bars == [
-        (512, 512, 2048, "cyan", "yellow", 40),
-        (512, 512, 2048, "cyan", "red", 40),
+        (512, 512, 2048, "cyan", "yellow", 34),
+        (512, 512, 2048, "cyan", "red", 34),
     ]
 
 
@@ -328,7 +328,7 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
     for title in ("短标题", "中等长度标题", "这是一个普通长度标题", "这是一个超过固定列宽的占位标题"):
         renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item=title))
 
-    assert bar_widths == [39, 39, 39, 39]
+    assert bar_widths == [33, 33, 33, 33]
     assert [renderer_module.get_string_width(line[: line.index("bar")]) for line in rendered] == [21, 21, 21, 21]
     assert "…" in rendered[-1]
 
@@ -336,14 +336,14 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
 @pytest.mark.parametrize(
     ("terminal_width", "expected_label_width", "expected_bar_width"),
     [
-        (100, 20, 39),
-        (71, 20, 10),
-        (70, 20, 0),
-        (61, 20, 0),
-        (60, 19, 0),
-        (51, 10, 0),
-        (50, 0, 0),
-        (41, 0, 0),
+        (100, 20, 33),
+        (77, 20, 10),
+        (76, 20, 0),
+        (66, 20, 0),
+        (65, 19, 0),
+        (56, 10, 0),
+        (55, 0, 0),
+        (46, 0, 0),
     ],
 )
 def test_progress_renderer_compresses_bar_before_label(
@@ -370,8 +370,29 @@ def test_progress_renderer_compresses_bar_before_label(
         expected_label = f"{renderer_module._fit_label('短标题', expected_label_width)} "
         assert rendered[0].startswith(expected_label)
     else:
-        assert rendered[0].startswith("1234567890/")
+        expected_stats = f"{'1234567890':>{renderer_module.PROGRESS_SIZE_WIDTH}}/"
+        assert rendered[0].startswith(expected_stats)
     assert bar_widths == ([expected_bar_width] if expected_bar_width else [])
+
+
+def test_progress_renderer_keeps_stats_width_fixed_across_rows(monkeypatch: pytest.MonkeyPatch):
+    rendered: list[str] = []
+    bar_widths: list[int] = []
+    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (112, 24))
+    monkeypatch.setattr(
+        renderer_module,
+        "_render_bar",
+        lambda *args: bar_widths.append(args[-1]) or "━" * args[-1],
+    )
+    monkeypatch.setattr(renderer_module, "colored_string", lambda text, **_: text)
+    monkeypatch.setattr(renderer_module.Logger.status, "set_line", lambda _key, text: rendered.append(text))
+
+    renderer = renderer_module.CliApplicationEventRenderer()
+    renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item="短标题"))
+    renderer.emit(DownloadProgress(current=1023, total=1023, speed_per_second=1023, item="另一个标题"))
+
+    assert bar_widths == [45, 45]
+    assert [renderer_module.get_string_width(line) for line in rendered] == [112, 112]
 
 
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,6 +333,24 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
     assert "…" in rendered[-1]
 
 
+def test_progress_renderer_preserves_bar_on_narrow_terminal(monkeypatch: pytest.MonkeyPatch):
+    rendered: list[str] = []
+    bar_widths: list[int] = []
+    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (70, 24))
+    monkeypatch.setattr(
+        renderer_module,
+        "_render_bar",
+        lambda *args: bar_widths.append(args[-1]) or "bar",
+    )
+    monkeypatch.setattr(renderer_module.Logger.status, "set_line", lambda _key, text: rendered.append(text))
+
+    renderer = renderer_module.CliApplicationEventRenderer()
+    renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item="短标题"))
+
+    assert bar_widths == [10]
+    assert "bar" in rendered[0]
+
+
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):
     output: list[tuple[str, object]] = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,7 +337,8 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
     ("terminal_width", "expected_label_width", "expected_bar_width"),
     [
         (100, 20, 39),
-        (70, 20, 9),
+        (71, 20, 10),
+        (70, 20, 0),
         (61, 20, 0),
         (60, 19, 0),
         (51, 10, 0),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,6 +313,26 @@ def test_progress_labels_are_truncated_by_terminal_width():
     assert renderer_module._truncate_label("一二三四五六", 7) == "一二三…"
 
 
+def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: pytest.MonkeyPatch):
+    rendered: list[str] = []
+    bar_widths: list[int] = []
+    monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (100, 24))
+    monkeypatch.setattr(
+        renderer_module,
+        "_render_bar",
+        lambda *args: bar_widths.append(args[-1]) or "bar",
+    )
+    monkeypatch.setattr(renderer_module.Logger.status, "set_line", lambda _key, text: rendered.append(text))
+
+    renderer = renderer_module.CliApplicationEventRenderer()
+    for title in ("第94话 厉天行与皇帝", "第95话 皇帝“驾崩”", "第96话", "这是一个超过固定列宽的标题"):
+        renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item=title))
+
+    assert bar_widths == [39, 39, 39, 39]
+    assert [renderer_module.get_string_width(line[: line.index("bar")]) for line in rendered] == [21, 21, 21, 21]
+    assert "…" in rendered[-1]
+
+
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):
     output: list[tuple[str, object]] = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -284,8 +284,8 @@ def test_progress_renderer_turns_only_buffered_segment_red(monkeypatch: pytest.M
     )
 
     assert rendered_bars == [
-        (512, 512, 2048, "cyan", "yellow", 34),
-        (512, 512, 2048, "cyan", "red", 34),
+        (512, 512, 2048, "cyan", "yellow", 43),
+        (512, 512, 2048, "cyan", "red", 43),
     ]
 
 
@@ -328,7 +328,7 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
     for title in ("短标题", "中等长度标题", "这是一个普通长度标题", "这是一个超过固定列宽的占位标题"):
         renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item=title))
 
-    assert bar_widths == [33, 33, 33, 33]
+    assert bar_widths == [42, 42, 42, 42]
     assert [renderer_module.get_string_width(line[: line.index("bar")]) for line in rendered] == [21, 21, 21, 21]
     assert "…" in rendered[-1]
 
@@ -336,14 +336,14 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
 @pytest.mark.parametrize(
     ("terminal_width", "expected_label_width", "expected_bar_width"),
     [
-        (100, 20, 33),
-        (77, 20, 10),
-        (76, 20, 0),
-        (66, 20, 0),
-        (65, 19, 0),
-        (56, 10, 0),
-        (55, 0, 0),
+        (100, 20, 42),
+        (68, 20, 10),
+        (67, 20, 0),
+        (57, 20, 0),
+        (56, 19, 0),
+        (47, 10, 0),
         (46, 0, 0),
+        (37, 0, 0),
     ],
 )
 def test_progress_renderer_compresses_bar_before_label(
@@ -370,12 +370,12 @@ def test_progress_renderer_compresses_bar_before_label(
         expected_label = f"{renderer_module._fit_label('短标题', expected_label_width)} "
         assert rendered[0].startswith(expected_label)
     else:
-        expected_stats = f"{'1234567890':>{renderer_module.PROGRESS_SIZE_WIDTH}}/"
+        expected_stats = f"{'1234567890':>{renderer_module.PROGRESS_SIZE_MIN_WIDTH}}/"
         assert rendered[0].startswith(expected_stats)
     assert bar_widths == ([expected_bar_width] if expected_bar_width else [])
 
 
-def test_progress_renderer_keeps_stats_width_fixed_across_rows(monkeypatch: pytest.MonkeyPatch):
+def test_progress_renderer_avoids_wrapping_for_wide_stats(monkeypatch: pytest.MonkeyPatch):
     rendered: list[str] = []
     bar_widths: list[int] = []
     monkeypatch.setattr(renderer_module, "get_terminal_size", lambda: (112, 24))
@@ -391,8 +391,8 @@ def test_progress_renderer_keeps_stats_width_fixed_across_rows(monkeypatch: pyte
     renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item="短标题"))
     renderer.emit(DownloadProgress(current=1023, total=1023, speed_per_second=1023, item="另一个标题"))
 
-    assert bar_widths == [45, 45]
-    assert [renderer_module.get_string_width(line) for line in rendered] == [112, 112]
+    assert bar_widths == [50, 45]
+    assert [renderer_module.get_string_width(line) for line in rendered] == [108, 112]
 
 
 def test_run_download_scopes_report_renderer_and_cleans_up_on_cancel(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -340,7 +340,8 @@ def test_progress_renderer_aligns_bars_for_different_label_widths(monkeypatch: p
         (70, 20, 9),
         (61, 20, 0),
         (60, 19, 0),
-        (42, 1, 0),
+        (51, 10, 0),
+        (50, 0, 0),
         (41, 0, 0),
     ],
 )
@@ -359,12 +360,16 @@ def test_progress_renderer_compresses_bar_before_label(
         lambda *args: bar_widths.append(args[-1]) or "bar",
     )
     monkeypatch.setattr(renderer_module.Logger.status, "set_line", lambda _key, text: rendered.append(text))
+    monkeypatch.setattr(renderer_module, "size_format", lambda _: "1234567890")
 
     renderer = renderer_module.CliApplicationEventRenderer()
     renderer.emit(DownloadProgress(current=1, total=2, speed_per_second=3, item="短标题"))
 
-    expected_label = f"{renderer_module._fit_label('短标题', expected_label_width)} " if expected_label_width else ""
-    assert rendered[0].startswith(expected_label)
+    if expected_label_width:
+        expected_label = f"{renderer_module._fit_label('短标题', expected_label_width)} "
+        assert rendered[0].startswith(expected_label)
+    else:
+        assert rendered[0].startswith("1234567890/")
     assert bar_widths == ([expected_bar_width] if expected_bar_width else [])
 
 


### PR DESCRIPTION
## 动机

多视频并发下载时，标题长度不同会导致每行进度条从不同列开始，影响可读性。根因是标题虽然限制了最大显示宽度，但短标题没有补齐到统一列宽。

## 解决方案

- 多视频进度标题列优先保持 20 个终端显示列；终端变窄时先将进度条压缩到 10 列，空间不足 10 列时隐藏进度条，再压缩标题列
- 短标题右侧补空格，长标题按中英文实际显示宽度截断并追加省略号；label 可用宽度低于 10 列时连同分隔空格隐藏
- current/total 保留原有 10 列、speed 保留原有 12 列的紧凑格式；仅当本行 stats 实际超宽时缩短该行进度条以避免换行
- 添加长短中文标题混排的回归测试，确保进度条起始列和宽度一致

## 类型

- [ ] :sparkles: feat: 添加新功能
- [x] :bug: fix: 修复 bug
- [ ] :pencil: docs: 对文档进行修改
- [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
- [ ] :zap: perf: 提高性能的代码修改
- [ ] :technologist: dx: 优化开发体验
- [ ] :hammer: workflow: 工作流变动
- [ ] :label: types: 类型声明修改
- [ ] :construction: wip: 工作正在进行中
- [x] :white_check_mark: test: 测试用例添加及修改
- [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
- [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
- [ ] :question: chore: 其它不涉及源码以及测试的修改
- [ ] :arrow_up: deps: 依赖项修改
- [ ] :bookmark: release: 发布新版本

## 验证

- `just fmt`
- `just lint`
- `uv run pytest -q tests/test_cli.py tests/test_utils/test_status_bar.py`（30 passed）