### PR TITLE
⚡️ perf: batch Haya file commits

### DIFF
--- a/rust/crates/haya/src/buffer.rs
+++ b/rust/crates/haya/src/buffer.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 
-use crate::DownloadError;
+use crate::{CommitBatch, DownloadError};
 
 #[derive(Debug)]
 pub(crate) struct OrderedBuffer {
@@ -72,21 +72,49 @@ impl OrderedBuffer {
         Ok(())
     }
 
-    pub fn pop_contiguous(&mut self) -> Vec<(u64, Bytes)> {
-        let mut pages = Vec::new();
+    pub fn pop_contiguous_batch(
+        &mut self,
+        max_bytes: usize,
+    ) -> Result<Option<CommitBatch>, DownloadError> {
+        if max_bytes == 0 {
+            return Err(DownloadError::Buffer(
+                "commit batch size must be positive".into(),
+            ));
+        }
+        let first_offset = self
+            .origin
+            .checked_add(
+                self.head
+                    .checked_mul(self.page_size as u64)
+                    .ok_or_else(|| DownloadError::Buffer("page offset overflow".into()))?,
+            )
+            .ok_or_else(|| DownloadError::Buffer("page offset overflow".into()))?;
+        let mut chunks = Vec::new();
+        let mut len = 0_usize;
         loop {
             let slot = self.head as usize % self.slots.len();
-            let Some(data) = self.slots[slot].take() else {
+            let Some(data) = self.slots[slot].as_ref() else {
                 break;
             };
-            let offset = self
-                .origin
-                .saturating_add(self.head.saturating_mul(self.page_size as u64));
+            if !chunks.is_empty() && len.saturating_add(data.len()) > max_bytes {
+                break;
+            }
+            let data = self.slots[slot]
+                .take()
+                .expect("the contiguous slot was checked above");
+            len = len
+                .checked_add(data.len())
+                .ok_or_else(|| DownloadError::Buffer("commit batch length overflow".into()))?;
             self.head += 1;
             self.ready -= 1;
-            pages.push((offset, data));
+            chunks.push(data);
         }
-        pages
+        if chunks.is_empty() {
+            return Ok(None);
+        }
+        CommitBatch::new(first_offset, chunks)
+            .map(Some)
+            .map_err(Into::into)
     }
 }
 
@@ -100,19 +128,65 @@ mod tests {
         buffer
             .insert(104, Bytes::from_static(b"efgh"))
             .expect("second page fits");
-        assert!(buffer.pop_contiguous().is_empty());
+        assert!(
+            buffer
+                .pop_contiguous_batch(usize::MAX)
+                .expect("valid batch")
+                .is_none()
+        );
 
         buffer
             .insert(100, Bytes::from_static(b"abcd"))
             .expect("first page fits");
+        let batch = buffer
+            .pop_contiguous_batch(usize::MAX)
+            .expect("valid batch")
+            .expect("contiguous batch");
+        assert_eq!(batch.offset(), 100);
         assert_eq!(
-            buffer.pop_contiguous(),
-            [
-                (100, Bytes::from_static(b"abcd")),
-                (104, Bytes::from_static(b"efgh")),
-            ]
+            batch.chunks(),
+            [Bytes::from_static(b"abcd"), Bytes::from_static(b"efgh")]
         );
         assert_eq!(buffer.ready_pages(), 0);
         assert_eq!(buffer.window_end_offset(), 120);
+    }
+
+    #[test]
+    fn releases_contiguous_pages_in_bounded_batches() {
+        let mut buffer = OrderedBuffer::new(100, 4, 5).expect("valid buffer");
+        for (offset, bytes) in [
+            (100, &b"aaaa"[..]),
+            (104, &b"bbbb"[..]),
+            (108, &b"cccc"[..]),
+            (112, &b"dddd"[..]),
+            (116, &b"e"[..]),
+        ] {
+            buffer
+                .insert(offset, Bytes::copy_from_slice(bytes))
+                .expect("page fits");
+        }
+
+        let first = buffer
+            .pop_contiguous_batch(8)
+            .expect("valid batch")
+            .expect("first batch");
+        let second = buffer
+            .pop_contiguous_batch(8)
+            .expect("valid batch")
+            .expect("second batch");
+        let third = buffer
+            .pop_contiguous_batch(8)
+            .expect("valid batch")
+            .expect("third batch");
+
+        assert_eq!((first.offset(), first.len()), (100, 8));
+        assert_eq!((second.offset(), second.len()), (108, 8));
+        assert_eq!((third.offset(), third.len()), (116, 1));
+        assert!(
+            buffer
+                .pop_contiguous_batch(8)
+                .expect("valid batch")
+                .is_none()
+        );
     }
 }

--- a/rust/crates/haya/src/downloader.rs
+++ b/rust/crates/haya/src/downloader.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, num::NonZeroUsize, sync::Arc};
 
 use bytes::{Bytes, BytesMut};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
@@ -197,9 +197,14 @@ impl Downloader {
                     pool.record_success(completed.source);
                     received = received.saturating_add(bytes.len() as u64);
                     insert_range(&mut ring, self.spec.page_size, completed.work.range, bytes)?;
-                    for (offset, data) in ring.pop_contiguous() {
-                        let end = offset.saturating_add(data.len() as u64);
-                        if let Err(error) = self.sink.append(offset, data).await {
+                    let batch_size = self
+                        .sink
+                        .append_batch_size_hint()
+                        .map(NonZeroUsize::get)
+                        .unwrap_or(self.spec.page_size);
+                    while let Some(batch) = ring.pop_contiguous_batch(batch_size)? {
+                        let end = batch.end_offset();
+                        if let Err(error) = self.sink.append_batch(batch).await {
                             return self.fail_after_flush(error.into()).await;
                         }
                         committed = end;
@@ -383,8 +388,11 @@ mod tests {
         )
         .expect("range fits");
 
-        let pages = ring.pop_contiguous();
-        assert_eq!(pages[0].1.as_ptr(), block_start);
-        assert_eq!(pages[1].1.as_ptr(), block_start.wrapping_add(4));
+        let batch = ring
+            .pop_contiguous_batch(8)
+            .expect("valid batch")
+            .expect("contiguous batch");
+        assert_eq!(batch.chunks()[0].as_ptr(), block_start);
+        assert_eq!(batch.chunks()[1].as_ptr(), block_start.wrapping_add(4));
     }
 }

--- a/rust/crates/haya/src/file.rs
+++ b/rust/crates/haya/src/file.rs
@@ -1,14 +1,16 @@
-use std::path::Path;
+use std::{io::IoSlice, num::NonZeroUsize, path::Path};
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncSeekExt, AsyncWriteExt, SeekFrom},
     sync::Mutex,
 };
 
-use crate::{CommitSink, SinkError};
+use crate::{CommitBatch, CommitSink, SinkError};
+
+const FILE_APPEND_BATCH_SIZE: usize = 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FileOpenMode {
@@ -30,6 +32,86 @@ struct FileState {
     committed: u64,
     closed: bool,
     poisoned: bool,
+    #[cfg(test)]
+    fail_write_after_chunks: Option<usize>,
+    #[cfg(test)]
+    fail_flush: bool,
+}
+
+struct ChunkCursor<'a> {
+    chunks: &'a [Bytes],
+    chunk_index: usize,
+    chunk_offset: usize,
+    remaining: usize,
+}
+
+impl<'a> ChunkCursor<'a> {
+    fn new(chunks: &'a [Bytes]) -> Self {
+        let remaining = chunks.iter().fold(0_usize, |total, chunk| {
+            total
+                .checked_add(chunk.len())
+                .expect("CommitBatch validated its total length")
+        });
+        Self {
+            chunks,
+            chunk_index: 0,
+            chunk_offset: 0,
+            remaining,
+        }
+    }
+}
+
+impl Buf for ChunkCursor<'_> {
+    fn remaining(&self) -> usize {
+        self.remaining
+    }
+
+    fn chunk(&self) -> &[u8] {
+        self.chunks
+            .get(self.chunk_index)
+            .map_or(&[], |chunk| &chunk[self.chunk_offset..])
+    }
+
+    fn advance(&mut self, mut count: usize) {
+        assert!(count <= self.remaining, "cannot advance beyond the batch");
+        self.remaining -= count;
+        while count > 0 {
+            let available = self.chunks[self.chunk_index].len() - self.chunk_offset;
+            if count < available {
+                self.chunk_offset += count;
+                return;
+            }
+            count -= available;
+            self.chunk_index += 1;
+            self.chunk_offset = 0;
+        }
+    }
+
+    fn chunks_vectored<'a>(&'a self, destination: &mut [IoSlice<'a>]) -> usize {
+        if destination.is_empty() {
+            return 0;
+        }
+        let Some((first, rest)) = self
+            .chunks
+            .get(self.chunk_index..)
+            .and_then(|chunks| chunks.split_first())
+        else {
+            return 0;
+        };
+        let mut written = 0;
+        if let Some(slot) = destination.get_mut(written) {
+            *slot = IoSlice::new(&first[self.chunk_offset..]);
+            written += 1;
+        }
+        for chunk in rest {
+            let Some(slot) = destination.get_mut(written) else {
+                break;
+            };
+            *slot = IoSlice::new(chunk);
+            written += 1;
+        }
+        written
+    }
 }
 
 impl FileSink {
@@ -63,6 +145,10 @@ impl FileSink {
                 committed,
                 closed: false,
                 poisoned: false,
+                #[cfg(test)]
+                fail_write_after_chunks: None,
+                #[cfg(test)]
+                fail_flush: false,
             }),
         })
     }
@@ -79,6 +165,31 @@ impl CommitSink for FileSink {
     }
 
     async fn append(&self, offset: u64, data: Bytes) -> Result<(), SinkError> {
+        if data.is_empty() {
+            let state = self.state.lock().await;
+            if state.closed {
+                return Err(SinkError::new("cannot append to a closed file sink"));
+            }
+            if state.poisoned {
+                return Err(cancelled_append_error());
+            }
+            if offset != state.committed {
+                return Err(SinkError::new(format!(
+                    "append at {offset}, committed offset is {}",
+                    state.committed
+                )));
+            }
+            return Ok(());
+        }
+        let batch = CommitBatch::new(offset, vec![data])?;
+        self.append_batch(batch).await
+    }
+
+    fn append_batch_size_hint(&self) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(FILE_APPEND_BATCH_SIZE)
+    }
+
+    async fn append_batch(&self, batch: CommitBatch) -> Result<(), SinkError> {
         let mut state = self.state.lock().await;
         if state.closed {
             return Err(SinkError::new("cannot append to a closed file sink"));
@@ -86,23 +197,41 @@ impl CommitSink for FileSink {
         if state.poisoned {
             return Err(cancelled_append_error());
         }
-        if offset != state.committed {
+        if batch.offset() != state.committed {
             return Err(SinkError::new(format!(
-                "append at {offset}, committed offset is {}",
+                "append at {}, committed offset is {}",
+                batch.offset(),
                 state.committed
             )));
         }
+        let committed = state.committed;
+        let end_offset = batch.end_offset();
+        #[cfg(test)]
+        let fail_write_after_chunks = state.fail_write_after_chunks;
+        #[cfg(test)]
+        let fail_flush = state.fail_flush;
         state.poisoned = true;
         let file = state.file.as_mut().expect("an open sink retains its file");
         let write_result = async {
-            file.write_all(&data).await?;
+            #[cfg(test)]
+            if let Some(chunk_count) = fail_write_after_chunks {
+                let mut cursor =
+                    ChunkCursor::new(&batch.chunks()[..chunk_count.min(batch.chunks().len())]);
+                file.write_all_buf(&mut cursor).await?;
+                return Err(std::io::Error::other("injected batch write failure"));
+            }
+            let mut cursor = ChunkCursor::new(batch.chunks());
+            file.write_all_buf(&mut cursor).await?;
             // Tokio may report the buffered write's OS error only when the
             // in-flight blocking operation is polled again.
+            #[cfg(test)]
+            if fail_flush {
+                return Err(std::io::Error::other("injected batch flush failure"));
+            }
             file.flush().await
         }
         .await;
         if let Err(write_error) = write_result {
-            let committed = state.committed;
             let file = state
                 .file
                 .as_mut()
@@ -125,7 +254,7 @@ impl CommitSink for FileSink {
                 "failed to write output file: {write_error}"
             )));
         }
-        state.committed += data.len() as u64;
+        state.committed = end_offset;
         state.poisoned = false;
         Ok(())
     }
@@ -184,6 +313,8 @@ mod tests {
                 committed: 0,
                 closed: false,
                 poisoned: false,
+                fail_write_after_chunks: None,
+                fail_flush: false,
             }),
         };
 
@@ -233,5 +364,60 @@ mod tests {
         assert!(sink.append(0, Bytes::from_static(b"tail")).await.is_err());
         assert!(sink.close().await.is_err());
         assert!(sink.state.lock().await.file.is_none());
+    }
+
+    #[tokio::test]
+    async fn rolls_back_a_partially_written_batch_and_allows_retry() {
+        let temporary = tempfile::NamedTempFile::new().expect("temporary file");
+        let sink = FileSink::open(temporary.path(), FileOpenMode::Overwrite)
+            .await
+            .expect("open file sink");
+        sink.state.lock().await.fail_write_after_chunks = Some(1);
+
+        let failed = sink
+            .append_batch(
+                CommitBatch::new(
+                    0,
+                    vec![Bytes::from_static(b"first"), Bytes::from_static(b"second")],
+                )
+                .expect("valid batch"),
+            )
+            .await;
+
+        assert!(failed.is_err());
+        assert_eq!(sink.committed_offset().await.expect("offset"), 0);
+        assert!(
+            std::fs::read(temporary.path())
+                .expect("read file")
+                .is_empty()
+        );
+
+        sink.state.lock().await.fail_write_after_chunks = None;
+        sink.append(0, Bytes::from_static(b"retry"))
+            .await
+            .expect("retry succeeds");
+        assert_eq!(
+            std::fs::read(temporary.path()).expect("read file"),
+            b"retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn rolls_back_a_batch_when_its_flush_fails() {
+        let temporary = tempfile::NamedTempFile::new().expect("temporary file");
+        let sink = FileSink::open(temporary.path(), FileOpenMode::Overwrite)
+            .await
+            .expect("open file sink");
+        sink.state.lock().await.fail_flush = true;
+
+        let failed = sink.append(0, Bytes::from_static(b"uncommitted")).await;
+
+        assert!(failed.is_err());
+        assert_eq!(sink.committed_offset().await.expect("offset"), 0);
+        assert!(
+            std::fs::read(temporary.path())
+                .expect("read file")
+                .is_empty()
+        );
     }
 }

--- a/rust/crates/haya/src/lib.rs
+++ b/rust/crates/haya/src/lib.rs
@@ -12,5 +12,5 @@ pub use downloader::Downloader;
 pub use error::{DownloadError, SinkError, SourceError, SourceErrorKind};
 pub use event::{DownloadReport, DownloadSnapshot, NullProgressSink, ProgressSink};
 pub use model::{ByteRange, DownloadSpec};
-pub use sink::CommitSink;
+pub use sink::{CommitBatch, CommitSink};
 pub use source::{ByteStream, RangeSource};

--- a/rust/crates/haya/src/sink.rs
+++ b/rust/crates/haya/src/sink.rs
@@ -1,15 +1,94 @@
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 
 use crate::SinkError;
 
+#[derive(Debug)]
+pub struct CommitBatch {
+    offset: u64,
+    chunks: Box<[Bytes]>,
+    len: usize,
+}
+
+impl CommitBatch {
+    pub fn new(offset: u64, chunks: Vec<Bytes>) -> Result<Self, SinkError> {
+        if chunks.is_empty() || chunks.iter().any(Bytes::is_empty) {
+            return Err(SinkError::new(
+                "a commit batch must contain only non-empty chunks",
+            ));
+        }
+        let len = chunks.iter().try_fold(0_usize, |total, chunk| {
+            total
+                .checked_add(chunk.len())
+                .ok_or_else(|| SinkError::new("commit batch length overflow"))
+        })?;
+        let len_u64 =
+            u64::try_from(len).map_err(|_| SinkError::new("commit batch length exceeds u64"))?;
+        offset
+            .checked_add(len_u64)
+            .ok_or_else(|| SinkError::new("commit batch end offset overflow"))?;
+        Ok(Self {
+            offset,
+            chunks: chunks.into_boxed_slice(),
+            len,
+        })
+    }
+
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    pub fn end_offset(&self) -> u64 {
+        self.offset + u64::try_from(self.len).expect("CommitBatch validated its end offset")
+    }
+
+    pub fn chunks(&self) -> &[Bytes] {
+        &self.chunks
+    }
+
+    pub fn into_chunks(self) -> Box<[Bytes]> {
+        self.chunks
+    }
+}
+
 #[async_trait]
 pub trait CommitSink: Send + Sync {
     async fn committed_offset(&self) -> Result<u64, SinkError>;
 
     async fn append(&self, offset: u64, data: Bytes) -> Result<(), SinkError>;
+
+    /// Preferred upper bound for one append batch. The default preserves the
+    /// historical one-page append and cancellation granularity.
+    fn append_batch_size_hint(&self) -> Option<NonZeroUsize> {
+        None
+    }
+
+    /// Appends a contiguous batch. The default implementation may commit a
+    /// prefix before returning an error; sinks can override it with stronger
+    /// transactional behavior.
+    async fn append_batch(&self, batch: CommitBatch) -> Result<(), SinkError> {
+        let mut offset = batch.offset();
+        for chunk in batch.into_chunks() {
+            let chunk_len = u64::try_from(chunk.len())
+                .map_err(|_| SinkError::new("commit batch chunk length exceeds u64"))?;
+            let next_offset = offset
+                .checked_add(chunk_len)
+                .ok_or_else(|| SinkError::new("commit batch end offset overflow"))?;
+            self.append(offset, chunk).await?;
+            offset = next_offset;
+        }
+        Ok(())
+    }
 
     async fn flush(&self) -> Result<(), SinkError>;
 
@@ -19,3 +98,15 @@ pub trait CommitSink: Send + Sync {
 }
 
 pub(crate) type SharedSink = Arc<dyn CommitSink>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_chunks_and_offset_overflow() {
+        assert!(CommitBatch::new(0, Vec::new()).is_err());
+        assert!(CommitBatch::new(0, vec![Bytes::new()]).is_err());
+        assert!(CommitBatch::new(u64::MAX, vec![Bytes::from_static(b"x")]).is_err());
+    }
+}

--- a/rust/crates/haya/tests/downloader.rs
+++ b/rust/crates/haya/tests/downloader.rs
@@ -25,6 +25,22 @@ struct MemorySink {
     cancel_on_append: Option<CancellationToken>,
 }
 
+struct BatchedMemorySink {
+    inner: MemorySink,
+    batch_size: usize,
+    batches: Mutex<Vec<(u64, Vec<usize>)>>,
+}
+
+impl BatchedMemorySink {
+    fn new(batch_size: usize) -> Self {
+        Self {
+            inner: MemorySink::default(),
+            batch_size,
+            batches: Mutex::new(Vec::new()),
+        }
+    }
+}
+
 impl MemorySink {
     fn with_bytes(bytes: &[u8]) -> Self {
         Self {
@@ -70,6 +86,37 @@ impl CommitSink for MemorySink {
     async fn close(&self) -> Result<(), SinkError> {
         self.closes.fetch_add(1, Ordering::Relaxed);
         self.flush().await
+    }
+}
+
+#[async_trait]
+impl CommitSink for BatchedMemorySink {
+    async fn committed_offset(&self) -> Result<u64, SinkError> {
+        self.inner.committed_offset().await
+    }
+
+    async fn append(&self, offset: u64, data: Bytes) -> Result<(), SinkError> {
+        self.inner.append(offset, data).await
+    }
+
+    fn append_batch_size_hint(&self) -> Option<std::num::NonZeroUsize> {
+        std::num::NonZeroUsize::new(self.batch_size)
+    }
+
+    async fn append_batch(&self, batch: haya::CommitBatch) -> Result<(), SinkError> {
+        self.batches.lock().expect("batch lock poisoned").push((
+            batch.offset(),
+            batch.chunks().iter().map(Bytes::len).collect(),
+        ));
+        CommitSink::append_batch(&self.inner, batch).await
+    }
+
+    async fn flush(&self) -> Result<(), SinkError> {
+        self.inner.flush().await
+    }
+
+    async fn close(&self) -> Result<(), SinkError> {
+        self.inner.close().await
     }
 }
 
@@ -325,6 +372,35 @@ async fn downloads_out_of_order_ranges_and_a_short_final_page() {
     assert_eq!(report.committed_bytes, expected.len() as u64);
     assert_eq!(report.received_bytes, expected.len() as u64);
     assert_eq!(sink.closes.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn commits_contiguous_pages_in_sink_bounded_batches() {
+    let expected = payload(5 * 1024 - 7);
+    let sink = Arc::new(BatchedMemorySink::new(2 * 1024));
+    let mut download_spec = spec(expected.len() as u64, 1024);
+    download_spec.block_size = expected.len();
+    download_spec.workers = 1;
+
+    Downloader::new(
+        download_spec,
+        vec![Arc::new(MemorySource::new(expected.clone()))],
+        sink.clone(),
+    )
+    .expect("valid downloader")
+    .run()
+    .await
+    .expect("download succeeds");
+
+    assert_eq!(sink.inner.bytes(), expected);
+    assert_eq!(
+        *sink.batches.lock().expect("batch lock poisoned"),
+        [
+            (0, vec![1024, 1024]),
+            (2048, vec![1024, 1024]),
+            (4096, vec![1017]),
+        ]
+    );
 }
 
 #[tokio::test]

--- a/rust/crates/haya/tests/file_sink.rs
+++ b/rust/crates/haya/tests/file_sink.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use haya::{
-    CommitSink,
+    CommitBatch, CommitSink,
     file::{FileOpenMode, FileSink},
 };
 
@@ -21,6 +21,63 @@ async fn overwrites_and_appends_contiguously() {
     sink.close().await.expect("close sink");
 
     assert_eq!(tokio::fs::read(path).await.expect("read output"), b"new");
+}
+
+#[tokio::test]
+async fn appends_a_multi_chunk_batch_as_one_commit() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    let sink = FileSink::open(&path, FileOpenMode::Overwrite)
+        .await
+        .expect("open sink");
+
+    sink.append_batch(
+        CommitBatch::new(
+            0,
+            vec![
+                Bytes::from_static(b"first-"),
+                Bytes::from_static(b"second-"),
+                Bytes::from_static(b"tail"),
+            ],
+        )
+        .expect("valid batch"),
+    )
+    .await
+    .expect("append batch");
+
+    assert_eq!(sink.committed_offset().await.expect("offset"), 17);
+    assert_eq!(
+        tokio::fs::read(&path).await.expect("read output"),
+        b"first-second-tail"
+    );
+}
+
+#[tokio::test]
+async fn resumes_with_a_non_aligned_multi_chunk_batch() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    tokio::fs::write(&path, b"prefix!")
+        .await
+        .expect("seed output");
+    let sink = FileSink::open(&path, FileOpenMode::ResumeFromLength)
+        .await
+        .expect("open sink");
+
+    sink.append_batch(
+        CommitBatch::new(
+            7,
+            vec![Bytes::from_static(b"-middle"), Bytes::from_static(b"-tail")],
+        )
+        .expect("valid batch"),
+    )
+    .await
+    .expect("append batch");
+    sink.close().await.expect("close sink");
+
+    assert_eq!(
+        tokio::fs::read(&path).await.expect("read output"),
+        b"prefix!-middle-tail"
+    );
 }
 
 #[tokio::test]
@@ -57,4 +114,17 @@ async fn rejects_non_contiguous_writes_and_writes_after_close() {
     assert!(sink.append(1, Bytes::from_static(b"gap")).await.is_err());
     sink.close().await.expect("close sink");
     assert!(sink.append(0, Bytes::from_static(b"late")).await.is_err());
+}
+
+#[tokio::test]
+async fn preserves_empty_append_behavior() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("output.bin");
+    let sink = FileSink::open(&path, FileOpenMode::Overwrite)
+        .await
+        .expect("open sink");
+
+    sink.append(0, Bytes::new()).await.expect("empty append");
+    assert_eq!(sink.committed_offset().await.expect("offset"), 0);
+    assert!(sink.append(1, Bytes::new()).await.is_err());
 }


### PR DESCRIPTION
## 动机

Haya 当前会将已完成的 Range 拆成 64 KiB page，并对每个 page 分别执行文件写入和 `flush`。这会产生大量细粒度文件提交，同时已有连续 page 仍然可以在不复制媒体数据的情况下批量处理。

## 解决方案

- 新增 `CommitBatch` 与兼容的 `CommitSink::append_batch` 接口；普通 sink 默认保持逐页行为。
- `FileSink` 将连续 page 以最多 1 MiB 的批次通过 vectored buffer 写入，并且每批只执行一次 `flush`。
- 整批写入或最终 `flush` 失败时，文件回滚到批次开始前的 committed offset。
- 保持原有逐页取消语义、非对齐续传、空 append 行为以及 dropped append future 的 poison 语义。
- 默认 `block-size`、ordered window 与 worker 配置均未改动。

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [x] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

## 验证

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `just fmt`
- `just lint`
