### PR TITLE
⚡️ perf: share Haya worker limits

### DIFF
--- a/rust/crates/haya/src/downloader.rs
+++ b/rust/crates/haya/src/downloader.rs
@@ -2,12 +2,12 @@ use std::{collections::VecDeque, sync::Arc};
 
 use bytes::{Bytes, BytesMut};
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
-use tokio::time::Instant;
+use tokio::{sync::OwnedSemaphorePermit, time::Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     ByteRange, CommitSink, DownloadError, DownloadReport, DownloadSnapshot, DownloadSpec,
-    NullProgressSink, ProgressSink, RangeSource, SourceError, SourceErrorKind,
+    NullProgressSink, ProgressSink, RangeSource, SourceError, SourceErrorKind, WorkerLimit,
     buffer::OrderedBuffer, sink::SharedSink, source::SharedSource, source_pool::SourcePool,
 };
 
@@ -23,12 +23,25 @@ struct AttemptResult {
     result: Result<Bytes, SourceError>,
 }
 
+type PendingWorker = BoxFuture<'static, OwnedSemaphorePermit>;
+
+fn release_workers(
+    in_flight: &mut FuturesUnordered<BoxFuture<'static, AttemptResult>>,
+    pending_worker: &mut Option<PendingWorker>,
+    ready_worker: &mut Option<OwnedSemaphorePermit>,
+) {
+    in_flight.clear();
+    pending_worker.take();
+    ready_worker.take();
+}
+
 pub struct Downloader {
     spec: DownloadSpec,
     sources: Vec<SharedSource>,
     sink: SharedSink,
     progress: Arc<dyn ProgressSink>,
     cancellation: CancellationToken,
+    worker_limit: WorkerLimit,
 }
 
 impl Downloader {
@@ -37,12 +50,15 @@ impl Downloader {
         sources: Vec<Arc<dyn RangeSource>>,
         sink: Arc<dyn CommitSink>,
     ) -> Result<Self, DownloadError> {
+        let spec = spec.validate()?;
+        let worker_limit = WorkerLimit::new(spec.workers)?;
         Ok(Self {
-            spec: spec.validate()?,
+            spec,
             sources,
             sink,
             progress: Arc::new(NullProgressSink),
             cancellation: CancellationToken::new(),
+            worker_limit,
         })
     }
 
@@ -53,6 +69,11 @@ impl Downloader {
 
     pub fn with_cancellation_token(mut self, cancellation: CancellationToken) -> Self {
         self.cancellation = cancellation;
+        self
+    }
+
+    pub fn with_worker_limit(mut self, worker_limit: WorkerLimit) -> Self {
+        self.worker_limit = worker_limit;
         self
     }
 
@@ -93,6 +114,8 @@ impl Downloader {
         let mut queue = VecDeque::new();
         let mut in_flight: FuturesUnordered<BoxFuture<'static, AttemptResult>> =
             FuturesUnordered::new();
+        let mut pending_worker: Option<PendingWorker> = None;
+        let mut ready_worker: Option<OwnedSemaphorePermit> = None;
         let mut next_offset = origin;
         let mut committed = origin;
         let mut received = 0_u64;
@@ -100,6 +123,7 @@ impl Downloader {
 
         loop {
             if self.cancellation.is_cancelled() {
+                release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                 return self.cancelled().await;
             }
             self.enqueue_new_work(
@@ -110,18 +134,37 @@ impl Downloader {
                 in_flight.len(),
             )?;
 
+            let now = Instant::now();
+            if queue.is_empty() || in_flight.len() >= self.spec.workers || !pool.has_ready(now) {
+                pending_worker = None;
+                ready_worker = None;
+            }
+
             while in_flight.len() < self.spec.workers {
-                let Some(work) = queue.pop_front() else {
+                if queue.is_empty() || !pool.has_ready(Instant::now()) {
+                    break;
+                }
+                let worker = if let Some(worker) = ready_worker.take() {
+                    worker
+                } else if let Some(worker) = self.worker_limit.try_acquire_owned() {
+                    worker
+                } else {
+                    if pending_worker.is_none() {
+                        pending_worker = Some(self.worker_limit.clone().acquire_owned().boxed());
+                    }
                     break;
                 };
+                let work = queue.pop_front().expect("the queue was checked above");
                 let Some((source, range_source)) = pool.select(Instant::now()) else {
                     queue.push_front(work);
+                    ready_worker = Some(worker);
                     break;
                 };
                 attempts += 1;
                 let attempt_timeout = self.spec.attempt_timeout;
                 in_flight.push(
                     async move {
+                        let _worker = worker;
                         let result = tokio::time::timeout(
                             attempt_timeout,
                             fetch_exact(range_source, work.range),
@@ -146,6 +189,7 @@ impl Downloader {
             self.publish_progress(received, committed, &ring, next_offset, in_flight.len());
 
             if committed == expected {
+                release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                 self.sink.close().await?;
                 return Ok(DownloadReport {
                     committed_bytes: committed,
@@ -154,7 +198,7 @@ impl Downloader {
                 });
             }
 
-            if in_flight.is_empty() {
+            if in_flight.is_empty() && pending_worker.is_none() && ready_worker.is_none() {
                 if !pool.has_usable() {
                     return self.fail_after_flush(DownloadError::NoUsableSource).await;
                 }
@@ -169,27 +213,48 @@ impl Downloader {
                 return self.fail_after_flush(DownloadError::Stalled).await;
             }
 
-            let cooldown_ready_at = if !queue.is_empty() && in_flight.len() < self.spec.workers {
+            let cooldown_ready_at = if !queue.is_empty()
+                && in_flight.len() < self.spec.workers
+                && !pool.has_ready(Instant::now())
+            {
                 pool.next_ready_at()
             } else {
                 None
             };
-            let completed = if let Some(ready_at) = cooldown_ready_at {
+            enum SchedulerEvent {
+                Completed(AttemptResult),
+                WorkerReady(OwnedSemaphorePermit),
+                CooldownReady,
+                Cancelled,
+            }
+            let event = if let Some(ready_at) = cooldown_ready_at {
                 tokio::select! {
                     biased;
-                    _ = self.cancellation.cancelled() => return self.cancelled().await,
-                    result = in_flight.next() => Some(result.ok_or(DownloadError::Stalled)?),
-                    _ = tokio::time::sleep_until(ready_at) => None,
+                    _ = self.cancellation.cancelled() => SchedulerEvent::Cancelled,
+                    result = in_flight.next(), if !in_flight.is_empty() => SchedulerEvent::Completed(result.ok_or(DownloadError::Stalled)?),
+                    worker = async { pending_worker.as_mut().expect("guarded pending worker").await }, if pending_worker.is_some() => SchedulerEvent::WorkerReady(worker),
+                    _ = tokio::time::sleep_until(ready_at) => SchedulerEvent::CooldownReady,
                 }
             } else {
                 tokio::select! {
                     biased;
-                    _ = self.cancellation.cancelled() => return self.cancelled().await,
-                    result = in_flight.next() => Some(result.ok_or(DownloadError::Stalled)?),
+                    _ = self.cancellation.cancelled() => SchedulerEvent::Cancelled,
+                    result = in_flight.next(), if !in_flight.is_empty() => SchedulerEvent::Completed(result.ok_or(DownloadError::Stalled)?),
+                    worker = async { pending_worker.as_mut().expect("guarded pending worker").await }, if pending_worker.is_some() => SchedulerEvent::WorkerReady(worker),
                 }
             };
-            let Some(completed) = completed else {
-                continue;
+            let completed = match event {
+                SchedulerEvent::Completed(completed) => completed,
+                SchedulerEvent::WorkerReady(worker) => {
+                    pending_worker = None;
+                    ready_worker = Some(worker);
+                    continue;
+                }
+                SchedulerEvent::CooldownReady => continue,
+                SchedulerEvent::Cancelled => {
+                    release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
+                    return self.cancelled().await;
+                }
             };
 
             match completed.result {
@@ -200,20 +265,24 @@ impl Downloader {
                     for (offset, data) in ring.pop_contiguous() {
                         let end = offset.saturating_add(data.len() as u64);
                         if let Err(error) = self.sink.append(offset, data).await {
+                            release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                             return self.fail_after_flush(error.into()).await;
                         }
                         committed = end;
                         if self.cancellation.is_cancelled() {
+                            release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                             return self.cancelled().await;
                         }
                     }
                 }
                 Err(error) => {
                     if let Err(config_error) = pool.record_failure(completed.source, &error) {
+                        release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                         return self.fail_after_flush(config_error).await;
                     }
                     let attempt = completed.work.attempts + 1;
                     if !pool.has_usable() {
+                        release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                         return self
                             .fail_after_flush(DownloadError::RetryExhausted {
                                 range: completed.work.range,
@@ -239,6 +308,7 @@ impl Downloader {
                             attempts: 0,
                         });
                     } else {
+                        release_workers(&mut in_flight, &mut pending_worker, &mut ready_worker);
                         return self
                             .fail_after_flush(DownloadError::RetryExhausted {
                                 range: completed.work.range,

--- a/rust/crates/haya/src/lib.rs
+++ b/rust/crates/haya/src/lib.rs
@@ -7,6 +7,7 @@ mod model;
 mod sink;
 mod source;
 mod source_pool;
+mod worker_limit;
 
 pub use downloader::Downloader;
 pub use error::{DownloadError, SinkError, SourceError, SourceErrorKind};
@@ -14,3 +15,4 @@ pub use event::{DownloadReport, DownloadSnapshot, NullProgressSink, ProgressSink
 pub use model::{ByteRange, DownloadSpec};
 pub use sink::CommitSink;
 pub use source::{ByteStream, RangeSource};
+pub use worker_limit::WorkerLimit;

--- a/rust/crates/haya/src/source_pool.rs
+++ b/rust/crates/haya/src/source_pool.rs
@@ -78,6 +78,12 @@ impl SourcePool {
         self.health.iter().any(|health| !health.disabled)
     }
 
+    pub fn has_ready(&self, now: Instant) -> bool {
+        self.health
+            .iter()
+            .any(|health| !health.disabled && health.ready_at <= now)
+    }
+
     pub fn next_ready_at(&self) -> Option<Instant> {
         self.health
             .iter()

--- a/rust/crates/haya/src/worker_limit.rs
+++ b/rust/crates/haya/src/worker_limit.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::DownloadError;
+
+#[derive(Clone, Debug)]
+pub struct WorkerLimit {
+    capacity: usize,
+    semaphore: Arc<Semaphore>,
+}
+
+impl WorkerLimit {
+    pub fn new(capacity: usize) -> Result<Self, DownloadError> {
+        if capacity == 0 || capacity > Semaphore::MAX_PERMITS {
+            return Err(DownloadError::InvalidSpec(format!(
+                "worker limit capacity must be between 1 and {}",
+                Semaphore::MAX_PERMITS
+            )));
+        }
+        Ok(Self {
+            capacity,
+            semaphore: Arc::new(Semaphore::new(capacity)),
+        })
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub(crate) fn try_acquire_owned(&self) -> Option<OwnedSemaphorePermit> {
+        self.semaphore.clone().try_acquire_owned().ok()
+    }
+
+    pub(crate) async fn acquire_owned(self) -> OwnedSemaphorePermit {
+        self.semaphore
+            .acquire_owned()
+            .await
+            .expect("Haya never closes a worker limit")
+    }
+}

--- a/rust/crates/haya/tests/worker_limit.rs
+++ b/rust/crates/haya/tests/worker_limit.rs
@@ -1,0 +1,291 @@
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures_util::stream;
+use haya::{
+    ByteRange, ByteStream, CommitSink, DownloadSpec, Downloader, RangeSource, SinkError,
+    SourceError, WorkerLimit,
+};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Default)]
+struct MemorySink(Mutex<Vec<u8>>);
+
+#[async_trait]
+impl CommitSink for MemorySink {
+    async fn committed_offset(&self) -> Result<u64, SinkError> {
+        Ok(self.0.lock().expect("sink lock poisoned").len() as u64)
+    }
+
+    async fn append(&self, offset: u64, data: Bytes) -> Result<(), SinkError> {
+        let mut bytes = self.0.lock().expect("sink lock poisoned");
+        if bytes.len() as u64 != offset {
+            return Err(SinkError::new("non-contiguous append"));
+        }
+        bytes.extend_from_slice(&data);
+        Ok(())
+    }
+
+    async fn flush(&self) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct Activity {
+    active: AtomicUsize,
+    peak: AtomicUsize,
+    total: AtomicUsize,
+    changed: Notify,
+}
+
+impl Activity {
+    fn enter(self: &Arc<Self>) -> ActivityGuard {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.total.fetch_add(1, Ordering::SeqCst);
+        self.peak.fetch_max(active, Ordering::SeqCst);
+        self.changed.notify_waiters();
+        ActivityGuard(self.clone())
+    }
+
+    async fn wait_for_total(&self, expected: usize) {
+        loop {
+            let notified = self.changed.notified();
+            if self.total.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct ActivityGuard(Arc<Activity>);
+
+impl Drop for ActivityGuard {
+    fn drop(&mut self) {
+        self.0.active.fetch_sub(1, Ordering::SeqCst);
+        self.0.changed.notify_waiters();
+    }
+}
+
+struct TrackedSource {
+    payload: Bytes,
+    activity: Arc<Activity>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl RangeSource for TrackedSource {
+    async fn open(&self, range: ByteRange) -> Result<ByteStream, SourceError> {
+        let guard = self.activity.enter();
+        self.release.notified().await;
+        let bytes = self.payload.slice(range.start as usize..range.end as usize);
+        Ok(Box::pin(stream::once(async move {
+            drop(guard);
+            Ok(bytes)
+        })))
+    }
+}
+
+fn spec(size: usize, workers: usize) -> DownloadSpec {
+    let mut spec = DownloadSpec::new(size as u64);
+    spec.page_size = 1024;
+    spec.block_size = 1024;
+    spec.window_pages = 16;
+    spec.workers = workers;
+    spec.attempt_timeout = Duration::from_secs(2);
+    spec
+}
+
+#[test]
+fn rejects_a_zero_capacity() {
+    assert!(WorkerLimit::new(0).is_err());
+    assert!(WorkerLimit::new(tokio::sync::Semaphore::MAX_PERMITS + 1).is_err());
+}
+
+#[tokio::test]
+async fn bounds_two_downloaders_and_reuses_released_workers() {
+    let activity = Arc::new(Activity::default());
+    let release = Arc::new(Notify::new());
+    let limit = WorkerLimit::new(3).expect("valid limit");
+    let payload = Bytes::from(vec![7; 8 * 1024]);
+    let source = Arc::new(TrackedSource {
+        payload: payload.clone(),
+        activity: activity.clone(),
+        release: release.clone(),
+    });
+
+    let first = tokio::spawn(
+        Downloader::new(
+            spec(payload.len(), 8),
+            vec![source.clone()],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit.clone())
+        .run(),
+    );
+    let second = tokio::spawn(
+        Downloader::new(
+            spec(payload.len(), 8),
+            vec![source],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit)
+        .run(),
+    );
+
+    activity.wait_for_total(3).await;
+    assert_eq!(activity.active.load(Ordering::SeqCst), 3);
+    assert_eq!(activity.peak.load(Ordering::SeqCst), 3);
+
+    release.notify_waiters();
+    tokio::time::timeout(Duration::from_millis(500), activity.wait_for_total(4))
+        .await
+        .expect("a waiting sibling reuses a released worker");
+    while !first.is_finished() || !second.is_finished() {
+        release.notify_waiters();
+        tokio::task::yield_now().await;
+    }
+    first.await.expect("first joins").expect("first succeeds");
+    second
+        .await
+        .expect("second joins")
+        .expect("second succeeds");
+    assert_eq!(activity.peak.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn waiting_for_a_worker_does_not_consume_attempt_timeout() {
+    let activity = Arc::new(Activity::default());
+    let first_release = Arc::new(Notify::new());
+    let limit = WorkerLimit::new(1).expect("valid limit");
+    let payload = Bytes::from(vec![3; 1024]);
+
+    let mut first_spec = spec(payload.len(), 1);
+    first_spec.attempt_timeout = Duration::from_secs(1);
+    let first = tokio::spawn(
+        Downloader::new(
+            first_spec,
+            vec![Arc::new(TrackedSource {
+                payload: payload.clone(),
+                activity: activity.clone(),
+                release: first_release.clone(),
+            })],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit.clone())
+        .run(),
+    );
+    activity.wait_for_total(1).await;
+
+    let second_release = Arc::new(Notify::new());
+    let mut second_spec = spec(payload.len(), 1);
+    second_spec.attempt_timeout = Duration::from_millis(20);
+    let second = tokio::spawn(
+        Downloader::new(
+            second_spec,
+            vec![Arc::new(TrackedSource {
+                payload,
+                activity: activity.clone(),
+                release: second_release.clone(),
+            })],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit)
+        .run(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(!second.is_finished());
+    first_release.notify_waiters();
+    first.await.expect("first joins").expect("first succeeds");
+    activity.wait_for_total(2).await;
+    second_release.notify_waiters();
+    second
+        .await
+        .expect("second joins")
+        .expect("second succeeds");
+}
+
+#[tokio::test]
+async fn cancelling_a_worker_waiter_does_not_leak_capacity() {
+    let activity = Arc::new(Activity::default());
+    let release = Arc::new(Notify::new());
+    let limit = WorkerLimit::new(1).expect("valid limit");
+    let payload = Bytes::from(vec![5; 1024]);
+    let first = tokio::spawn(
+        Downloader::new(
+            spec(payload.len(), 1),
+            vec![Arc::new(TrackedSource {
+                payload: payload.clone(),
+                activity: activity.clone(),
+                release: release.clone(),
+            })],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit.clone())
+        .run(),
+    );
+    activity.wait_for_total(1).await;
+
+    let cancellation = CancellationToken::new();
+    let waiting = tokio::spawn(
+        Downloader::new(
+            spec(payload.len(), 1),
+            vec![Arc::new(TrackedSource {
+                payload: payload.clone(),
+                activity: activity.clone(),
+                release: release.clone(),
+            })],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit.clone())
+        .with_cancellation_token(cancellation.clone())
+        .run(),
+    );
+    tokio::task::yield_now().await;
+    cancellation.cancel();
+    assert!(matches!(
+        tokio::time::timeout(Duration::from_millis(100), waiting)
+            .await
+            .expect("waiter cancels promptly")
+            .expect("waiter joins"),
+        Err(haya::DownloadError::Cancelled)
+    ));
+
+    release.notify_waiters();
+    first.await.expect("first joins").expect("first succeeds");
+
+    let third_release = Arc::new(Notify::new());
+    let third = tokio::spawn(
+        Downloader::new(
+            spec(payload.len(), 1),
+            vec![Arc::new(TrackedSource {
+                payload,
+                activity: activity.clone(),
+                release: third_release.clone(),
+            })],
+            Arc::new(MemorySink::default()),
+        )
+        .expect("valid downloader")
+        .with_worker_limit(limit)
+        .run(),
+    );
+    activity.wait_for_total(2).await;
+    third_release.notify_waiters();
+    third.await.expect("third joins").expect("third succeeds");
+}

--- a/rust/crates/yutto/src/lib.rs
+++ b/rust/crates/yutto/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use haya::{
-    CommitSink, DownloadSnapshot, DownloadSpec, Downloader, ProgressSink,
+    CommitSink, DownloadSnapshot, DownloadSpec, Downloader, ProgressSink, WorkerLimit,
     file::{FileOpenMode, FileSink},
 };
 use haya_http::HttpRangeSource;
@@ -176,7 +176,8 @@ impl YuttoSession {
         self.session.is_closed()
     }
 
-    #[pyo3(signature = (sources, target, expected_size, *, overwrite=false, workers=8, block_size=524288))]
+    #[pyo3(signature = (sources, target, expected_size, *, overwrite=false, workers=8, block_size=524288, worker_limit=None))]
+    #[allow(clippy::too_many_arguments)]
     fn start_transfer(
         &self,
         sources: Vec<String>,
@@ -185,6 +186,7 @@ impl YuttoSession {
         overwrite: bool,
         workers: usize,
         block_size: usize,
+        worker_limit: Option<PyRef<'_, TransferWorkerLimit>>,
     ) -> PyResult<TransferHandle> {
         start_transfer_with_session(
             &self.session,
@@ -194,7 +196,30 @@ impl YuttoSession {
             overwrite,
             workers,
             block_size,
+            worker_limit.map(|limit| limit.inner.clone()),
         )
+    }
+}
+
+#[pyclass(frozen, module = "yutto._core")]
+struct TransferWorkerLimit {
+    inner: WorkerLimit,
+}
+
+#[pymethods]
+impl TransferWorkerLimit {
+    #[new]
+    fn new(capacity: i64) -> PyResult<Self> {
+        let capacity = usize::try_from(capacity)
+            .map_err(|_| PyValueError::new_err("worker limit capacity must be positive"))?;
+        let inner =
+            WorkerLimit::new(capacity).map_err(|error| PyValueError::new_err(error.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    #[getter]
+    fn capacity(&self) -> usize {
+        self.inner.capacity()
     }
 }
 
@@ -272,6 +297,7 @@ impl ProgressSink for StateProgress {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn start_transfer_with_session(
     session: &Session,
     sources: Vec<String>,
@@ -280,6 +306,7 @@ fn start_transfer_with_session(
     overwrite: bool,
     workers: usize,
     block_size: usize,
+    worker_limit: Option<WorkerLimit>,
 ) -> PyResult<TransferHandle> {
     if sources.is_empty() {
         return Err(PyValueError::new_err("at least one source is required"));
@@ -315,6 +342,7 @@ fn start_transfer_with_session(
             target,
             overwrite,
             spec,
+            worker_limit,
             cancellation: task_cancellation.clone(),
             state: task_state.clone(),
         })
@@ -344,6 +372,7 @@ struct TransferArgs {
     target: PathBuf,
     overwrite: bool,
     spec: DownloadSpec,
+    worker_limit: Option<WorkerLimit>,
     cancellation: CancellationToken,
     state: Arc<Mutex<TransferState>>,
 }
@@ -385,12 +414,14 @@ async fn run_transfer(args: TransferArgs) -> Result<u64, String> {
     }
 
     let progress = Arc::new(StateProgress { state: args.state });
-    let result = Downloader::new(args.spec, sources, sink.clone())
+    let mut downloader = Downloader::new(args.spec, sources, sink.clone())
         .map_err(|error| error.to_string())?
         .with_progress_sink(progress)
-        .with_cancellation_token(args.cancellation)
-        .run()
-        .await;
+        .with_cancellation_token(args.cancellation);
+    if let Some(worker_limit) = args.worker_limit {
+        downloader = downloader.with_worker_limit(worker_limit);
+    }
+    let result = downloader.run().await;
     let close_result = sink.close().await;
     match (result, close_result) {
         (Ok(report), Ok(())) => Ok(report.committed_bytes),
@@ -436,6 +467,7 @@ fn yutto(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<YuttoSession>()?;
     module.add_class::<NativeResponse>()?;
     module.add_class::<TransferHandle>()?;
+    module.add_class::<TransferWorkerLimit>()?;
     module.add_class::<TransferSnapshot>()?;
     module.add("HttpError", module.py().get_type::<HttpError>())?;
     module.add("InvalidUrlError", module.py().get_type::<InvalidUrlError>())?;

--- a/src/yutto/_core.pyi
+++ b/src/yutto/_core.pyi
@@ -44,6 +44,11 @@ class TransferHandle:
     def snapshot(self) -> TransferSnapshot: ...
     def result(self) -> int: ...
 
+class TransferWorkerLimit:
+    def __init__(self, capacity: int) -> None: ...
+    @property
+    def capacity(self) -> int: ...
+
 class YuttoSession:
     def __init__(
         self,
@@ -79,4 +84,5 @@ class YuttoSession:
         overwrite: bool = ...,
         workers: int = ...,
         block_size: int = ...,
+        worker_limit: TransferWorkerLimit | None = ...,
     ) -> TransferHandle: ...

--- a/src/yutto/_native.py
+++ b/src/yutto/_native.py
@@ -12,6 +12,7 @@ from yutto._core import (
     SessionClosedError,
     TransferHandle,
     TransferSnapshot,
+    TransferWorkerLimit,
     UnsupportedProtocolError,
     YuttoSession,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "SessionClosedError",
     "TransferHandle",
     "TransferSnapshot",
+    "TransferWorkerLimit",
     "UnsupportedProtocolError",
     "YuttoSession",
     "wait_for_transfer",

--- a/src/yutto/downloader/transfer.py
+++ b/src/yutto/downloader/transfer.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 from typing import TYPE_CHECKING
 
-from yutto._native import wait_for_transfer
+from yutto._native import TransferWorkerLimit, wait_for_transfer
 from yutto.core.events import DownloadStage, DownloadStageChanged
 from yutto.core.operation import emit_download_event, emit_download_report
 from yutto.downloader.progressbar import show_progress
@@ -75,20 +75,20 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
             size = await _probe_media_size(scope, stream.url, mirrors)
             prepared_transfers.append(([stream.url, *mirrors], target, size))
 
-        completed_transfers = 0
         total_size = sum(size for _, _, size in prepared_transfers)
-        for worker_batch in _allocate_native_worker_batches(scope.download_workers, len(prepared_transfers)):
+        worker_limit = TransferWorkerLimit(scope.download_workers)
+        batch_size = 1 if scope.download_workers == 1 else len(prepared_transfers)
+        for batch_start in range(0, len(prepared_transfers), batch_size):
             batch_tasks = []
-            for workers in worker_batch:
-                sources, target, size = prepared_transfers[completed_transfers]
-                completed_transfers += 1
+            for sources, target, size in prepared_transfers[batch_start : batch_start + batch_size]:
                 handle = scope.session.start_transfer(
                     sources,
                     target,
                     size,
                     overwrite=plan.overwrite,
-                    workers=workers,
+                    workers=scope.download_workers,
                     block_size=plan.block_size,
+                    worker_limit=worker_limit,
                 )
                 handles.append(handle)
                 wait_task = asyncio.create_task(wait_for_transfer(handle))
@@ -111,17 +111,6 @@ async def download_video_and_audio(scope: ExecutionScope, plan: DownloadPlan) ->
         except asyncio.CancelledError:
             await cleanup_task
             raise
-
-
-def _allocate_native_worker_batches(total_workers: int, transfer_count: int) -> list[list[int]]:
-    batches = []
-    remaining = transfer_count
-    while remaining:
-        batch_size = min(total_workers, remaining)
-        workers_per_transfer, extra_workers = divmod(total_workers, batch_size)
-        batches.append([workers_per_transfer + (index < extra_workers) for index in range(batch_size)])
-        remaining -= batch_size
-    return batches
 
 
 async def _wait_for_native_transfers(wait_tasks: Iterable[asyncio.Task[int]]) -> None:

--- a/tests/test_processor/test_downloader.py
+++ b/tests/test_processor/test_downloader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -9,13 +10,13 @@ from returns.result import Failure, Success
 import yutto.downloader.transfer as transfer_module
 from tests.helpers.http_range_server import LocalRangeServer, RangeFault
 from tests.test_processor.test_download_result import make_request, make_resource_only_episode
+from yutto._native import TransferWorkerLimit
 from yutto.core.events import DownloadEvent, DownloadProgress
 from yutto.core.execution import ExecutionScope
 from yutto.core.operation import bind_download_event_sink
 from yutto.downloader.planner import DownloadPlanner
 from yutto.downloader.progressbar import show_progress
 from yutto.downloader.transfer import (
-    _allocate_native_worker_batches,
     _probe_media_size,
     _wait_for_native_transfers,
     download_video_and_audio,
@@ -28,6 +29,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 pytestmark = pytest.mark.processor
+
+
+@pytest.mark.parametrize("capacity", [-1, 0, sys.maxsize])
+def test_native_worker_limit_rejects_invalid_capacity(capacity: int):
+    with pytest.raises(ValueError):
+        TransferWorkerLimit(capacity)
 
 
 @as_sync
@@ -153,19 +160,6 @@ async def test_probe_media_size_rejects_a_source_without_a_known_length(monkeypa
     monkeypatch.setattr(Fetcher, "get_size", get_size)
     with pytest.raises(MaxRetryError, match="未返回长度"):
         await _probe_media_size(ExecutionScope(cast("Any", object())), "primary", [])
-
-
-@pytest.mark.parametrize(
-    ("workers", "transfers", "expected"),
-    [
-        (8, 2, [[4, 4]]),
-        (3, 2, [[2, 1]]),
-        (1, 2, [[1], [1]]),
-    ],
-)
-def test_native_worker_budget_is_global(workers: int, transfers: int, expected: list[list[int]]):
-    assert _allocate_native_worker_batches(workers, transfers) == expected
-    assert all(sum(batch) <= workers for batch in expected)
 
 
 @as_sync
@@ -333,6 +327,10 @@ async def test_native_transfer_reuses_the_scope_session_and_maps_workers(
 ):
     captured: dict[str, Any] = {}
 
+    class WorkerLimit:
+        def __init__(self, capacity: int) -> None:
+            self.capacity = capacity
+
     class Snapshot:
         origin_bytes = 0
         received_bytes = 123
@@ -365,6 +363,7 @@ async def test_native_transfer_reuses_the_scope_session_and_maps_workers(
             return Handle()
 
     monkeypatch.setattr(Fetcher, "get_size", get_size)
+    monkeypatch.setattr(transfer_module, "TransferWorkerLimit", WorkerLimit)
 
     episode = make_resource_only_episode()
     episode["audios"] = [
@@ -404,6 +403,171 @@ async def test_native_transfer_reuses_the_scope_session_and_maps_workers(
     assert args[2] == 123
     assert kwargs["workers"] == 3
     assert kwargs["block_size"] == 64 * 1024
+    assert isinstance(kwargs["worker_limit"], WorkerLimit)
+    assert kwargs["worker_limit"].capacity == 3
+
+
+@as_sync
+async def test_item_transfers_start_together_and_share_one_worker_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    started: list[tuple[object, dict[str, object]]] = []
+    both_started = asyncio.Event()
+
+    class WorkerLimit:
+        def __init__(self, capacity: int) -> None:
+            self.capacity = capacity
+
+    class Snapshot:
+        origin_bytes = 0
+        received_bytes = 1
+        committed_bytes = 1
+        window_saturated = False
+
+    class Handle:
+        async def wait(self) -> None:
+            await both_started.wait()
+
+        def done(self) -> bool:
+            return both_started.is_set()
+
+        def cancel(self) -> None:
+            raise AssertionError("completed handle must not be cancelled")
+
+        def snapshot(self) -> Snapshot:
+            return Snapshot()
+
+        def result(self) -> int:
+            return 1
+
+    async def get_size(_scope: ExecutionScope, _url: str) -> Success[int]:
+        return Success(1)
+
+    class FakeSession:
+        def start_transfer(self, *args: object, **kwargs: object) -> Handle:
+            started.append((args[0], kwargs))
+            if len(started) == 2:
+                both_started.set()
+            return Handle()
+
+    monkeypatch.setattr(Fetcher, "get_size", get_size)
+    monkeypatch.setattr(transfer_module, "TransferWorkerLimit", WorkerLimit)
+
+    episode = make_resource_only_episode()
+    episode["videos"] = [
+        {
+            "url": "https://video.example/media",
+            "mirrors": [],
+            "codec": "avc",
+            "width": 1920,
+            "height": 1080,
+            "quality": 80,
+        }
+    ]
+    episode["audios"] = [
+        {
+            "url": "https://audio.example/media",
+            "mirrors": [],
+            "codec": "mp4a",
+            "width": 0,
+            "height": 0,
+            "quality": 30280,
+        }
+    ]
+    base_request = make_request(tmp_path, video=True, audio=True)
+    plan = DownloadPlanner().plan(episode, type(base_request).model_validate(base_request.model_dump()))
+
+    await download_video_and_audio(
+        ExecutionScope(cast("Any", FakeSession()), download_workers=2),
+        plan,
+    )
+
+    assert len(started) == 2
+    limits = [kwargs["worker_limit"] for _, kwargs in started]
+    assert limits[0] is limits[1]
+    assert isinstance(limits[0], WorkerLimit)
+    assert limits[0].capacity == 2
+    assert all(kwargs["workers"] == 2 for _, kwargs in started)
+
+
+@as_sync
+async def test_one_worker_preserves_serial_transfer_setup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    started: list[str] = []
+
+    class WorkerLimit:
+        def __init__(self, capacity: int) -> None:
+            self.capacity = capacity
+
+    class Snapshot:
+        origin_bytes = 0
+        received_bytes = 1
+        committed_bytes = 1
+        window_saturated = False
+
+    class Handle:
+        def __init__(self, source: str) -> None:
+            self.source = source
+
+        async def wait(self) -> None:
+            assert started[-1] == self.source
+
+        def done(self) -> bool:
+            return True
+
+        def cancel(self) -> None:
+            raise AssertionError("completed handle must not be cancelled")
+
+        def snapshot(self) -> Snapshot:
+            return Snapshot()
+
+        def result(self) -> int:
+            return 1
+
+    async def get_size(_scope: ExecutionScope, _url: str) -> Success[int]:
+        return Success(1)
+
+    class FakeSession:
+        def start_transfer(self, sources: list[str], *_args: object, **_kwargs: object) -> Handle:
+            started.append(sources[0])
+            return Handle(sources[0])
+
+    monkeypatch.setattr(Fetcher, "get_size", get_size)
+    monkeypatch.setattr(transfer_module, "TransferWorkerLimit", WorkerLimit)
+
+    episode = make_resource_only_episode()
+    episode["videos"] = [
+        {
+            "url": "video",
+            "mirrors": [],
+            "codec": "avc",
+            "width": 1920,
+            "height": 1080,
+            "quality": 80,
+        }
+    ]
+    episode["audios"] = [
+        {
+            "url": "audio",
+            "mirrors": [],
+            "codec": "mp4a",
+            "width": 0,
+            "height": 0,
+            "quality": 30280,
+        }
+    ]
+    base_request = make_request(tmp_path, video=True, audio=True)
+    plan = DownloadPlanner().plan(episode, type(base_request).model_validate(base_request.model_dump()))
+
+    await download_video_and_audio(
+        ExecutionScope(cast("Any", FakeSession()), download_workers=1),
+        plan,
+    )
+
+    assert started == ["video", "audio"]
 
 
 @as_sync


### PR DESCRIPTION
## 动机

yutto 同时下载视频和音频时，会静态拆分 `--num-workers`。较短的音频完成后，其 worker 额度无法被仍在下载的视频复用，导致剩余阶段的 Range 并发低于用户配置。

## 解决方案

- 为 Haya 新增可共享的 `WorkerLimit`，以 Tokio semaphore 限制多个 Downloader 的 aggregate active Range 数量。
- 每个 Downloader 最多只登记一个 FIFO permit waiter，避免单条流提前排满共享队列。
- permit 仅覆盖真实 HTTP Range attempt；等待 permit 不计入网络 attempt timeout，也不覆盖 cooldown、文件写入或 flush。
- 为 PyO3 增加 `TransferWorkerLimit`，一次音视频下载中的 native handle 共享同一个限制器。
- 当 `--num-workers >= 2` 时同时启动音视频，两条流结束后额度自动被存活流复用；`--num-workers 1` 保持原有串行 setup 和失败副作用。
- 不改变默认 `block-size`、ordered window、`jobs × num-workers` 或 server 的现有语义。

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [x] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [x] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

## 验证

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `uv run maturin develop`
- `just fmt`
- `just lint`
- `uv run pytest tests/test_processor/test_downloader.py -q`（18 passed）
- `just test`（323 passed, 1 skipped）
