### PR TITLE
🐛 fix: distinguish preview episode filenames

### DIFF
--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -63,11 +63,12 @@ def build_bangumi_info(
     auto_subpath_template: str = "{name}",
 ) -> EpisodeInfo:
     avid = bangumi_info["avid"]
+    episode_name_prefix = "【预告】" if bangumi_info["is_preview"] else ""
     subpath_variables_base: PathTemplateVariableDict = {
         "id": bangumi_info["id"],
         "aid": str(avid.as_aid()),
         "bvid": str(avid.as_bvid()),
-        "name": bangumi_info["name"],
+        "name": f"{episode_name_prefix}{bangumi_info['name']}",
         "title": UNKNOWN,
         "username": UNKNOWN,
         "series_title": UNKNOWN,
@@ -85,7 +86,7 @@ def build_bangumi_info(
             avid=avid,
             cid=bangumi_info["cid"],
             url=f"https://www.bilibili.com/bangumi/play/ep{bangumi_info['episode_id']}",
-            name=bangumi_info["name"],
+            name=f"{episode_name_prefix}{bangumi_info['name']}",
             title=str(subpath_variables_base["title"]),
             cover_url=bangumi_info["metadata"]["thumb"],
             uploader=uploader,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## 动机

番剧预告默认会被下载，但预告与下一周上线的正式剧集可能使用同一个标题。已有预告文件会让正式剧集因路径相同而被误判为已下载。

## 解决方案

- 对番剧列表中标记为预告的条目，在展示名称和输出路径名称前增加 `【预告】`
- 保持原始元数据标题不变

验证：

- `just fmt`
- `just lint`
- 使用 `ep4292433 -b -p=-1` 完成真实音频下载与合并，产物为 `【预告】xxxxx.m4a`

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
