### PR TITLE
✨ feat: add preview skipping option

### DIFF
--- a/docs/guide/cli/batch.md
+++ b/docs/guide/cli/batch.md
@@ -83,6 +83,14 @@ yutto <url> -b -p "~3,10,12~14,16,-4~"
 - 配置项 `batch.with_section`
 - 默认值 `False`
 
+## 跳过预告片
+
+- 参数 `--skip-preview`
+- 配置项 `batch.skip_preview`
+- 默认值 `False`
+
+启用后，番剧批量下载会在选集前排除预告片。因此 `--skip-preview -p=-1` 会选择最后一话正式内容。
+
 ## 指定稿件发布时间范围
 
 - 参数 `--batch-filter-start-time` 和 `--batch-filter-end-time` 分别表示`开始`和`结束`时间，该区间**左闭右开**

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -261,6 +261,11 @@
           "title": "With Section",
           "type": "boolean"
         },
+        "skip_preview": {
+          "default": false,
+          "title": "Skip Preview",
+          "type": "boolean"
+        },
         "batch_filter_start_time": {
           "anyOf": [
             {
@@ -486,6 +491,7 @@
       "$ref": "#/$defs/YuttoBatchSettings",
       "default": {
         "with_section": false,
+        "skip_preview": false,
         "batch_filter_start_time": null,
         "batch_filter_end_time": null
       }

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -455,6 +455,12 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
         help="同时下载附加剧集（PV、预告以及特别篇等专区内容）",
     )
     group_batch.add_argument(
+        "--skip-preview",
+        action="store_true",
+        default=settings.batch.skip_preview,
+        help="跳过预告片",
+    )
+    group_batch.add_argument(
         "--batch-filter-start-time",
         default=settings.batch.batch_filter_start_time,
         help="只下载该时间之后（包含临界值）发布的稿件",

--- a/src/yutto/cli/request_adapter.py
+++ b/src/yutto/cli/request_adapter.py
@@ -35,6 +35,7 @@ def download_request_from_namespace(args: argparse.Namespace) -> DownloadRequest
         },
         "selection": {
             "episodes": args.episodes,
+            "skip_preview": args.skip_preview,
             "start_time": args.batch_filter_start_time,
             "end_time": args.batch_filter_end_time,
         },
@@ -125,6 +126,7 @@ def _download_request_defaults_from_settings(settings: YuttoSettings) -> dict[st
         "scope": {"batch": False, "with_section": settings.batch.with_section},
         "selection": {
             "episodes": "1~-1",
+            "skip_preview": settings.batch.skip_preview,
             "start_time": settings.batch.batch_filter_start_time,
             "end_time": settings.batch.batch_filter_end_time,
         },

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -77,6 +77,7 @@ class YuttoDanmakuSettings(BaseModel):
 
 class YuttoBatchSettings(BaseModel):
     with_section: Annotated[bool, Field(False)]
+    skip_preview: Annotated[bool, Field(False)]
     batch_filter_start_time: Annotated[str | None, Field(None)]
     batch_filter_end_time: Annotated[str | None, Field(None)]
 

--- a/src/yutto/core/request.py
+++ b/src/yutto/core/request.py
@@ -39,6 +39,7 @@ class SelectionRequestOptions(_RequestModel):
     """Filters applied while selecting episodes from an expanded scope."""
 
     episodes: str = "1~-1"
+    skip_preview: bool = False
     start_time: str | None = None
     end_time: str | None = None
 

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -373,6 +373,7 @@ class DownloadManager:
                 extractor_options = ExtractorOptions(
                     episodes=request.selection.episodes,
                     with_section=request.scope.with_section,
+                    skip_preview=request.selection.skip_preview,
                     require_video=request.resources.video,
                     require_audio=request.resources.audio,
                     require_danmaku=request.resources.danmaku,

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -85,9 +85,11 @@ class BangumiBatchExtractor(BatchExtractor):
         bangumi_list["pages"] = list(
             filter(lambda item: options["with_section"] or not item["is_section"], bangumi_list["pages"])
         )
+        if options["skip_preview"]:
+            bangumi_list["pages"] = list(filter(lambda item: not item["is_preview"], bangumi_list["pages"]))
         # 选集过滤
         episodes = parse_episodes_selection(options["episodes"], len(bangumi_list["pages"]))
-        bangumi_list["pages"] = list(filter(lambda item: item["id"] in episodes, bangumi_list["pages"]))
+        bangumi_list["pages"] = [item for index, item in enumerate(bangumi_list["pages"], start=1) if index in episodes]
         return ResolveOutcome(
             items=tuple(
                 make_bangumi_episode(

--- a/src/yutto/types.py
+++ b/src/yutto/types.py
@@ -218,6 +218,7 @@ class MultiLangSubtitle(TypedDict):
 class ExtractorOptions(TypedDict):
     episodes: str
     with_section: bool
+    skip_preview: bool
     require_video: bool
     require_audio: bool
     require_danmaku: bool

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -32,6 +32,7 @@ def test_default_namespace_maps_to_grouped_core_request():
     assert request.access.auth_profile == "default"
     assert request.scope.batch is False
     assert request.selection.episodes == "1~-1"
+    assert request.selection.skip_preview is False
     assert request.resources.video is True
     assert request.resources.metadata is False
     assert request.stream.video_download_codec == "avc"
@@ -58,6 +59,7 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
                 "--episodes",
                 "2,4~6",
                 "--with-section",
+                "--skip-preview",
                 "--batch-filter-start-time",
                 "2026-01-01",
                 "--batch-filter-end-time",
@@ -137,6 +139,7 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
     assert request.scope.model_dump() == {"batch": True, "with_section": True}
     assert request.selection.model_dump() == {
         "episodes": "2,4~6",
+        "skip_preview": True,
         "start_time": "2026-01-01",
         "end_time": "2026-02-01",
     }

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -67,6 +67,7 @@ def make_request(tmp_dir: Path | None) -> DownloadRequest:
             "scope": {"batch": False, "with_section": True},
             "selection": {
                 "episodes": "2,4",
+                "skip_preview": True,
                 "start_time": "2024-01-02 03:04:05",
                 "end_time": "2025-06-07",
             },
@@ -189,6 +190,7 @@ async def test_process_request_preserves_extractor_mapping_and_passes_download_r
     assert captured_extractor_options == {
         "episodes": "2,4",
         "with_section": True,
+        "skip_preview": True,
         "require_video": True,
         "require_audio": False,
         "require_danmaku": True,

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -147,6 +147,7 @@ async def test_manager_reports_unmatched_url_as_structured_error(monkeypatch: py
 EMPTY_EXTRACTOR_OPTIONS: ExtractorOptions = {
     "episodes": "1",
     "with_section": False,
+    "skip_preview": False,
     "require_video": True,
     "require_audio": True,
     "require_danmaku": True,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## 动机

部分用户希望追番时完全不下载预告片，并让 `-p=-1` 始终选择最后一话正式内容。

本 PR 是 #816 的上层 PR。

## 解决方案

- 添加番剧批量参数 `--skip-preview` 与配置项 `batch.skip_preview`
- 在解析 `-p/--episodes` 前过滤预告片，并按过滤后列表的位置选集，因此 `--skip-preview -p=-1` 会选择最后一话正式内容
- 将选项接入核心请求、CLI/服务端请求适配和提取器选项
- 更新配置 schema、批量下载文档及请求映射测试

验证：

- `just fmt`
- `just lint`
- 35 个相关请求映射、管理器和结构化错误测试
- `just docs-build`

## 类型

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
