### PR TITLE
✨ feat: rename extra episodes option

### DIFF
--- a/docs/guide/cli/batch.md
+++ b/docs/guide/cli/batch.md
@@ -79,9 +79,11 @@ yutto <url> -b -p "~3,10,12~14,16,-4~"
 
 ## 同时下载附加剧集
 
-- 参数 `-s` 或 `--with-section`
-- 配置项 `batch.with_section`
+- 参数 `--with-extra-episodes`
+- 配置项 `batch.with_extra_episodes`
 - 默认值 `False`
+
+`-s` 和 `--with-section` 已弃用。目前仍可兼容旧脚本，但会打印弃用提示，请迁移到 `--with-extra-episodes`。
 
 ## 跳过预告片
 

--- a/docs/guide/cli/introduction.md
+++ b/docs/guide/cli/introduction.md
@@ -102,7 +102,7 @@ block_keyword_patterns = [
 
 [batch]
 # 下载额外剧集
-with_section = true
+with_extra_episodes = true
 ```
 
 如果你使用 VS Code 对配置文件编辑，强烈建议使用 [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) 扩展，配合我提供的 schema，可以获得最佳的提示体验。

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -256,9 +256,9 @@
     },
     "YuttoBatchSettings": {
       "properties": {
-        "with_section": {
+        "with_extra_episodes": {
           "default": false,
-          "title": "With Section",
+          "title": "With Extra Episodes",
           "type": "boolean"
         },
         "skip_preview": {
@@ -490,7 +490,7 @@
     "batch": {
       "$ref": "#/$defs/YuttoBatchSettings",
       "default": {
-        "with_section": false,
+        "with_extra_episodes": false,
         "skip_preview": false,
         "batch_filter_start_time": null,
         "batch_filter_end_time": null

--- a/src/yutto/cli/cli.py
+++ b/src/yutto/cli/cli.py
@@ -33,6 +33,21 @@ SUBCOMMANDS: list[str] = ["download", "auth", "serve"]
 REMOVED_TOP_LEVEL_SUBCOMMANDS: list[str] = ["login"]
 
 
+class _DeprecatedExtraEpisodesAction(argparse.Action):
+    def __init__(self, option_strings: Sequence[str], dest: str, **kwargs: Any):
+        super().__init__(option_strings, dest, nargs=0, **kwargs)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        Logger.deprecated_warning(f"参数 {option_string} 已弃用，推荐改用 --with-extra-episodes")
+        setattr(namespace, self.dest, True)
+
+
 def handle_default_subcommand(argv: list[str]) -> list[str]:
     if len(argv) == 0:
         return ["download", *argv]
@@ -448,11 +463,18 @@ def add_download_arguments(parser: argparse.ArgumentParser, settings: YuttoSetti
     group_batch.add_argument("-b", "--batch", action="store_true", help="批量下载")
     group_batch.add_argument("-p", "--episodes", default="1~-1", help="选集")
     group_batch.add_argument(
+        "--with-extra-episodes",
+        action="store_true",
+        default=settings.batch.with_extra_episodes,
+        help="同时下载附加剧集（PV、预告以及特别篇等专区内容）",
+    )
+    group_batch.add_argument(
         "-s",
         "--with-section",
-        action="store_true",
-        default=settings.batch.with_section,
-        help="同时下载附加剧集（PV、预告以及特别篇等专区内容）",
+        dest="with_extra_episodes",
+        action=_DeprecatedExtraEpisodesAction,
+        default=argparse.SUPPRESS,
+        help="（弃用）等同于 --with-extra-episodes，请迁移到正式名称",
     )
     group_batch.add_argument(
         "--skip-preview",

--- a/src/yutto/cli/request_adapter.py
+++ b/src/yutto/cli/request_adapter.py
@@ -31,7 +31,7 @@ def download_request_from_namespace(args: argparse.Namespace) -> DownloadRequest
         },
         "scope": {
             "batch": args.batch,
-            "with_section": args.with_section,
+            "with_extra_episodes": args.with_extra_episodes,
         },
         "selection": {
             "episodes": args.episodes,
@@ -123,7 +123,7 @@ def _download_request_defaults_from_settings(settings: YuttoSettings) -> dict[st
             "login_strict": settings.basic.login_strict,
             "vip_strict": settings.basic.vip_strict,
         },
-        "scope": {"batch": False, "with_section": settings.batch.with_section},
+        "scope": {"batch": False, "with_extra_episodes": settings.batch.with_extra_episodes},
         "selection": {
             "episodes": "1~-1",
             "skip_preview": settings.batch.skip_preview,

--- a/src/yutto/cli/settings.py
+++ b/src/yutto/cli/settings.py
@@ -76,7 +76,7 @@ class YuttoDanmakuSettings(BaseModel):
 
 
 class YuttoBatchSettings(BaseModel):
-    with_section: Annotated[bool, Field(False)]
+    with_extra_episodes: Annotated[bool, Field(False)]
     skip_preview: Annotated[bool, Field(False)]
     batch_filter_start_time: Annotated[str | None, Field(None)]
     batch_filter_end_time: Annotated[str | None, Field(None)]

--- a/src/yutto/core/request.py
+++ b/src/yutto/core/request.py
@@ -32,7 +32,7 @@ class ScopeRequestOptions(_RequestModel):
     """Whether resolution targets one episode or an expanded collection."""
 
     batch: bool = False
-    with_section: bool = False
+    with_extra_episodes: bool = False
 
 
 class SelectionRequestOptions(_RequestModel):

--- a/src/yutto/download_manager.py
+++ b/src/yutto/download_manager.py
@@ -372,7 +372,7 @@ class DownloadManager:
             if extractor.match(url):
                 extractor_options = ExtractorOptions(
                     episodes=request.selection.episodes,
-                    with_section=request.scope.with_section,
+                    with_extra_episodes=request.scope.with_extra_episodes,
                     skip_preview=request.selection.skip_preview,
                     require_video=request.resources.video,
                     require_audio=request.resources.audio,

--- a/src/yutto/extractor/bangumi_batch.py
+++ b/src/yutto/extractor/bangumi_batch.py
@@ -81,9 +81,12 @@ class BangumiBatchExtractor(BatchExtractor):
 
         bangumi_list = await get_bangumi_list(scope, self.season_id)
         emit_download_report(bangumi_list["title"], badge="番剧")
-        # 如果没有 with_section 则不需要专区内容
+        # 如果没有 with_extra_episodes 则不需要专区内容
         bangumi_list["pages"] = list(
-            filter(lambda item: options["with_section"] or not item["is_section"], bangumi_list["pages"])
+            filter(
+                lambda item: options["with_extra_episodes"] or not item["is_section"],
+                bangumi_list["pages"],
+            )
         )
         if options["skip_preview"]:
             bangumi_list["pages"] = list(filter(lambda item: not item["is_preview"], bangumi_list["pages"]))

--- a/src/yutto/types.py
+++ b/src/yutto/types.py
@@ -217,7 +217,7 @@ class MultiLangSubtitle(TypedDict):
 
 class ExtractorOptions(TypedDict):
     episodes: str
-    with_section: bool
+    with_extra_episodes: bool
     skip_preview: bool
     require_video: bool
     require_audio: bool

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 import yutto.__main__ as main_module
+import yutto.cli.cli as cli_module
 from yutto.cli.cli import add_download_arguments, cli, handle_default_subcommand
 from yutto.cli.request_adapter import (
     download_request_from_mapping,
@@ -58,7 +59,7 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
                 "--batch",
                 "--episodes",
                 "2,4~6",
-                "--with-section",
+                "--with-extra-episodes",
                 "--skip-preview",
                 "--batch-filter-start-time",
                 "2026-01-01",
@@ -136,7 +137,7 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
         "login_strict": True,
         "vip_strict": True,
     }
-    assert request.scope.model_dump() == {"batch": True, "with_section": True}
+    assert request.scope.model_dump() == {"batch": True, "with_extra_episodes": True}
     assert request.selection.model_dump() == {
         "episodes": "2,4~6",
         "skip_preview": True,
@@ -195,6 +196,23 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
         "block_colorful": True,
         "block_keyword_patterns": ["spoiler", "广告"],
     }
+
+
+def test_extra_episodes_cli_option():
+    args = parse_download_args(["BV1xx411c7mD", "--with-extra-episodes"])
+
+    assert args.with_extra_episodes is True
+
+
+@pytest.mark.parametrize("option", ["-s", "--with-section"])
+def test_deprecated_extra_episodes_cli_options_warn_and_map_to_new_name(option: str, monkeypatch: pytest.MonkeyPatch):
+    warnings: list[str] = []
+    monkeypatch.setattr(cli_module.Logger, "deprecated_warning", warnings.append)
+
+    args = parse_download_args(["BV1xx411c7mD", option])
+
+    assert args.with_extra_episodes is True
+    assert warnings == [f"参数 {option} 已弃用，推荐改用 --with-extra-episodes"]
 
 
 def test_cli_and_secret_options_do_not_cross_core_boundary(tmp_path: Path):

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -198,12 +198,6 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
     }
 
 
-def test_extra_episodes_cli_option():
-    args = parse_download_args(["BV1xx411c7mD", "--with-extra-episodes"])
-
-    assert args.with_extra_episodes is True
-
-
 @pytest.mark.parametrize("option", ["-s", "--with-section"])
 def test_deprecated_extra_episodes_cli_options_warn_and_map_to_new_name(option: str, monkeypatch: pytest.MonkeyPatch):
     warnings: list[str] = []

--- a/tests/test_core/test_request.py
+++ b/tests/test_core/test_request.py
@@ -7,7 +7,6 @@ from typing import Any
 import pytest
 
 import yutto.__main__ as main_module
-import yutto.cli.cli as cli_module
 from yutto.cli.cli import add_download_arguments, cli, handle_default_subcommand
 from yutto.cli.request_adapter import (
     download_request_from_mapping,
@@ -196,17 +195,6 @@ def test_namespace_adapter_preserves_download_semantics(tmp_path: Path):
         "block_colorful": True,
         "block_keyword_patterns": ["spoiler", "广告"],
     }
-
-
-@pytest.mark.parametrize("option", ["-s", "--with-section"])
-def test_deprecated_extra_episodes_cli_options_warn_and_map_to_new_name(option: str, monkeypatch: pytest.MonkeyPatch):
-    warnings: list[str] = []
-    monkeypatch.setattr(cli_module.Logger, "deprecated_warning", warnings.append)
-
-    args = parse_download_args(["BV1xx411c7mD", option])
-
-    assert args.with_extra_episodes is True
-    assert warnings == [f"参数 {option} 已弃用，推荐改用 --with-extra-episodes"]
 
 
 def test_cli_and_secret_options_do_not_cross_core_boundary(tmp_path: Path):

--- a/tests/test_processor/test_manager_semantics.py
+++ b/tests/test_processor/test_manager_semantics.py
@@ -64,7 +64,7 @@ def make_request(tmp_dir: Path | None) -> DownloadRequest:
     return DownloadRequest.model_validate(
         {
             "source": {"url": "BV1baseline"},
-            "scope": {"batch": False, "with_section": True},
+            "scope": {"batch": False, "with_extra_episodes": True},
             "selection": {
                 "episodes": "2,4",
                 "skip_preview": True,
@@ -189,7 +189,7 @@ async def test_process_request_preserves_extractor_mapping_and_passes_download_r
     ]
     assert captured_extractor_options == {
         "episodes": "2,4",
-        "with_section": True,
+        "with_extra_episodes": True,
         "skip_preview": True,
         "require_video": True,
         "require_audio": False,

--- a/tests/test_processor/test_structured_errors.py
+++ b/tests/test_processor/test_structured_errors.py
@@ -146,7 +146,7 @@ async def test_manager_reports_unmatched_url_as_structured_error(monkeypatch: py
 
 EMPTY_EXTRACTOR_OPTIONS: ExtractorOptions = {
     "episodes": "1",
-    "with_section": False,
+    "with_extra_episodes": False,
     "skip_preview": False,
     "require_video": True,
     "require_audio": True,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

`--with-section` 使用了 Bilibili API 的内部字段名，无法直观表达该选项会下载 PV、预告和特别篇等附加剧集。

## 解决方案

- 将正式 CLI 选项重命名为 `--with-extra-episodes`。
- 仅在 CLI 兼容旧的 `-s` 和 `--with-section`，使用时打印弃用提示并建议迁移。
- 配置项、请求模型和提取器内部统一使用 `with_extra_episodes`；旧 TOML 配置项和 RPC 字段不做兼容。
- 同步更新配置 schema、文档和测试。

验证：

- `just fmt`
- `just lint`
- `uv run -p 3.11 pytest tests/test_core/test_request.py tests/test_processor/test_manager_semantics.py tests/test_processor/test_structured_errors.py -q`（35 passed）
- `just docs-build`
- `git diff --check`

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [x] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [x] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [x] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
