### PR TITLE
🧑‍💻 dx: track native sources in uv cache keys

### DIFF
--- a/packages/biliass/pyproject.toml
+++ b/packages/biliass/pyproject.toml
@@ -35,6 +35,18 @@ Issues = "https://github.com/yutto-dev/yutto/issues"
 [project.scripts]
 biliass = "biliass.__main__:main"
 
+[tool.uv]
+cache-keys = [
+  { file = "pyproject.toml" },
+  { file = "rust/Cargo.toml" },
+  { file = "rust/Cargo.lock" },
+  { file = "rust/build.rs" },
+  { file = "rust/src/**/*.rs" },
+  { file = "rust/proto/**/*.proto" },
+  { env = "MATURIN_PEP517_ARGS" },
+  { env = "RUSTFLAGS" },
+]
+
 [tool.maturin]
 features = ["pyo3/extension-module"]
 module-name = "biliass._core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,17 @@ dev = [
   "pytest-codspeed>=5.0.3",
 ]
 
+[tool.uv]
+cache-keys = [
+  { file = "pyproject.toml" },
+  { file = "rust/Cargo.toml" },
+  { file = "rust/Cargo.lock" },
+  { file = "rust/crates/*/Cargo.toml" },
+  { file = "rust/crates/*/src/**/*.rs" },
+  { env = "MATURIN_PEP517_ARGS" },
+  { env = "RUSTFLAGS" },
+]
+
 [tool.uv.sources]
 biliass = { workspace = true }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

`yutto` 和 workspace 中的 `biliass` 都是 maturin editable package，但 uv 默认不会把 Rust 源码作为本地构建缓存的失效条件。仅修改 Rust 构建输入后直接运行 `uv run`，可能继续加载旧的原生扩展。

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

## 解决方案

- 分别在 yutto 与 biliass 的 `pyproject.toml` 中配置项目级 `tool.uv.cache-keys`
- 精确跟踪各自的 Cargo manifests、lockfile 和 Rust 源码，避免匹配 `target/` 生成文件
- 为 biliass 补充 `build.rs` 与 protobuf 输入，为两者补充 `MATURIN_PEP517_ARGS` 和 `RUSTFLAGS`

验证：

- `just fmt`
- `just lint`
- `uv lock --check`
- `uv sync --dry-run`（首次重建后显示 `Would make no changes`）
- `uv run --no-sync python -c 'import biliass._core, yutto._core'`

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [x] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [x] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
