### PR TITLE
🐛 fix: stabilize transient fetch failures

### DIFF
--- a/src/yutto/utils/fetcher.py
+++ b/src/yutto/utils/fetcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import random
 from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import quote, unquote, urlparse
@@ -31,46 +32,59 @@ RetT = TypeVar("RetT")
 InputT = ParamSpec("InputT")
 
 
-class MaxRetry:
-    """重试装饰器，为请求方法提供一定的重试次数
+class WithReconnect:
+    """重连装饰器，为请求方法提供一定的额外尝试次数。"""
 
-    ### Args
+    DEFAULT_MAX_RETRY = 4
+    RETRY_BACKOFF_BASE = 0.5
+    RETRY_BACKOFF_MAX = 4.0
+    RETRY_JITTER_RATIO = 0.2
 
-    - max_retry (int): 额外重试次数（如重试次数为 2，则最多尝试 3 次）
-    """
-
-    def __init__(self, max_retry: int = 2):
+    def __init__(self, max_retry: int = DEFAULT_MAX_RETRY):
         self.max_retry = max_retry
 
     def __call__(
         self, connect_once: Callable[InputT, Coroutine[Any, Any, RetT]]
     ) -> Callable[InputT, Coroutine[Any, Any, Result[RetT, MaxRetryError]]]:
         async def connect_n_times(*args: InputT.args, **kwargs: InputT.kwargs) -> Result[RetT, MaxRetryError]:
-            retry = self.max_retry + 1
-            while retry:
+            attempts = self.max_retry + 1
+            last_error: HttpError | None = None
+            for attempt in range(attempts):
                 try:
                     return Success(await connect_once(*args, **kwargs))
                 except SessionClosedError:
                     raise
-                except HttpTimeoutError:
-                    emit_download_report(
-                        f"抓取超时，正在重试，剩余 {retry - 1} 次",
-                        level=ReportLevel.WARNING,
-                    )
-                except (InvalidUrlError, UnsupportedProtocolError) as e:
-                    raise e
-                except HttpError as e:
-                    await asyncio.sleep(0.5)
-                    error_type = e.__class__.__name__
-                    emit_download_report(
-                        f"抓取失败（{error_type}），正在重试，剩余 {retry - 1} 次",
-                        level=ReportLevel.WARNING,
-                    )
-                finally:
-                    retry -= 1
+                except (InvalidUrlError, UnsupportedProtocolError):
+                    raise
+                except HttpError as error:
+                    last_error = error
+
+                remaining = attempts - attempt - 1
+                if remaining == 0:
+                    break
+                delay = self._retry_delay(attempt)
+                error_label = (
+                    "抓取超时"
+                    if isinstance(last_error, HttpTimeoutError)
+                    else f"抓取失败（{type(last_error).__name__}）"
+                )
+                emit_download_report(
+                    f"{error_label}，将在 {delay:.1f} 秒后重试，剩余 {remaining} 次",
+                    level=ReportLevel.WARNING,
+                )
+                await asyncio.sleep(delay)
+
             return Failure(MaxRetryError("超出最大重试次数！"))
 
         return connect_n_times
+
+    @staticmethod
+    def _retry_delay(attempt: int) -> float:
+        base = min(WithReconnect.RETRY_BACKOFF_BASE * 2**attempt, WithReconnect.RETRY_BACKOFF_MAX)
+        return random.uniform(
+            base * (1 - WithReconnect.RETRY_JITTER_RATIO),
+            min(base * (1 + WithReconnect.RETRY_JITTER_RATIO), WithReconnect.RETRY_BACKOFF_MAX),
+        )
 
 
 class _FetchTrace:
@@ -145,7 +159,7 @@ def cookies_from_auth(auth_info: AuthInfo | None) -> dict[str, str]:
 
 class Fetcher:
     @staticmethod
-    @MaxRetry(2)
+    @WithReconnect()
     async def fetch_text(
         scope: ExecutionScope,
         url: str,
@@ -164,7 +178,7 @@ class Fetcher:
                 return body.decode(encoding or "utf-8", errors="replace")
 
     @staticmethod
-    @MaxRetry(2)
+    @WithReconnect()
     async def fetch_bin(
         scope: ExecutionScope,
         url: str,
@@ -182,7 +196,7 @@ class Fetcher:
                 return body
 
     @staticmethod
-    @MaxRetry(2)
+    @WithReconnect()
     async def fetch_json(
         scope: ExecutionScope,
         url: str,
@@ -200,7 +214,7 @@ class Fetcher:
                 return result
 
     @staticmethod
-    @MaxRetry(2)
+    @WithReconnect()
     async def get_redirected_url(scope: ExecutionScope, url: str) -> str:
         # 关于为什么要前往重定向 url，是因为 B 站的 url 类型实在是太多了，比如有 b23.tv 的短链接
         # 为 SEO 的搜索引擎链接、甚至有的 av、BV 链接实际上是番剧页面，一一列举实在太麻烦，而且最后一种
@@ -216,7 +230,7 @@ class Fetcher:
                 return redirected_url
 
     @staticmethod
-    @MaxRetry(2)
+    @WithReconnect()
     async def get_size(scope: ExecutionScope, url: str) -> int | None:
         async with scope.fetch_guard():
             with trace_fetch("Fetch size", url) as trace:
@@ -228,7 +242,7 @@ class Fetcher:
                 return size
 
     @staticmethod
-    @MaxRetry(2)
+    @WithReconnect()
     async def touch_url(scope: ExecutionScope, url: str) -> None:
         if url in scope.touched_urls:
             emit_download_report(f"Fetch touch skipped: {url} (cache hit)", level=ReportLevel.DEBUG)

--- a/tests/test_utils/test_fetcher.py
+++ b/tests/test_utils/test_fetcher.py
@@ -216,7 +216,11 @@ async def test_fetch_bin_keeps_non_success_status_as_success_none():
 
 
 @as_sync
-async def test_fetch_json_retries_non_success_status():
+async def test_fetch_json_retries_non_success_status(monkeypatch: pytest.MonkeyPatch):
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(fetcher_module.asyncio, "sleep", no_sleep)
     scope = ExecutionScope(cast("Any", _StatusSession(404)))
     match await Fetcher.fetch_json(scope, "https://example.com"):
         case Failure(error):


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->

## 动机

元数据 fetch 在冷连接或系统代理短暂抖动时可能连续触发固定的 5 秒超时。原实现只进行 3 次立即重试，多个并发请求还可能同步重试，容易把短暂网络问题放大为整次启动失败。

本 PR 是 Stack #829 的顶层，依赖中层调试日志改造 #825；最底层 workflow 触发优化见 #828。

## 解决方案

- 将 `MaxRetry` 重命名为更符合行为语义的类式装饰器 `WithReconnect`。
- 将 fetch 尝试预算从 3 次提高到 5 次。
- 在重连之间采用有上限的指数退避，并加入 ±20% 抖动，避免并发请求同步重试。
- 将退避参数和计算方法封装在 `WithReconnect` 内。
- 只在确实还有下一次尝试时等待；最终失败保持原有错误文案，具体底层错误由带 URL 的 fetch trace 日志呈现。

验证：

- `just fmt`
- `just lint`
- `uv run pytest tests/test_utils/test_fetcher.py -q`（15 passed）
- `just ci-test 3.11`（315 passed，1 skipped）
- 当前认证与 `proxy = auto` 下连续 10 个冷会话请求 `nav`：10/10 成功，其中一次跨过 5 秒坏窗口后自动恢复

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [x] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
