### PR TITLE
🔨 workflow: skip native builds for Python-only changes

### DIFF
--- a/.github/workflows/yutto-build-and-release.yml
+++ b/.github/workflows/yutto-build-and-release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
     paths:
-      - "src/yutto/**"
       - "rust/**"
       - "pyproject.toml"
       - "README.md"
@@ -16,7 +15,6 @@ on:
       - ".github/workflows/build-and-release.yml"
   pull_request:
     paths:
-      - "src/yutto/**"
       - "rust/**"
       - "pyproject.toml"
       - "README.md"


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->

## 动机

`Build and Release (yutto)` 当前会被 `src/yutto/**` 下的纯 Python 改动触发，导致只改 Python 逻辑的 PR 也运行完整的多平台原生 wheel 构建矩阵。Python 行为已经由 unit test 和 e2e test workflow 覆盖，无需为此重复构建所有原生发行产物。

这是 Stack #829 的最底层 PR；中层 fetch 日志改造见 #825，顶层 fetch 重连稳定性改造见 #826。

## 解决方案

- 从 yutto 构建 workflow 的 `push` 和 `pull_request` 路径过滤中移除 `src/yutto/**`。
- 保留 `rust/**`、`pyproject.toml`、README、LICENSE 和构建 workflow 自身作为触发路径。
- 保留 `merge_group` 的最终构建验证。

验证：

- `just fmt`
- `just lint`
- 使用 Ruby YAML 解析器加载全部 `.github/workflows/*.yml`
- #825 的 Python-only head `7389d76` 与 #826 的 Python-only head `83b0952` 均未触发 `Build and Release (yutto)`

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [x] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
