### PR TITLE
♻️ refactor: remove unused runtime event annotation contract

### DIFF
--- a/src/yutto/core/events.py
+++ b/src/yutto/core/events.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path  # noqa: TC003 - runtime type hints are part of the event contract
-from typing import Literal, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 
-from yutto.core.result import (  # noqa: TC001 - runtime type hints support schema introspection
-    ItemSkipReason,
-    ResolvedItem,
-)
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from yutto.core.result import ItemSkipReason, ResolvedItem
 
 
 class DownloadStage(StrEnum):

--- a/tests/test_core/test_task_service.py
+++ b/tests/test_core/test_task_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING, get_type_hints
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -178,12 +178,6 @@ async def test_download_events_are_noop_outside_application_context():
 )
 def test_runtime_event_encoding_preserves_protocol(event, expected):
     assert _encode_runtime_event(event) == expected
-
-
-def test_download_event_annotations_are_available_at_runtime():
-    assert get_type_hints(DownloadArtifactCreated)["path"] is Path
-    assert get_type_hints(DownloadItemSkipped)["reason"] is ItemSkipReason
-    assert get_type_hints(DownloadItemListed)["item"] is ResolvedItem
 
 
 def test_encode_runtime_event_item_listed_carries_full_wire_fields():


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

事件 dataclass 的类型注解目前没有生产代码在运行时反射，但为了维持这一未使用的行为，相关类型仍被运行时导入，并由一个专门的 `get_type_hints()` 测试固定下来。

## 解决方案

- 删除没有实际消费者的运行时类型注解测试
- 将 `Path`、`ItemSkipReason` 和 `ResolvedItem` 导入移入 `TYPE_CHECKING`
- 移除对应的 `TC001` / `TC003` 抑制

验证：

- `just fmt`
- `just lint`
- `uv run pytest tests/test_core/test_task_service.py -q`（10 passed）

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [x] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [x] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [ ] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol xhigh)</sup>
</div>
