### PR TITLE
🐛 fix: improve terminal width detection for wide characters

### DIFF
--- a/src/yutto/utils/console/formatter.py
+++ b/src/yutto/utils/console/formatter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import unicodedata
 from typing import Literal
 
 from yutto.utils.console.colorful import no_colored_string
@@ -40,10 +41,22 @@ def get_char_width(char: str) -> int:
     o = ord(char)
     if o == 0xE or o == 0xF:
         return 0
+
+    width = 1
     for num, wid in widths:
         if o <= num:
-            return wid
-    return 1
+            width = wid
+            break
+
+    # 旧表中的部分现代宽字符可能仍被判为 1，这里用当前 Unicode 宽度属性补正为 2 。
+    if (
+        width == 1
+        and unicodedata.category(char) not in {"Mn", "Me", "Mc", "Cf"}
+        and unicodedata.east_asian_width(char) in {"W", "F"}
+    ):
+        return 2
+
+    return width
 
 
 def get_string_width(string: str) -> int:

--- a/tests/test_utils/test_formatter.py
+++ b/tests/test_utils/test_formatter.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from yutto.utils.console.formatter import get_char_width, get_string_width
+
+
+@pytest.mark.parametrize(
+    ("char", "expected"),
+    [
+        ("a", 1),
+        ("中", 2),
+        ("⚡", 2),
+        ("\u0301", 0),
+    ],
+)
+def test_get_char_width(char: str, expected: int):
+    assert get_char_width(char) == expected
+
+
+def test_get_string_width():
+    assert get_string_width("/⚡") == 3


### PR DESCRIPTION
## 动机

终端进度条在高速下载时会使用 `/⚡` 作为速度后缀。

现有字符宽度表会将 `⚡`（U+26A1）判断为 1 个终端单元格，但其 Unicode East Asian Width 属性为 `W`，实际终端通常按 2 个单元格显示。这会导致进度条总宽度少计算 1，进而导致终端连续换行。

该问题在 #803 后出现。

## 解决方案

保留现有老旧字符宽度表的行为，并在字符原本被判断为宽度 1 时，使用 Python `unicodedata` 中的 East Asian Width 信息补充旧表遗漏的 `W` / `F` 宽字符。

同时添加字符宽度相关测试，覆盖普通 ASCII、中文、组合字符以及 `⚡` 和 `/⚡` 的宽度计算。

如果维护者认为这种方向更合适，我也可以在后续 PR 中引入 `wcwidth`，进一步重构 `formatter` 中的终端字符宽度计算逻辑。

已通过：

- `just fmt`
- `just lint`
- `uv run pytest -q tests/test_utils/test_formatter.py`
- `uv run pytest -q tests/test_cli.py tests/test_utils/test_status_bar.py`

## 类型

- [x] :bug: fix: 修复 bug
- [x] :white_check_mark: test: 测试用例添加及修改
