### PR TITLE
⚡ perf: reuse collection metadata

### DIFF
--- a/src/yutto/api/collection.py
+++ b/src/yutto/api/collection.py
@@ -1,63 +1,67 @@
 from __future__ import annotations
 
-import asyncio
 import math
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
-from yutto.types import BvId
+from yutto.types import BvId, MId
 from yutto.utils.fetcher import Fetcher, unwrap_fetch_result
 
 if TYPE_CHECKING:
     from yutto.core.execution import ExecutionScope
-    from yutto.types import AvId, MId, SeriesId
+    from yutto.types import AvId, SeriesId
 
 
 class CollectionDetailsItem(TypedDict):
     id: int
-    title: str
     avid: AvId
 
 
 class CollectionDetails(TypedDict):
+    mid: MId
     title: str
     pages: list[CollectionDetailsItem]
 
 
-async def get_collection_details(scope: ExecutionScope, series_id: SeriesId, mid: MId) -> CollectionDetails:
-    title, avids = await asyncio.gather(
-        _get_collection_title(scope, series_id),
-        _get_collection_avids(scope, series_id, mid),
+async def _get_collection_page(
+    scope: ExecutionScope,
+    series_id: SeriesId,
+    pn: int,
+    ps: int,
+) -> dict[str, Any]:
+    api = "https://api.bilibili.com/x/polymer/web-space/seasons_archives_list?season_id={series_id}&sort_reverse=false&page_num={pn}&page_size={ps}"
+    collection_url = api.format(
+        series_id=series_id,
+        pn=pn,
+        ps=ps,
     )
-    return CollectionDetails(
-        title=title,
-        pages=[
-            CollectionDetailsItem(
-                id=i + 1,
-                title="",  # TODO: 这里应该是合集内的标题，但目前没找到相关的 API
-                avid=avid,
-            )
-            for i, avid in enumerate(avids)
-        ],
-    )
+    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, collection_url))
+    return json_data["data"]
 
 
-async def _get_collection_avids(scope: ExecutionScope, series_id: SeriesId, mid: MId) -> list[AvId]:
-    api = "https://api.bilibili.com/x/polymer/web-space/seasons_archives_list?mid={mid}&season_id={series_id}&sort_reverse=false&page_num={pn}&page_size={ps}"
+async def get_collection_details(
+    scope: ExecutionScope,
+    series_id: SeriesId,
+) -> CollectionDetails:
     ps = 30
-    pn = 1
-    total = 1
-    all_avid: list[AvId] = []
 
-    while pn <= total:
-        space_videos_url = api.format(series_id=series_id, ps=ps, pn=pn, mid=mid)
-        json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, space_videos_url))
-        total = math.ceil(json_data["data"]["page"]["total"] / ps)
-        pn += 1
-        all_avid += [BvId(archives["bvid"]) for archives in json_data["data"]["archives"]]
-    return all_avid
+    data = await _get_collection_page(scope, series_id, 1, ps)
 
+    mid = MId(str(data["meta"]["mid"]))
+    title = data["meta"]["title"]
+    total = math.ceil(data["page"]["total"] / ps)
 
-async def _get_collection_title(scope: ExecutionScope, series_id: SeriesId) -> str:
-    api = "https://api.bilibili.com/x/v1/medialist/info?type=8&biz_id={series_id}"
-    json_data = unwrap_fetch_result(await Fetcher.fetch_json(scope, api.format(series_id=series_id)))
-    return json_data["data"]["title"]
+    pages: list[CollectionDetailsItem] = []
+
+    for pn in range(1, total + 1):
+        if pn > 1:
+            data = await _get_collection_page(scope, series_id, pn, ps)
+
+        pages.extend(
+            CollectionDetailsItem(
+                id=ps * (pn - 1) + i + 1,
+                avid=BvId(archive["bvid"]),
+            )
+            for i, archive in enumerate(data["archives"])
+        )
+
+    return CollectionDetails(mid=mid, title=title, pages=pages)

--- a/src/yutto/api/ugc_video.py
+++ b/src/yutto/api/ugc_video.py
@@ -18,7 +18,9 @@ from yutto.types import (
     BvId,
     CId,
     EpisodeId,
+    MId,
     MultiLangSubtitle,
+    SeriesId,
     VideoUrlMeta,
     format_ids,
 )
@@ -37,6 +39,11 @@ class _UgcVideoPageInfo(TypedDict):
     part: str
 
 
+class _UgcCollectionInfo(TypedDict):
+    series_id: SeriesId
+    title: str
+
+
 class _UgcVideoInfo(TypedDict):
     avid: AvId
     aid: AId
@@ -45,6 +52,9 @@ class _UgcVideoInfo(TypedDict):
     is_bangumi: bool
     picture: str
     title: str
+    collection: _UgcCollectionInfo | None
+    owner_uid: MId
+    owner_uname: str
     pubdate: int
     description: str
     pages: list[_UgcVideoPageInfo]
@@ -58,11 +68,14 @@ class UgcVideoListItem(TypedDict):
     name: str
     avid: AvId
     cid: CId
+    owner_uid: MId
+    owner_uname: str
     metadata: MetaData
 
 
 class UgcVideoList(TypedDict):
     title: str
+    collection: _UgcCollectionInfo | None
     pubdate: int
     avid: AvId
     pages: list[UgcVideoListItem]
@@ -104,6 +117,7 @@ async def get_ugc_video_info(scope: ExecutionScope, avid: AvId) -> _UgcVideoInfo
     if res_json_data.get("redirect_url") and (ep_match := regex_ep.match(res_json_data["redirect_url"])):
         episode_id = EpisodeId(ep_match.group("episode_id"))
 
+    owner = res_json_data["owner"]
     actors = _parse_actor_info(res_json_data)
     genres = _parse_genre_info(res_json_data)
     tags: list[str] = await get_ugc_video_tag(scope, avid)
@@ -115,6 +129,9 @@ async def get_ugc_video_info(scope: ExecutionScope, avid: AvId) -> _UgcVideoInfo
         is_bangumi=bool(episode_id),
         picture=res_json_data["pic"],
         title=res_json_data["title"],
+        collection=_parse_ugc_collection_info(res_json_data),
+        owner_uid=MId(str(owner["mid"])),
+        owner_uname=owner["name"],
         pubdate=res_json_data["pubdate"],
         description=res_json_data["desc"],
         pages=[
@@ -137,6 +154,7 @@ async def get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
     video_title = video_info["title"]
     result: UgcVideoList = {
         "title": video_title,
+        "collection": video_info["collection"],
         "avid": avid,
         "pubdate": video_info["pubdate"],
         "pages": [],
@@ -152,6 +170,8 @@ async def get_ugc_video_list(scope: ExecutionScope, avid: AvId) -> UgcVideoList:
             name=page_info["part"],
             avid=avid,
             cid=page_info["cid"],
+            owner_uid=video_info["owner_uid"],
+            owner_uname=video_info["owner_uname"],
             metadata=_parse_ugc_video_metadata(video_info, page_info, is_first_page=i == 0),
         )
         for i, page_info in enumerate(video_info["pages"])
@@ -353,6 +373,25 @@ def _parse_ugc_video_metadata(
         website=video_info["bvid"].to_url(),
         chapter_info_data=[],
     )
+
+
+def _parse_ugc_collection_info(video_info: dict[str, Any]) -> _UgcCollectionInfo | None:
+    ugc_season = video_info.get("ugc_season")
+    if not isinstance(ugc_season, dict):
+        return None
+
+    for section in ugc_season.get("sections", []):
+        for episode in section.get("episodes", []):
+            if episode.get("bvid") != video_info["bvid"]:
+                continue
+            title = episode.get("title")
+            season_id = episode.get("season_id")
+            if isinstance(title, str) and title and season_id is not None:
+                return _UgcCollectionInfo(
+                    series_id=SeriesId(str(season_id)),
+                    title=title,
+                )
+    return None
 
 
 def _parse_actor_info(video_info: dict[str, Any]):

--- a/src/yutto/extractor/collection.py
+++ b/src/yutto/extractor/collection.py
@@ -12,7 +12,7 @@ from yutto.extractor.common import make_ugc_video_episode
 from yutto.extractor.outcome import ResolveOutcome
 from yutto.extractor.utils.batch import resolve_ugc_video_lists
 from yutto.input_parser import parse_episodes_selection
-from yutto.types import MId, SeriesId
+from yutto.types import SeriesId
 
 if TYPE_CHECKING:
     from yutto.api.ugc_video import UgcVideoList
@@ -26,21 +26,19 @@ class CollectionExtractor(BatchExtractor):
     """视频合集"""
 
     REGEX_COLLECTION_LISTS = re.compile(
-        r"https?://space\.bilibili\.com/(?P<mid>\d+)/lists/(?P<series_id>\d+)\?type=season"
+        r"https?://space\.bilibili\.com/\d+/lists/(?P<series_id>\d+)\?type=season"
     )
     # 订阅合集后，在个人空间的收藏夹页面
     REGEX_COLLECTION_FAV_PAGE: re.Pattern[str] = re.compile(
-        r"https?://space\.bilibili\.com/(?P<mid>\d+)/favlist\?fid=(?P<series_id>\d+)&ftype=collect"
+        r"https?://space\.bilibili\.com/\d+/favlist\?fid=(?P<series_id>\d+)&ftype=collect"
     )
 
-    mid: MId
     series_id: SeriesId
 
     def match(self, url: str) -> bool:
         if (match_obj := self.REGEX_COLLECTION_LISTS.match(url)) or (
             match_obj := self.REGEX_COLLECTION_FAV_PAGE.match(url)
         ):
-            self.mid = MId(match_obj.group("mid"))
             self.series_id = SeriesId(match_obj.group("series_id"))
             return True
         else:
@@ -53,10 +51,8 @@ class CollectionExtractor(BatchExtractor):
         *,
         on_item: EpisodeListedCallback | None = None,
     ) -> ExtractorResolveOutcome:
-        username, collection_details = await asyncio.gather(
-            get_user_name(scope, self.mid),
-            get_collection_details(scope, self.series_id, self.mid),
-        )
+        collection_details = await get_collection_details(scope, self.series_id)
+        username = await get_user_name(scope, collection_details["mid"])
         collection_title = collection_details["title"]
         emit_download_report(collection_title, badge="视频合集")
 
@@ -78,6 +74,12 @@ class CollectionExtractor(BatchExtractor):
                     f"视频合集 {collection_title} 中的视频 {items[index]['avid']} 包含多个视频！",
                     ReportLevel.ERROR,
                 )
+            collection = ugc_video_list["collection"]
+            video_title = (
+                collection["title"]
+                if collection is not None and collection["series_id"] == self.series_id
+                else ugc_video_list["title"]
+            )
             built: list[ResolvableEpisode] = []
             for ugc_video_item in ugc_video_list["pages"]:
                 episode = make_ugc_video_episode(
@@ -87,10 +89,9 @@ class CollectionExtractor(BatchExtractor):
                     options,
                     {
                         # TODO: 关于对于 id 的优化
-                        # TODO: 关于对于 title 的优化（最好使用合集标题，而不是原来的视频标题）
                         "series_title": collection_title,
                         "username": username,  # 虽然默认模板的用不上，但这里可以提供一下
-                        "title": ugc_video_list["title"],
+                        "title": video_title,
                         "pubdate": ugc_video_list["pubdate"],
                     },
                     "{series_title}/{title}",

--- a/src/yutto/extractor/common.py
+++ b/src/yutto/extractor/common.py
@@ -266,14 +266,8 @@ def build_ugc_video_info(
     auto_subpath_template: str = "{title}",
     display_group: str | None = None,
 ) -> EpisodeInfo:
-    owner_uid: str = (
-        ugc_video_info["metadata"]["actor"][0]["profile"].split("/")[-1]
-        if ugc_video_info["metadata"]["actor"]
-        else UNKNOWN
-    )
-    owner_uname: str = (
-        ugc_video_info["metadata"]["actor"][0]["name"] if ugc_video_info["metadata"]["actor"] else UNKNOWN
-    )
+    owner_uid = str(ugc_video_info["owner_uid"])
+    owner_uname = ugc_video_info["owner_uname"]
     subpath_variables_base: PathTemplateVariableDict = {
         "id": ugc_video_info["id"],
         "aid": str(avid.as_aid()),

--- a/tests/test_api/test_collection.py
+++ b/tests/test_api/test_collection.py
@@ -14,12 +14,13 @@ from yutto.utils.functional import as_sync
 async def test_get_collection_details():
     # 测试页面：https://space.bilibili.com/6762654/lists?sid=39879&ctype=0
     series_id = SeriesId("39879")
-    mid = MId("6762654")
     async with create_client() as client:
         scope = ExecutionScope(client)
-        collection_details = await get_collection_details(scope, series_id=series_id, mid=mid)
+        collection_details = await get_collection_details(scope, series_id=series_id)
         title = collection_details["title"]
-        avids = [page["avid"] for page in collection_details["pages"]]
+        pages = collection_details["pages"]
+        avids = [page["avid"] for page in pages]
+        assert collection_details["mid"] == MId("6762654")
         assert title == "傻开心整活"
         assert BvId("BV1er4y1H7tQ") in avids
         assert BvId("BV1Yi4y1C7u6") in avids

--- a/tests/test_api/test_ugc_video.py
+++ b/tests/test_api/test_ugc_video.py
@@ -9,7 +9,7 @@ from yutto.api.ugc_video import (
     get_ugc_video_subtitles,
 )
 from yutto.core.execution import ExecutionScope
-from yutto.types import AId, BvId, CId, EpisodeId
+from yutto.types import AId, BvId, CId, EpisodeId, MId, SeriesId
 from yutto.utils.fetcher import create_client
 from yutto.utils.functional import as_sync
 
@@ -47,6 +47,23 @@ async def test_get_ugc_video_title():
         scope = ExecutionScope(client)
         title = (await get_ugc_video_list(scope, avid))["title"]
         assert title == "用 bilili 下载 B 站视频"
+
+
+@pytest.mark.api
+@as_sync
+async def test_get_ugc_video_collection_title():
+    avid = BvId("BV1SU4y1e78w")
+    async with create_client() as client:
+        scope = ExecutionScope(client)
+        ugc_video_list = await get_ugc_video_list(scope, avid)
+        page = ugc_video_list["pages"][0]
+        assert ugc_video_list["title"] == "【动物园怪谈解析重置版01】游客规则逐条全解"
+        assert ugc_video_list["collection"] == {
+            "series_id": SeriesId("590244"),
+            "title": "【01】游客规则逐条全解",
+        }
+        assert page["owner_uid"] == MId("5303577")
+        assert page["owner_uname"] == "狼蛹1126"
 
 
 @pytest.mark.api


### PR DESCRIPTION
## 动机

Related to #473。

合集解析目前仍会额外请求 `/x/v1/medialist/info` 获取合集标题；同时 `/x/web-interface/view` 已经包含合集内单集标题和唯一的投稿 `owner`，但这些信息没有被直接复用。

## 解决方案

直接复用 `seasons_archives_list` 返回的 `meta.title`、`meta.mid` 和 `archives` 构建合集信息，移除额外的合集标题请求以及该接口中不需要的 `mid` 参数。

解析合集视频时，复用 `/x/web-interface/view` 中的 `ugc_season` 获取当前合集内的单集标题；`owner_uid` / `owner_uname` 则直接取唯一的 `data.owner`，不再通过 `metadata.actor[0]`（可能来自 `staff`）反推。

同时补充 API 测试，验证合集标题、合集内单集标题以及投稿 owner。

## 类型

- [x] :zap: perf: 提高性能的代码修改
- [x] :white_check_mark: test: 测试用例添加及修改
