### PR TITLE
👷 ci: skip flaky UGC metadata tests

### DIFF
--- a/tests/test_api/test_ugc_video.py
+++ b/tests/test_api/test_ugc_video.py
@@ -40,6 +40,7 @@ async def test_get_ugc_video_info():
 
 
 @pytest.mark.api
+@pytest.mark.ci_skip
 @as_sync
 async def test_get_ugc_video_title():
     avid = BvId("BV1vZ4y1M7mQ")
@@ -50,6 +51,7 @@ async def test_get_ugc_video_title():
 
 
 @pytest.mark.api
+@pytest.mark.ci_skip
 @as_sync
 async def test_get_ugc_video_list():
     avid = BvId("BV1vZ4y1M7mQ")


### PR DESCRIPTION
## 动机

`test_get_ugc_video_title` 和 `test_get_ugc_video_list` 都会实时请求 Bilibili 的 [`x/web-interface/view`](https://api.bilibili.com/x/web-interface/view?bvid=BV1vZ4y1M7mQ)。该视频目前在本地仍可正常读取，但 GitHub-hosted runner 到这个外部服务的请求会间歇性耗尽 yutto 的重试，继而抛出 `MaxRetryError` / `NotFoundError`。

这不是 #846 的依赖更新引入的回归；相同失败已跨无关提交、Python 版本和 workflow 重跑出现：

- [#846 的 Python 3.12 job（两个测试均失败，6 次 pytest rerun）](https://github.com/yutto-dev/yutto/actions/runs/33899378175/job/101287646220)
- [main 的 Python 3.14t job（两个测试均失败，6 次 pytest rerun）](https://github.com/yutto-dev/yutto/actions/runs/33792038798/job/100770687563)
- [main 的 Python 3.11 job（list 测试失败，4 次 pytest rerun）](https://github.com/yutto-dev/yutto/actions/runs/33792061821/job/100770765345)
- [#846 较早 head 的 Python 3.12 job（title 测试失败，3 次 pytest rerun）](https://github.com/yutto-dev/yutto/actions/runs/33884015774/job/101059285960)

## 解决方案

仅给这两个依赖实时 UGC 元数据接口的测试添加现有的 `ci_skip` marker。`just ci-test` 会排除它们，避免外部服务可用性阻塞 CI；`just test` 不排除 `ci_skip`，因此本地覆盖保留不变。没有修改产品代码或其他测试。

验证：

- `just fmt`
- `just lint`
- `uv run pytest -q tests/test_api/test_ugc_video.py::test_get_ugc_video_title tests/test_api/test_ugc_video.py::test_get_ugc_video_list`（2 passed）
- `uv run pytest -q -m '(api or processor or biliass) and not (ci_skip or ignore)' tests/test_api/test_ugc_video.py`（1 skipped, 4 deselected）
- `just ci-test 3.14`（282 passed, 1 skipped）

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [x] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
