### PR TITLE
👷 ci: separate CodSpeed benchmarks from unit test jobs

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,12 +49,49 @@ jobs:
         run: |
           just ci-test ${{ matrix.python-version }}
 
+  benchmarks:
+    name: Python 3.14 benchmarks (CodSpeed)
+    runs-on: ubuntu-latest
+    # Preserve PR comparisons, main baselines and manual runs, but not merge
+    # groups or workflows running in forks. No needs: unit tests finish separately.
+    if: ${{ github.event_name != 'merge_group' && !github.event.repository.fork }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Install python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          architecture: "x64"
+          allow-prereleases: true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          just ci-install 3.14
+
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v5
-        if: ${{ matrix.python-version == '3.14' && github.event_name != 'merge_group' && !github.event.repository.fork }}
         with:
           mode: simulation
-          run: uv run -p ${{ matrix.python-version }} pytest --codspeed
+          run: uv run -p 3.14 pytest --codspeed
 
   unit-test-rust:
     name: yutto Rust unit test


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- 感谢你的贡献；请不要删除本模板；已阅读 CONTRIBUTING.md。 -->

## 动机

Python 3.14 的 **job** 确实是近期 Unit Test 的关键路径，但不是 Python 3.14 的普通单测慢：串行挂在其后的 CodSpeed simulation 才是主要原因。将性能测量与功能测试分开显示，避免普通单测通过状态额外等待约 4 分钟，也避免 benchmark 被 matrix fail-fast 连带取消。

### 多次运行的证据

以下均取 **attempt 1** 的 GitHub jobs/steps 时间戳，单位秒；job 时长不含排队。样本包含 2026-08-29 至 09-06 的功能 PR、依赖 PR 和 main push，而非只取一次快/慢样本。

| Unit Test run | 3.14 job | 安装依赖 | 普通单测 | CodSpeed | 移出 benchmark 后功能 jobs 最长时长¹ |
| --- | ---: | ---: | ---: | ---: | ---: |
| [33246880768](https://github.com/yutto-dev/yutto/actions/runs/33246880768) | 431 | 158 | 27 | 232 | 211 |
| [33349637756](https://github.com/yutto-dev/yutto/actions/runs/33349637756) | 439 | 162 | 22 | 239 | 201 |
| [33350068229](https://github.com/yutto-dev/yutto/actions/runs/33350068229) | 428 | 161 | 24 | 232 | 203 |
| [33961655812](https://github.com/yutto-dev/yutto/actions/runs/33961655812) | 425 | 151 | 22 | 232 | 199 |
| [33963035915](https://github.com/yutto-dev/yutto/actions/runs/33963035915) | 446 | 155 | 23 | 243 | 203 |
| [33963065044](https://github.com/yutto-dev/yutto/actions/runs/33963065044) | 442 | 150 | 21 | 244 | 198 |
| [33963109572](https://github.com/yutto-dev/yutto/actions/runs/33963109572) | 441 | 156 | 22 | 236 | 217 |
| [33963545569](https://github.com/yutto-dev/yutto/actions/runs/33963545569) | 392 | 132 | 20 | 209 | 196 |
| [34013607328](https://github.com/yutto-dev/yutto/actions/runs/34013607328) | 440 | 156 | 21 | 240 | 202 |
| [34013619022](https://github.com/yutto-dev/yutto/actions/runs/34013619022) | 419 | 145 | 24 | 231 | 205 |
| **中位数** | **435** | **155.5** | **22** | **234** | **202.5** |

¹ 这是可复算的排队外估算：保留其余 jobs，用 `3.14 job - Run benchmarks` 替换旧 3.14 job，再取最大值；不是改动后的实测。

- 五个版本普通单测中位数：3.11 **19.5s**、3.12 **21s**、3.13 **22s**、3.14 **22s**、3.14t **20.5s**。没有 3.14 特有的慢单测证据。
- 3.14 job 的典型分布约为 **54% benchmark、36% 安装、5% 普通单测**，余下为 runner/actions 设置与收尾。安装日志显示本地 yutto/biliass 原生扩展构建，而非单纯下载依赖。
- [33963545569 的 3.14 日志](https://github.com/yutto-dev/yutto/actions/runs/33963545569/job/101299522774)：普通 pytest **318 passed / 1 skipped / 130 deselected，17.39s**；CodSpeed 仅选择 **32 个 biliass corpus benchmark**，**197.32s**，加 instrument 设置和上传为 209s。已命中 CodSpeed instrument cache，上传成功；不是漏配 benchmark cache 导致。
- 当前普通 CI 收集 319 项：API 29、biliass 36、core 45、processor 100、runtime 18、server 81、utils 10。32 个 benchmark 的功能断言和 64 个 snapshots **也在普通单测中运行**。保留全部现有选择表达式和版本矩阵，不把普通 corpus 测试删除。
- 成功样本的 3.14 排队为 **2–145s**；完成时延与 job 执行时长分开看。[33963109572](https://github.com/yutto-dev/yutto/actions/runs/33963109572) 的 441s job，加 145s 排队达到 586s。不能把 rerun 的 `updated_at-created_at` 当测试耗时。
- 另查了 [33899378175 attempt 1](https://github.com/yutto-dev/yutto/actions/runs/33899378175/attempts/1)：网络测试失败/重试令多个版本达到 97–103s，随后 matrix 取消、benchmark 没有执行；不混入成功 benchmark 的统计。相关 flaky 测试已由 #847 独立处理，本 PR 不扩大 skip 范围。
- 同期六组配对运行的 e2e 最长 job 为 **227–248s**，Python lint 为 **133–184s**；有原生构建触发时还需考虑 build workflow 的依赖/排队。拆分后功能反馈的关键路径转向其他 Python/e2e/构建工作，**全部检查/本 workflow 的最终完成仍需等 benchmark**。

## 解决方案

只改 `.github/workflows/unit-test.yml`：

- 从 Python matrix 移出 CodSpeed，新增独立的 `Python 3.14 benchmarks (CodSpeed)` job，没有 `needs`，不串联功能测试。
- 仍用现有 `ubuntu-latest`、Python 3.14 x64、相同 action 版本、递归 corpus checkout、`just ci-install 3.14`、`uv run -p 3.14 pytest --codspeed` 和 simulation 模式。
- **显式保持原触发策略**：上游仓库的 PR（包括来自 fork 的 PR）、main push、手动 dispatch 运行 benchmark；merge group 和在 fork 仓库自身运行的 workflow 跳过。不是改成仅 nightly/manual，不增加 paths 过滤，不改变 required-check/组织设置。
- 独立 job 的日志与成功/失败状态可见，继续上传现有 [CodSpeed 项目](https://codspeed.io/yutto-dev/yutto)；不加 `continue-on-error`。新增 job 仅 `contents: read`，不引入 secret、OIDC 或新 GitHub App。

### 收益与边界

功能 jobs 的排队外预计最长时长从中位数 **7m15s → 约 3m23s**，但 **不声称全部 CI 缩短 4 分钟**。若 runner 同时可用且构建时间相当，完整关键路径只少了原先串行的普通单测约 22s，benchmark 本身仍约 3.9 分钟；额外独立 job 要重复约 2.5–3 分钟环境设置/构建，也可能增加排队。

这是保留每次 PR 性能对比、main 基线与功能覆盖的最小解耦。当前公开仓库使用标准 GitHub-hosted runner，不增加付费服务。更复杂的 native build cache/共享 wheel pipeline 应另测命中率、Python ABI/3.14t 隔离与无效化，不与本次拆分混合。

### Runner 选择（2026-09-06 官方文档核对；仅调研，未启用）

**建议继续免费标准 GitHub-hosted runner，不安装/启用新服务。** 当前公开仓库的 `ubuntu-latest` 是 4 vCPU / 16 GB，标准 hosted 用量免费。新增 runner 要比较的是「付费 + 管理/信任成本」与维护者节省的等待时间，而不是节省现有账单；目前没有同负载 A/B 证据证明需要更大机器。

| 选项 | 成本 / 适配 | 授权与信任边界 |
| --- | --- | --- |
| [标准 GitHub-hosted](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) | [公开仓库免费](https://docs.github.com/en/billing/concepts/product-billing/github-actions#free-use-of-github-actions)，每个 job 新 VM；本 PR 保留 | 无新 App、付款或组织改动 |
| [GitHub larger runners](https://docs.github.com/en/billing/reference/actions-runner-pricing) | Linux x64 8 核 $0.022/min、16 核 $0.042/min；公开仓库也收费 | [需要 Team/Enterprise Cloud、组织 owner 配置、付款方式和 runner group 授权](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners/manage-larger-runners)，不必装第三方 App；未假定本组织现有计划/付款状态 |
| [CodSpeed Macro](https://codspeed.io/docs/features/macro-runners) | 16 核 ARM64 / 32 GB 裸机；600 min/月，超额 $0.032/min；额外 OSS 额度需申请 | 需要组织级 CodSpeed 集成/runner 权限，并允许 runner group 用于公开仓库；不是只换 YAML。现有上传正常不等于已授权 Macro |
| [Blacksmith](https://www.blacksmith.sh/pricing) | x64 8 核 $0.016/min，基础免费额度；OSS 计划有申请条件 | [必须 GitHub organization + App](https://docs.blacksmith.sh/introduction/quickstart)；[App 请求 runner 管理及 Contents/Actions/Workflows/PR 等写权限](https://docs.blacksmith.sh/blacksmith-administration/github-app)。OSS 页要求 permissive license，**yutto 是 GPL-3.0-only，不能假定适用** |
| [Namespace](https://namespace.so/pricing) | Linux 8 核 $0.008/min 预付 / $0.012 PAYG，试用不等于长期 OSS 免费 | [连接组织与第三方集成](https://namespace.so/docs/solutions/github-actions)；精确 App scopes 需在授权前核验，不能默认只读 |
| [BuildJet](https://buildjet.com/for-github-actions/docs/about/pricing) | AMD 8 核 $0.016/min，一次性 $5 credit | 第三方仓库授权、付款；[官方 billing 页目前没有 spending limit](https://buildjet.com/for-github-actions/docs/about/billing)，对公开 PR 的滥用费用控制不理想 |
| [自托管 / JIT](https://docs.github.com/en/actions/reference/security/secure-use#hardening-for-self-hosted-runners) | 机器/云资源、隔离、镜像维护由自己承担 | 仓库 admin / 组织 owner 授权；公开 PR 可执行不可信代码，不能放到长期复用且带 secret 的机器。即使 JIT 单次 job，底层环境仍需真正销毁/重建 |

CodSpeed Macro 主要解决 **walltime 测量稳定性**，不是 simulation 的等价加速开关。[CPU simulation](https://codspeed.io/docs/instruments/cpu) 测硬件无关的用户态性能，不含系统调用；改为 `walltime` 会改变指标和基线，还从 x64 换为 ARM64。只有确实需要 I/O/系统级 wall-clock 指标时才值得另外设计授权后的对照实验，不能悄悄替换现有 simulation。第三方 runner 即使免费也增加代码/缓存/凭据的信任边界；如未来试用，需限定仓库、保持 fork PR 无 secrets、最小 token 权限和可执行的预算上限。

### 验证

- `just ci-install 3.14`、`just fmt`、`just lint`、`git diff --check`：通过。
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/unit-test.yml`：通过。
- 对比解析后的 YAML：workflow 触发器、5 版本 matrix、原单测 steps、两个 Rust jobs 不变；新 benchmark job 无依赖且只读。
- 本地 macOS ARM64 / Python 3.14.7：原 CI pytest 命令加 `--durations=20`，**318 passed, 1 skipped, 130 deselected / 64 snapshots passed，12.93s**。本地不是 Linux simulation 性能基准。
- `pytest --codspeed --collect-only -q`：32 项；与普通 CI 的 319 个 test ids 比较，32 项全部被普通 CI 包含。submodule 指针和 `uv.lock` 未修改。
- GitHub 当前 head `3b47e180074334bb620df98c32cad0fe369e68d5`：**18/18 checks 通过**，包括五版本 unit/e2e、两个 Rust jobs、lint/docs 与独立 benchmark/CodSpeed report。

### 改动后 GitHub 实测

[PR Unit Test run 34014839151](https://github.com/yutto-dev/yutto/actions/runs/34014839151)（attempt 1）：

| 项目 | 运行结果 |
| --- | --- |
| Python 功能单测 jobs（3.11 / 3.12 / 3.13 / 3.14 / 3.14t） | 200 / 199 / 202 / **203** / 174s，均成功 |
| [3.14 功能单测](https://github.com/yutto-dev/yutto/actions/runs/34014839151/job/101436721298) | 安装 155s；单测 step 22s；pytest **318 passed / 1 skipped / 130 deselected，19.27s**，64 snapshots |
| [独立 benchmark](https://github.com/yutto-dev/yutto/actions/runs/34014839151/job/101436721279) | job **433s** = 安装 148s + CodSpeed 255s + 设置/收尾 30s；32 passed / 417 deselected，235.20s，64 snapshots；上传成功 |
| 两个 Rust jobs | 50 / 67s，均成功 |
| [e2e](https://github.com/yutto-dev/yutto/actions/runs/34014839097) | 最长 238s；从触发到完成 240s |
| 排队 / Unit workflow 完成 | 各 job 排队 2s；功能 jobs 全部完成于触发后 **205s**，含 benchmark 的 workflow 仍为 **435s** |

[CodSpeed PR 报告](https://github.com/yutto-dev/yutto/pull/850#issuecomment-5557304913) 也已出现：**32 untouched benchmarks**，证明独立 job 的性能结果没有隐藏或丢失。

最近的同基线对照是 [main `89a288d` run 34014331587](https://github.com/yutto-dev/yutto/actions/runs/34014331587)：旧 3.14 job **423s**（安装 150s、普通测试 22s、benchmark 231s），拆分后功能反馈 **203s**。新 benchmark 因运行波动到 255s，**全部 jobs 的最长时长反而是 433s，对照的 423s 没有整体提速**；这与「只解耦功能反馈，不宣称全 CI 减半」一致。整个 Unit workflow 的累计 job 时间为 **1270s → 1528s**，包含新增构建和其他 runner 波动；不是节省计算资源的改动。之后应继续按 job/step 和排队分别观察，而不把一次样本当稳定性能提升。

<details>
<summary>复算历史时长（gh + Python 3；只读 GitHub API）</summary>

```python
import json
import statistics
import subprocess
from datetime import datetime

runs = [33246880768, 33349637756, 33350068229, 33961655812,
        33963035915, 33963065044, 33963109572, 33963545569,
        34013607328, 34013619022]
rows = []
def seconds(obj):
    return (datetime.fromisoformat(obj['completed_at'])
            - datetime.fromisoformat(obj['started_at'])).total_seconds()
for run in runs:
    jobs = json.loads(subprocess.check_output([
        'gh', 'api',
        f'repos/yutto-dev/yutto/actions/runs/{run}/attempts/1/jobs?per_page=100'
    ]))['jobs']
    py = next(j for j in jobs if j['name'] == 'Python 3.14 on x64 unit test')
    steps = {s['name']: seconds(s) for s in py['steps']}
    remaining = max(seconds(j) - (steps['Run benchmarks'] if j == py else 0)
                    for j in jobs)
    row = [seconds(py), steps['Install dependencies'], steps['Run unit tests'],
           steps['Run benchmarks'], remaining]
    rows.append(row)
    print(run, *row)
print('medians:', *map(statistics.median, zip(*rows)))
```

</details>

## 类型

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
