### PR TITLE
👷 ci: skip native workspace installs in Python lint

### DIFF
--- a/.github/workflows/lint-and-fmt.yml
+++ b/.github/workflows/lint-and-fmt.yml
@@ -15,6 +15,11 @@ jobs:
         python-version: ["3.11"]
         architecture: ["x64"]
     name: Lint and Format (Python)
+    env:
+      # Keep just's uv run commands from reinstalling the native workspace packages.
+      UV_NO_SYNC: "true"
+      # Let ty resolve the workspace sources and their native-extension stubs.
+      PYTHONPATH: ${{ github.workspace }}/src:${{ github.workspace }}/packages/biliass/src
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -30,9 +35,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install just
         uses: extractions/setup-just@v4
         env:
@@ -40,7 +42,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          just ci-install ${{ matrix.python-version }}
+          # Keep third-party dependencies for ty, but skip native workspace builds.
+          uv sync --locked --all-extras --dev --no-install-workspace -p ${{ matrix.python-version }}
 
       - name: lint
         run: |


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- 感谢你的贡献 -->
<!-- 为了让我们更快地了解你所作的更改, **请不要删除本模板** -->
<!-- 在开始一个 PR 之前，请确定你已经阅读过 CONTRIBUTING.md -->
<!-- 为了节省你的时间，如果你需要一个新特性，在你开始为其工作之前，最佳选择是开启一个 featrue request 的 issue 让大家一起讨论 -->

## 动机

<!-- 请在这里描述你的修改 -->
<!-- 如果有相关讨论 issue 请链接到该处 -->
<!-- 如 fixes #59，这将会在本 PR 合并后自动 close 该 issue -->
<!-- 当然，如果这不是一个 bug fix 的 PR，请使用 closes #59 -->
<!-- 或者如果本 PR 只是与该 issue 相关，并没有完全解决该 issue 的话，请使用其他符号 -->
<!-- 如 related to #59 -->

Python lint 只运行静态检查（ty、Ruff、typos），但 `just ci-install` 会构建 editable 的 yutto / biliass 原生扩展。

[优化前的 Python lint 日志](https://github.com/yutto-dev/yutto/actions/runs/34014631345/job/101436183866) 显示：即使 setup-uv **精确命中约 44 MB 缓存**，仍会重新构建两个 workspace package，构建关键路径约 **111.5 秒**，整个依赖安装步骤 **112 秒**。这不是 registry 缓存失效；不需要为静态 lint 复用或重新构建原生扩展。

## 解决方案

<!-- 如果你的 PR 改动内容较多，请在这里详述你的解决方案 -->

仅修改 Python lint job：

- 使用 `uv sync --locked --all-extras --dev --no-install-workspace`，跳过两个 workspace package 的安装，保留 ty 解析第三方类型所需的 runtime/dev 依赖。不能简单改成 `--only-dev`。
- job 内设置 `UV_NO_SYNC=true`，避免 `just` 的版本变量和 lint/format recipes 中的 `uv run` 隐式重新安装项目。版本脚本仅通过 AST 读取源码，不导入原生模块。
- 通过 `PYTHONPATH` 暴露两个源码目录，让 ty 读取现有 `_core.pyi`；不忽略任何类型诊断，lint/format commands 和检查范围不变。
- 移除该 job 不再需要的 Rust toolchain 安装。其他 jobs、justfile、依赖定义、`uv.lock`、Cargo/ABI 缓存均不变。

保留 setup-uv 现有的缓存机制及默认 `**/pyproject.toml` / `**/uv.lock` 等文件哈希；`--locked` 额外保证依赖定义与锁文件一致。事件仍为 `pull_request`（不是 `pull_request_target`），未增加权限、secrets、跨 ref 缓存或外部服务，保留 fork PR 的信任边界。

### 验证

本地 Python 3.11.16 / uv 0.12.10：

- 在没有安装 yutto / biliass / maturin、没有原生二进制或 Cargo target 目录的环境下，`just fmt`、`just lint`、`just ci-lint`、`just ci-fmt-check` 全部通过（使用上述 job 环境变量）。
- 全新缓存和虚拟环境中，额外设置 `UV_NO_BUILD=true` 后 sync / CI lint / format 仍全部通过，安装 24 个第三方包，没有 workspace 构建。
- 临时类型探针确认两个 `_core.pyi` 和 Pydantic 的类型可解析，三个故意错误的参数分别被 ty 拒绝，返回类型断言通过。
- 临时副本中改变依赖组，`--locked` 拒绝过期锁文件且不修改它。
- actionlint 1.7.12、`git diff --check` 通过。

### GitHub Actions 前后证据

| Python 3.11 / Ubuntu x64 | [优化前](https://github.com/yutto-dev/yutto/actions/runs/34014631345/job/101436183866) | [本 PR](https://github.com/yutto-dev/yutto/actions/runs/34016432156/job/101440899015) |
| --- | --- | --- |
| setup-uv cache | 精确命中，45,885,425 B | 同一个 key 精确命中，45,885,425 B |
| 原生 workspace 构建 | yutto + biliass，关键路径约 111.5 s | 无 `Building` / `Built`，仅安装 24 个第三方包 |
| Install dependencies 步骤 | 112 s | 1 s |
| Python lint job 总时长 | 133 s | 10 s |
| lint / format | 通过 | 通过，184 个文件格式检查 |

以上为 GitHub job/step 的 `started_at` / `completed_at` 单次观测；job 总时长减少约 **92%**，不是多次基准测试。前后均为 Python 3.11.16 / uv 0.12.10，依赖定义和锁文件相同；本地冷缓存下载耗时不作为 GitHub 性能对比。

两个日志均包含以下精确命中，以及 `not saving cache`（没有靠新建缓存取得收益）：

```text
setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-f89943d1e108b1b0e3cc1ba52d91d524a0e298298f9474311f42bb13cfc16758
```

本 PR 的 **17 个 GitHub Actions checks 全部通过**，包括 [Lint and Format](https://github.com/yutto-dev/yutto/actions/runs/34016432156)、[Unit / Rust / benchmark](https://github.com/yutto-dev/yutto/actions/runs/34016432199)、[E2E](https://github.com/yutto-dev/yutto/actions/runs/34016432300) 和 docs build。

剩余限制：独立的 `CodSpeed Performance Analysis` app check 为失败，[自动报告](https://github.com/yutto-dev/yutto/pull/851#issuecomment-5557479462) 称 `test_protobuf_corpus[285968687]` 为 66.8 → 81.9 ms（-18.46% efficiency）。对应 benchmark Actions job 本身成功；已核对 benchmark job、源码、测试和依赖与比较基线 `87d77d5` 完全相同，新增环境变量仅属于 Python lint job。本 PR 不修改 benchmark，也未在外部服务确认或豁免该报告；未确定该差异的原因，因此不声称所有 checks 全绿。

## 类型

<!-- 本 PR 的类型（至少选择一个） -->

-  [ ] :sparkles: feat: 添加新功能
-  [ ] :bug: fix: 修复 bug
-  [ ] :pencil: docs: 对文档进行修改
-  [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
-  [ ] :zap: perf: 提高性能的代码修改
-  [ ] :technologist: dx: 优化开发体验
-  [ ] :hammer: workflow: 工作流变动
-  [ ] :label: types: 类型声明修改
-  [ ] :construction: wip: 工作正在进行中
-  [ ] :white_check_mark: test: 测试用例添加及修改
-  [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
-  [x] :construction_worker: ci: 更改 CI 配置文件和脚本
-  [ ] :question: chore: 其它不涉及源码以及测试的修改
-  [ ] :arrow_up: deps: 依赖项修改
-  [ ] :bookmark: release: 发布新版本
