### PR TITLE
👷 ci: configure `setup-vp` for docs project

### DIFF
--- a/.github/workflows/lint-and-fmt.yml
+++ b/.github/workflows/lint-and-fmt.yml
@@ -121,6 +121,7 @@ jobs:
           node-version: '24'
           cache: true
           cache-dependency-path: "docs/pnpm-lock.yaml"
+          run-install: false
 
       - name: Install dependencies
         working-directory: ./docs

--- a/.github/workflows/vitepress-deploy.yml
+++ b/.github/workflows/vitepress-deploy.yml
@@ -23,6 +23,7 @@ jobs:
           node-version: '24'
           cache: true
           cache-dependency-path: "docs/pnpm-lock.yaml"
+          run-install: false
 
       - name: Install dependencies
         working-directory: ./docs


### PR DESCRIPTION
## 动机

`voidzero-dev/setup-vp@v1` 默认会在 setup 阶段执行 `vp install`，但 yutto 的 VitePress 项目位于 `docs/`，原配置没有为 `setup-vp` 指定项目目录，因此它会在仓库根目录执行安装。

此前同一 `main` commit（`91cb07f`）在 Vite+ 0.3.0 下可以通过；重新运行后，`setup-vp` 安装到 Vite+ 0.3.1，并在仓库根目录执行 `vp install` 时因找不到 `package.json` 报错，导致 `Lint and Format (Docs)` 和 `VitePress Deploy` 在后续步骤开始前失败。

同时，两个 workflow 原本又会单独进入 `docs/` 执行一次 `vp i --frozen-lockfile`，因此依赖安装职责存在重复。

## 解决方案

在 `lint-and-fmt.yml` 和 `vitepress-deploy.yml` 中：

- 将 `setup-vp` 的 `working-directory` 设置为 `./docs`；
- 由 `setup-vp` 直接执行 `vp install --frozen-lockfile`；
- 删除重复的 `Install dependencies` step；
- 删除显式的 `cache-dependency-path`，由 `setup-vp` 在项目目录中自动检测 lockfile。

这样 `setup-vp` 会直接以 `docs/` 作为项目目录完成 Node.js、Vite+、依赖缓存和依赖安装的准备，后续继续执行现有的 `vp check` 和 VitePress build。

## 类型

- [ ] :sparkles: feat: 添加新功能
- [ ] :bug: fix: 修复 bug
- [ ] :pencil: docs: 对文档进行修改
- [ ] :recycle: refactor: 代码重构（既不是新增功能，也不是修改 bug 的代码变动）
- [ ] :zap: perf: 提高性能的代码修改
- [ ] :technologist: dx: 优化开发体验
- [ ] :hammer: workflow: 工作流变动
- [ ] :label: types: 类型声明修改
- [ ] :construction: wip: 工作正在进行中
- [ ] :white_check_mark: test: 测试用例添加及修改
- [ ] :hammer: build: 影响构建系统或外部依赖关系的更改
- [x] :construction_worker: ci: 更改 CI 配置文件和脚本
- [ ] :question: chore: 其它不涉及源码以及测试的修改
- [ ] :arrow_up: deps: 依赖项修改
- [ ] :bookmark: release: 发布新版本